### PR TITLE
chore(ci): enforce branch conventions via Rulesets and workflow

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -1,0 +1,38 @@
+name: Branch Name Check
+
+# Ruleset `Conventional branch naming` が Public Personal Repo では API 経由で
+# 適用できない (branch_name_pattern rule が 422) ため、代替として workflow で
+# branch 命名規約を強制する。push 時と PR 時の両方で発火し、違反を CI エラーに
+# する。
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - develop
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+concurrency:
+  group: branch-name-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Validate branch naming convention
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name pattern
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: |
+          pattern='^(feat|fix|refactor|chore|docs|test|perf|ci|deps|infra|release|hotfix)/[a-z0-9._-]+$'
+          if [[ ! "$BRANCH" =~ $pattern ]]; then
+            echo "::error title=Invalid branch name::Branch '$BRANCH' does not match convention"
+            echo "Expected: <type>/<description> where"
+            echo "  type = feat | fix | refactor | chore | docs | test | perf | ci | deps | infra | release | hotfix"
+            echo "  description = [a-z0-9._-]+"
+            exit 1
+          fi
+          echo "Branch '$BRANCH' matches naming convention ✓"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,9 @@
+branch=$(git rev-parse --abbrev-ref HEAD)
+pattern='^(main|develop|HEAD)$|^(feat|fix|refactor|chore|docs|test|perf|ci|deps|infra|release|hotfix)/[a-z0-9._-]+$'
+if ! printf '%s' "$branch" | grep -qE "$pattern"; then
+  printf 'Branch name "%s" does not match convention.\n' "$branch" >&2
+  printf 'Expected: main | develop | <type>/<description>\n' >&2
+  printf '  type = feat | fix | refactor | chore | docs | test | perf | ci | deps | infra | release | hotfix\n' >&2
+  printf '  description = [a-z0-9._-]+\n' >&2
+  exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 `perapera` は、任意の音声ソース（ブラウザタブ音声、マイク、画面共有音声）に対してリアルタイム文字起こし・翻訳を行い、翻訳結果を Chrome 上の閲覧対象にオーバーレイ表示する Chrome 拡張機能。
 
+**開発体制**: 本プロジェクトは **lihs-ie 単独開発** で進める。チーム化を前提とした承認・レビュー gate や、外部コントリビュータ向けの規約（`CONTRIBUTING.md` 等）は導入しない。将来体制が変わるまでこの前提を固定する。
+
 **現状**: 本リポジトリには実装コードは存在せず、`docs/in-progress/` 配下に設計文書のみが存在する。実装開始時は設計文書を正とする。
 
 ## ドキュメント構造

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,28 @@ GitHub Actions で利用する第三者 action は **コミット SHA で pin �
 
 SHA は最新タグに追従させる。更新は `actrun lint .github/workflows/<file>.yml --update-hash` で自動化する。ローカル CI 検証は `actrun workflow run .github/workflows/ci.yml` で行える（`actrun.toml` に skip 設定済、e2e / docker-relay は step-level `if: ${{ !env.ACTRUN_LOCAL }}` で actrun 時のみ skip）。
 
+## ブランチ保護
+
+GitHub Ruleset で `main` / `develop` を保護し、規約を実体として強制する。設定は `tools/rulesets/*.json` に版管理する:
+
+| Ruleset                      | 対象                           | 主なルール                                                                                                                                                                                                                     |
+| ---------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Protect main`               | `refs/heads/main`              | deletion / force push 禁止、linear history 強制、PR 必須、required status check `All Green`、`strict_required_status_checks_policy: true`、review thread resolution 必須                                                       |
+| `Protect develop`            | `refs/heads/develop`           | deletion / force push 禁止、PR 必須、required status check `All Green`、`strict_required_status_checks_policy: true`                                                                                                           |
+| `Conventional branch naming` | 全ブランチ (main/develop 除く) | `^(feat\|fix\|refactor\|chore\|docs\|test\|perf\|ci\|deps\|infra\|release\|hotfix)/[a-z0-9._-]+$` パターンのみ許可 — **現在は workflow と husky で代替**（Public Personal Repo では `branch_name_pattern` rule が 422 のため） |
+
+**branch 命名の現運用**:
+
+- `.github/workflows/branch-name-check.yml` — push / PR 時に CI で validate、違反は CI fail
+- `.husky/pre-push` — ローカル push 前に reject
+
+**bypass**:
+
+- `Protect main`: Repository admin が `bypass_mode: always`（緊急時のみ、通常運用では使用しない）
+- `Protect develop`: Repository admin が `bypass_mode: pull_request`（PR 経由でのみ bypass 可）
+
+**更新手順**: `tools/rulesets/<name>.json` を編集 → PR → merge → `gh api --method PUT repos/lihs-ie/perapera/rulesets/<id> --input tools/rulesets/<name>.json` で反映。詳細は `tools/rulesets/README.md`。
+
 ## 命名規則（本プロジェクト固有）
 
 グローバル規約（ユーザー `~/.claude/CLAUDE.md`）に加え、本プロジェクトで固有の識別子は以下:

--- a/tools/rulesets/README.md
+++ b/tools/rulesets/README.md
@@ -1,0 +1,70 @@
+# GitHub Rulesets
+
+`lihs-ie/perapera` に適用する GitHub Ruleset を JSON で版管理する。UI での手動設定に依存せず、再現・差分レビューを可能にする。
+
+## 一覧
+
+| ファイル               | 名前                         | 対象                           | 目的                                                                                                                 |
+| ---------------------- | ---------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `protect-main.json`    | `Protect main`               | `refs/heads/main`              | 本番ブランチ保護。削除・force push 禁止、PR 必須、`All Green` status check 必須、linear history 強制                 |
+| `protect-develop.json` | `Protect develop`            | `refs/heads/develop`           | 統合ブランチ保護。削除・force push 禁止、PR 必須、`All Green` status check 必須                                      |
+| `branch-naming.json`   | `Conventional branch naming` | 全ブランチ (main/develop 除く) | `feat\|fix\|refactor\|chore\|docs\|test\|perf\|ci\|deps\|infra\|release\|hotfix/...` パターンのみ許可 **(※ 未適用)** |
+
+> **注記**: `branch-naming.json` は現在 **未適用**。Public Personal Repo では API 経由での `branch_name_pattern` rule 追加が `422 Invalid rule 'branch_name_pattern'` で拒否されるため。
+> 代替として以下で命名規約を強制している:
+>
+> - `.github/workflows/branch-name-check.yml` — push / PR 時に CI で validation
+> - `.husky/pre-push` — ローカル push 前に reject
+>
+> Organization への移管や有料 plan への移行時に `gh api --method POST ... --input tools/rulesets/branch-naming.json` で本 JSON を適用し、workflow / hook 側は任意で残すか削除する。
+
+## 適用
+
+初回作成:
+
+```sh
+for name in protect-main protect-develop branch-naming; do
+  gh api --method POST \
+    -H "Accept: application/vnd.github+json" \
+    repos/lihs-ie/perapera/rulesets \
+    --input tools/rulesets/$name.json
+done
+```
+
+更新 (既存 ruleset の `id` を指定して PUT):
+
+```sh
+rs_id=$(gh api repos/lihs-ie/perapera/rulesets --jq '.[] | select(.name=="Protect main") | .id')
+gh api --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  repos/lihs-ie/perapera/rulesets/$rs_id \
+  --input tools/rulesets/protect-main.json
+```
+
+## 検証
+
+```sh
+gh api repos/lihs-ie/perapera/rulesets --jq '.[] | {id, name, enforcement, target}'
+```
+
+全 3 件が `enforcement: "active"` / `target: "branch"` で表示されれば OK。
+
+## 削除（テスト用途）
+
+```sh
+rs_id=$(gh api repos/lihs-ie/perapera/rulesets --jq '.[] | select(.name=="<name>") | .id')
+gh api --method DELETE repos/lihs-ie/perapera/rulesets/$rs_id
+```
+
+## 仕様の参照
+
+- REST API: https://docs.github.com/en/rest/repos/rules
+- Branch protection rules は ruleset で置換可能 (legacy 側は touch しない)
+- `integration_id: 15368` は GitHub Actions の固定 App ID
+- `actor_type: "RepositoryRole"` の `actor_id`: `1=read`, `2=triage`, `3=write`, `4=maintain`, `5=admin`
+- `bypass_mode`: `always`（無条件 bypass）/ `pull_request`（PR 経由のみ bypass）
+
+## 変更ポリシー
+
+- このディレクトリの JSON を変更したら必ず PR を通し、merge 後に上記「更新」コマンドで GitHub 側に反映
+- UI で手動変更した場合は、対応する JSON を即時更新して版管理と一致させる

--- a/tools/rulesets/branch-naming.json
+++ b/tools/rulesets/branch-naming.json
@@ -1,0 +1,23 @@
+{
+  "name": "Conventional branch naming",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/**"],
+      "exclude": ["refs/heads/main", "refs/heads/develop"]
+    }
+  },
+  "rules": [
+    {
+      "type": "branch_name_pattern",
+      "parameters": {
+        "operator": "regex",
+        "pattern": "^(feat|fix|refactor|chore|docs|test|perf|ci|deps|infra|release|hotfix)/[a-z0-9._-]+$",
+        "negate": false,
+        "name": "Conventional Commits compatible branch name"
+      }
+    }
+  ]
+}

--- a/tools/rulesets/protect-develop.json
+++ b/tools/rulesets/protect-develop.json
@@ -1,0 +1,39 @@
+{
+  "name": "Protect develop",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/develop"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [{ "context": "All Green", "integration_id": 15368 }]
+      }
+    }
+  ]
+}

--- a/tools/rulesets/protect-main.json
+++ b/tools/rulesets/protect-main.json
@@ -1,0 +1,40 @@
+{
+  "name": "Protect main",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [{ "context": "All Green", "integration_id": 15368 }]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

GitHub Ruleset を 3 つ版管理で追加し、`main` / `develop` 保護と feature branch 命名規約を強制する。

- `Protect main` ruleset (id=15323526, active): 削除/force push 禁止、linear history 強制、PR 必須、status check \`All Green\` (strict)、review thread resolution 必須
- `Protect develop` ruleset (id=15323527, active): 削除/force push 禁止、PR 必須、status check \`All Green\` (strict)
- `Conventional branch naming` は **未適用** (Public Personal Repo では \`branch_name_pattern\` rule が 422 のため)。代替として workflow + husky で enforce:
  - \`.github/workflows/branch-name-check.yml\` — push/PR で CI validate
  - \`.husky/pre-push\` — ローカル push 前に reject

## 関連設計文書

- CLAUDE.md §CI/CD (既存、SHA pin 規約)
- CLAUDE.md §ブランチ保護 (本 PR で新設)
- \`~/.claude/rules/git-workflow.md\` (グローバル規約、branch 命名)

## 変更内容

**新規:**
- \`tools/rulesets/{protect-main,protect-develop,branch-naming}.json\` — Ruleset 定義 (IaC)
- \`tools/rulesets/README.md\` — 適用/更新/検証手順
- \`.github/workflows/branch-name-check.yml\` — branch 命名 CI validation
- \`.husky/pre-push\` — ローカル branch 名チェック

**更新:**
- \`CLAUDE.md\` — §ブランチ保護 節を追加

## 動作確認

- [x] \`gh api repos/lihs-ie/perapera/rulesets\` で \`Protect main\` / \`Protect develop\` が \`enforcement: active\` で確認
- [x] ruleset A / B の rule 一覧を \`gh api .../rulesets/<id>\` で検証 (pull_request / required_status_checks / deletion / non_fast_forward / required_linear_history)
- [x] develop への直接 push を試行 → \`GH013: Repository rule violations\` で拒否 (ruleset B の enforce 実証)
- [x] \`gh api repos/lihs-ie/perapera/branches/main --jq .protected\` → \`true\`
- [x] \`git config core.hooksPath\` → \`.husky/_\` (husky v9 shim 有効)
- [x] \`actrun lint .github/workflows/branch-name-check.yml\` → clean
- [ ] CI \`All Green\` が本 PR で緑になる (次の CI run で確認)
- [ ] \`branch-name-check\` job が \`chore/ruleset-setup\` で pass する (同上)

## Breaking change / 互換性影響

- \`develop\` への直接 push が不可になる (PR 経由必須)
- \`main\` への直接 push が不可になる
- 既存 PR #1 (\`develop → main\`) は影響なし (既に \`All Green\` pass 済)

## 備考

- \`tools/rulesets/branch-naming.json\` は **未適用** だが、Organization 移管時に即 apply 可能な状態で残している
- \`integration_id: 15368\` は GitHub Actions App の固定 ID
- Admin の bypass: main は \`always\`、develop は \`pull_request\` (PR 経由のみ)