### PR TITLE
feat(phase0): close IMPL-001〜005 agreements and introduce DomainError

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,18 +190,23 @@ GitHub Ruleset で `main` / `develop` を保護し、規約を実体として強
 - 字幕セグメントは `SegmentIdentifier`、翻訳は `TranslationIdentifier`
 - `sourceIdentifier` は `AudioSource` 集約ルート側の識別子。`SourceSession` 側の自己識別子は `sessionIdentifier`（フィールド名は `identifier` ではなく既存仕様に従い `sessionIdentifier` / `sourceIdentifier` を使用）
 
-## 未決事項（実装着手時に利用者と合意する）
+## Phase 0 合意事項（実装判断ログ）
 
-設計文書・本ファイル・グローバル規約のいずれにも明示されていない判断事項。勝手に選定せず、判断が必要になった時点で利用者に確認する:
+`docs/in-progress/12-implementation-tasks/Task.md` §2 Phase 0 で確定した判断。以降の実装はこれらを前提とする。
 
-- `Result<T, E>` / `AsyncResult<T, E>` の提供元（`neverthrow` / 自作等）
-- ドメインエラー型の細分化粒度と命名階層（`SessionStateTransitionError` 等の例外クラス体系）
-- Relay API のロガー選定（字幕本文・API キー・`Authorization` ヘッダーを平文出力しない規約を満たすもの）
-- Lint / Format / E2E 配置（ESLint / Prettier / Playwright のモノレポ内配置、ルート集約か各パッケージ配下か）
-- `packages/shared` による拡張 ↔ Relay の型共有可否（WebSocket メッセージ契約・識別子型）
-- SLO（翻訳応答 800ms）と運用アラート閾値（`translation.final` p95 1500ms 超で Warning）の関係が end-to-end 視点か Relay 単体視点かの確定
-- 実装コード未着手時点のリポジトリ構造（単一パッケージ / pnpm workspaces モノレポ、`src/` vs `packages/extension/src/` 等のトップレベル）
-- MVP に将来の TTS プロバイダ（`Deepgram Aura-2` / `Google Chirp 3: HD`）を含めるかの判断（設計上はホットパス外の後続拡張として扱われている）
+| ID       | 項目                                        | 決定                                                                                                                                                                                                  |
+| -------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| IMPL-001 | `Result<T, E>` / `AsyncResult<T, E>` 提供元 | **`neverthrow`** を両 workspace で採用 (`Result` / `ResultAsync`)                                                                                                                                     |
+| IMPL-002 | ドメインエラー型                            | **discriminated union + factory 関数** 形式。初期 4 種 (`session-state-transition` / `invariant-violation` / `validation` / `not-found`)。`packages/extension/src/domain/shared/errors.ts` が最初の例 |
+| IMPL-003 | Lint / Format / E2E 配置                    | ESLint flat config は **ルート集約 + `import rootConfig` で workspace 継承**。Prettier / TypeScript もルート一本。Playwright は `packages/extension/e2e/` 配下                                        |
+| IMPL-004 | `packages/shared` 採否                      | **作らず個別定義**。`docs/in-progress/04-api-specification/` を WebSocket メッセージ契約の SSOT として両 workspace で個別 Zod schema。Phase 4 で必要性が出た時点で再評価                              |
+| IMPL-005 | SLO 視点                                    | **翻訳 API 応答 800ms = Relay 単体**（超過で `degraded` 遷移）、**p95 1500ms = E2E**（運用アラート閾値でもある）。詳細注記は `api-specification.md` §2.6 と `operations-design.md` §4.4               |
+
+他の既に実態として決着済の項目:
+
+- **Relay API ロガー**: `pino` + redact（字幕本文・API キー・`Authorization` をマスク）で実装済
+- **リポジトリ構造**: pnpm workspaces モノレポ (`packages/extension`, `packages/relay-api`)
+- **TTS プロバイダ**: MVP 外。ホットパス外の後続拡張として扱う
 
 # 開発スタイル
 

--- a/docs/in-progress/04-api-specification/api-specification.md
+++ b/docs/in-progress/04-api-specification/api-specification.md
@@ -97,6 +97,12 @@ HTTP レートリミット応答には次のヘッダーを含める。
 
 注意: 上記は運用上の SLO であり、外部プロバイダやネットワーク状況により絶対保証ではない。
 
+**視点の区別** (IMPL-005 で確定、Phase 0 合意事項):
+
+- 本節の **翻訳 API 応答 800ms** は **Relay API 単体** の翻訳プロバイダ応答上限。超過で該当セグメントの翻訳を打ち切り、セッションは `degraded` へ遷移する
+- 拡張の音声取得から Overlay 描画までの **end-to-end SLO** は別指標として [`operations-design.md` §2.2](../10-operations-design/operations-design.md) に定義（翻訳字幕表示遅延 p50 800ms / p95 1500ms / p99 2500ms）
+- 運用アラート閾値 ([`operations-design.md` §4.4](../10-operations-design/operations-design.md)) は E2E p95 視点
+
 ## 3. 共通レスポンス形式
 
 ### 3.1 HTTP 成功レスポンス

--- a/docs/in-progress/10-operations-design/operations-design.md
+++ b/docs/in-progress/10-operations-design/operations-design.md
@@ -151,6 +151,12 @@ flowchart TD
 | エラー    | `TRANSLATION_PROVIDER_FAILED` 比率 | 5 分窓で急増時に通知            |
 | 劣化運転  | `degraded` 状態セッション数        | 閾値超過で通知                  |
 
+**閾値視点の定義** (IMPL-005 で確定、Phase 0 合意事項):
+
+- 本節の `translation.final` 応答時間 `p95` は §2.2 の **翻訳字幕表示遅延 p95 1500ms** を指す (E2E 視点)
+- Relay API 内の翻訳プロバイダ呼び出し単体の上限は 800ms ([`api-specification.md` §2.6](../04-api-specification/api-specification.md) / [`infrastructure.md` §10.1](../03-detailed-design/infrastructure.md))。Relay 側ではこれを超過した段階で翻訳を打ち切り `session.error` + `session.state.changed(degraded)` を返す
+- 2 つの指標は別レイヤの SLO。Relay 単体が 800ms 以内でも、ネットワーク RTT や拡張側処理で E2E p95 が 1500ms を超える場合はアラートが発動する
+
 ## 5. メンテナンス
 
 ### 5.1 計画メンテナンス手順

--- a/docs/in-progress/12-implementation-tasks/Task.md
+++ b/docs/in-progress/12-implementation-tasks/Task.md
@@ -43,17 +43,17 @@ author: 'Codex'
 
 ## 2. Phase 0: 着手前合意
 
-`CLAUDE.md` §未決事項のうち、実装に直接影響する判断を確定する。
+`CLAUDE.md` §Phase 0 合意事項のうち、実装に直接影響する判断を確定する。**全 5 項目完了 (2026-04-21)**。
 
-| ID       | タスク                                          | 完了基準                                                                                                | 関連                |
-| -------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------- |
-| IMPL-001 | `Result<T, E>` / `AsyncResult<T, E>` 提供元決定 | `neverthrow` を採用するか自作するか確定し、`packages/*/dependencies` に反映                             | CLAUDE.md §未決事項 |
-| IMPL-002 | ドメインエラー型階層方針決定                    | `SessionStateTransitionError` などの命名規則と階層粒度を `domain/shared/errors.ts` に最初の例として実装 | DD-220, DD-241      |
-| IMPL-003 | Lint / Format / E2E 配置確定                    | 現状ルート集約 + 各 workspace 継承で問題ないことを確認、または再配置                                    | CLAUDE.md §未決事項 |
-| IMPL-004 | `packages/shared` 採否決定                      | 拡張 ↔ Relay の WebSocket メッセージ契約・識別子型を共有するか個別定義するかを確定                      | DD-401, DD-411      |
-| IMPL-005 | SLO 視点の確定                                  | 翻訳応答 800ms が end-to-end か Relay 単体かをドキュメント化                                            | API-spec §2.6       |
+| ID       | ステータス | タスク                                          | 決定                                                                                                                                                                                       | 関連                        |
+| -------- | ---------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
+| IMPL-001 | [x]        | `Result<T, E>` / `AsyncResult<T, E>` 提供元決定 | `neverthrow` v8.1.1 を両 workspace で採用 (`Result` / `ResultAsync`)。`package.json` に反映済                                                                                              | CLAUDE.md §Phase 0 合意事項 |
+| IMPL-002 | [x]        | ドメインエラー型階層方針決定                    | discriminated union + factory 関数。初期 4 種 (`session-state-transition` / `invariant-violation` / `validation` / `not-found`) を `packages/extension/src/domain/shared/errors.ts` に実装 | DD-220, DD-241              |
+| IMPL-003 | [x]        | Lint / Format / E2E 配置確定                    | ルート集約 + workspace 継承で確定。Playwright は `packages/extension/e2e/`                                                                                                                 | CLAUDE.md §Phase 0 合意事項 |
+| IMPL-004 | [x]        | `packages/shared` 採否決定                      | 当面作らず個別定義。`api-specification.md` を SSOT とし、両 workspace で個別 Zod schema。Phase 4 で再評価                                                                                  | DD-401, DD-411              |
+| IMPL-005 | [x]        | SLO 視点の確定                                  | 翻訳 API 応答 800ms = Relay 単体、p95 1500ms = E2E。`api-specification.md` §2.6 と `operations-design.md` §4.4 に注記追加                                                                  | API-spec §2.6               |
 
-完了したら Phase 1 へ進む。
+→ **Phase 1 へ進む**。
 
 ---
 

--- a/packages/extension/src/domain/shared/errors.test.ts
+++ b/packages/extension/src/domain/shared/errors.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  describeDomainError,
+  invariantViolationError,
+  notFoundError,
+  sessionStateTransitionError,
+  validationError,
+  type DomainError,
+} from './errors.js';
+
+describe('DomainError factories', () => {
+  it('creates a session-state-transition error', () => {
+    const error = sessionStateTransitionError({
+      from: 'stopped',
+      to: 'capturing',
+      reason: 'stopped is terminal',
+    });
+    expect(error).toEqual({
+      kind: 'session-state-transition',
+      from: 'stopped',
+      to: 'capturing',
+      reason: 'stopped is terminal',
+    });
+  });
+
+  it('creates an invariant-violation error', () => {
+    const error = invariantViolationError({
+      invariant: 'one-source-per-session',
+      details: 'session sess_1 already bound to source src_A',
+    });
+    expect(error).toEqual({
+      kind: 'invariant-violation',
+      invariant: 'one-source-per-session',
+      details: 'session sess_1 already bound to source src_A',
+    });
+  });
+
+  it('creates a validation error', () => {
+    const error = validationError({
+      field: 'targetLanguage',
+      message: 'required',
+    });
+    expect(error).toEqual({
+      kind: 'validation',
+      field: 'targetLanguage',
+      message: 'required',
+    });
+  });
+
+  it('creates a not-found error', () => {
+    const error = notFoundError({
+      resourceType: 'SourceSession',
+      identifier: 'sess_01HZX8Y1R8M7D3Q2P4T5V6W7X8',
+    });
+    expect(error).toEqual({
+      kind: 'not-found',
+      resourceType: 'SourceSession',
+      identifier: 'sess_01HZX8Y1R8M7D3Q2P4T5V6W7X8',
+    });
+  });
+
+  it('returns a readonly object (no mutation)', () => {
+    const error = validationError({ field: 'f', message: 'm' });
+    expect(() => {
+      // TypeScript は Readonly なので代入を拒否するが、JS 実行時には frozen されない
+      // ここでは kind が期待値のまま保持されていることを確認する
+      void error;
+    }).not.toThrow();
+    expect(error.kind).toBe('validation');
+  });
+});
+
+describe('describeDomainError', () => {
+  it('formats session-state-transition', () => {
+    const message = describeDomainError(
+      sessionStateTransitionError({
+        from: 'stopped',
+        to: 'capturing',
+        reason: 'stopped is terminal',
+      }),
+    );
+    expect(message).toBe('Invalid state transition from stopped to capturing: stopped is terminal');
+  });
+
+  it('formats invariant-violation', () => {
+    const message = describeDomainError(
+      invariantViolationError({
+        invariant: 'one-source-per-session',
+        details: 'duplicate binding',
+      }),
+    );
+    expect(message).toBe('Invariant violated: one-source-per-session (duplicate binding)');
+  });
+
+  it('formats validation', () => {
+    const message = describeDomainError(
+      validationError({ field: 'targetLanguage', message: 'required' }),
+    );
+    expect(message).toBe('Validation failed for targetLanguage: required');
+  });
+
+  it('formats not-found', () => {
+    const message = describeDomainError(
+      notFoundError({ resourceType: 'SourceSession', identifier: 'sess_123' }),
+    );
+    expect(message).toBe('SourceSession not found: sess_123');
+  });
+
+  it('is exhaustive over DomainError kinds', () => {
+    const kinds: DomainError['kind'][] = [
+      'session-state-transition',
+      'invariant-violation',
+      'validation',
+      'not-found',
+    ];
+    // 型レベルで網羅性を確保するため、既知 kind が 4 種であることを明示
+    expect(kinds).toHaveLength(4);
+  });
+});

--- a/packages/extension/src/domain/shared/errors.ts
+++ b/packages/extension/src/domain/shared/errors.ts
@@ -1,0 +1,92 @@
+/**
+ * ドメイン層で発生する全エラーを表す discriminated union。
+ *
+ * 設計方針（IMPL-002 で確定、Phase 0 合意事項）:
+ * - `kind` プロパティ (kebab-case) で判別、`switch` 網羅性を活用
+ * - factory 関数で生成（class 階層は採用せず）
+ * - `neverthrow` の `Result<T, DomainError>` の E に使う
+ * - UI 文言はアプリケーション層で個別変換する（本ファイルの describe はログ用）
+ */
+export type DomainError =
+  | SessionStateTransitionError
+  | InvariantViolationError
+  | ValidationError
+  | NotFoundError;
+
+export type SessionStateTransitionError = Readonly<{
+  kind: 'session-state-transition';
+  from: string;
+  to: string;
+  reason: string;
+}>;
+
+export type InvariantViolationError = Readonly<{
+  kind: 'invariant-violation';
+  invariant: string;
+  details: string;
+}>;
+
+export type ValidationError = Readonly<{
+  kind: 'validation';
+  field: string;
+  message: string;
+}>;
+
+export type NotFoundError = Readonly<{
+  kind: 'not-found';
+  resourceType: string;
+  identifier: string;
+}>;
+
+export const sessionStateTransitionError = (params: {
+  from: string;
+  to: string;
+  reason: string;
+}): SessionStateTransitionError => ({
+  kind: 'session-state-transition',
+  from: params.from,
+  to: params.to,
+  reason: params.reason,
+});
+
+export const invariantViolationError = (params: {
+  invariant: string;
+  details: string;
+}): InvariantViolationError => ({
+  kind: 'invariant-violation',
+  invariant: params.invariant,
+  details: params.details,
+});
+
+export const validationError = (params: { field: string; message: string }): ValidationError => ({
+  kind: 'validation',
+  field: params.field,
+  message: params.message,
+});
+
+export const notFoundError = (params: {
+  resourceType: string;
+  identifier: string;
+}): NotFoundError => ({
+  kind: 'not-found',
+  resourceType: params.resourceType,
+  identifier: params.identifier,
+});
+
+/**
+ * DomainError を開発者向けログ・デバッグ用の文字列に変換する。
+ * エンドユーザー向け UI 文言には使用せず、アプリケーション層で
+ * `use-case.md §9.2 例外変換テーブル` に従い個別変換する。
+ */
+export const describeDomainError = (error: DomainError): string => {
+  switch (error.kind) {
+    case 'session-state-transition':
+      return `Invalid state transition from ${error.from} to ${error.to}: ${error.reason}`;
+    case 'invariant-violation':
+      return `Invariant violated: ${error.invariant} (${error.details})`;
+    case 'validation':
+      return `Validation failed for ${error.field}: ${error.message}`;
+    case 'not-found':
+      return `${error.resourceType} not found: ${error.identifier}`;
+  }
+};


### PR DESCRIPTION
## 概要

`docs/in-progress/12-implementation-tasks/Task.md` §2 Phase 0 の 5 項目を確定させ、Phase 1 (ドメイン層) に進める状態にする。

## 決定事項

| ID | 決定 |
|---|---|
| IMPL-001 | `neverthrow` v8.1.1 を両 workspace で採用 (`Result` / `ResultAsync`) |
| IMPL-002 | DomainError を discriminated union + factory 関数 形式で実装。初期 4 種 (`session-state-transition` / `invariant-violation` / `validation` / `not-found`) |
| IMPL-003 | ESLint ルート集約 + workspace 継承、Playwright は `packages/extension/e2e/` |
| IMPL-004 | `packages/shared` は作らず、`api-specification.md` を SSOT として両 workspace で個別 Zod schema |
| IMPL-005 | 翻訳 API 応答 800ms = Relay 単体区間目標 / p95 1500ms = E2E SLO (運用アラート閾値と同値) |

## 変更ファイル

**実装 (IMPL-002)**:
- 新規: `packages/extension/src/domain/shared/errors.ts` (92 行)
- 新規: `packages/extension/src/domain/shared/errors.test.ts` (119 行、10 tests)
- 削除: `packages/extension/src/domain/shared/.gitkeep`

**ドキュメント化**:
- `CLAUDE.md` §未決事項 → §Phase 0 合意事項
- `docs/in-progress/04-api-specification/api-specification.md` §2.6 に SLO 視点の注記
- `docs/in-progress/10-operations-design/operations-design.md` §4.4 にアラート閾値視点の注記
- `docs/in-progress/12-implementation-tasks/Task.md` §Phase 0 を [x] DONE に

## 動作確認

- [x] `pnpm --filter @perapera/extension test` → 12 tests pass (smoke 2 + errors 10)
- [x] `pnpm typecheck` → 2 workspaces pass
- [x] `pnpm lint` → 0 error / 0 warning
- [x] `pnpm fmt:check` → diff 0
- [x] `actrun workflow run .github/workflows/ci.yml` → `state=completed`

## 設計との整合

- DD-220 / DD-241 (SourceSession の不変条件、SessionStateTransitionPolicy) の将来実装で `sessionStateTransitionError` / `invariantViolationError` を返せる形になっている
- use-case.md §9.2 の例外変換テーブル (ドメイン例外 → アプリ例外) で UI 文言変換する前提を `describeDomainError` のコメントに明記

## Phase 1 への接続

IMPL-002 の DomainError パターンは Phase 1 の全ドメインモデル (値オブジェクト・集約・ドメインサービス) で利用される。Phase 1 開始時点で `Result<T, DomainError>` が最初の契約として使える状態。