### PR TITLE
feat(domain): IMPL-101〜108 value objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ tmp/
 
 # actrun (local workflow runner) outputs
 _build/
+
+# Claude Code local permissions (個人環境依存)
+.claude/settings.local.json

--- a/packages/extension/src/domain/profile/overlay-settings.test.ts
+++ b/packages/extension/src/domain/profile/overlay-settings.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { createOverlaySettings } from './overlay-settings.js';
+
+const baseValid = {
+  positionPreset: 'bottom' as const,
+  opacity: 0.85,
+  maxLines: 2,
+  fontScale: 1,
+  showOriginalText: true,
+  showTranslatedText: true,
+};
+
+describe('OverlaySettings', () => {
+  it('accepts valid settings', () => {
+    const result = createOverlaySettings(baseValid);
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('accepts opacity 0 and 1 (boundary)', () => {
+    expect(createOverlaySettings({ ...baseValid, opacity: 0 }).isOk()).toBe(true);
+    expect(createOverlaySettings({ ...baseValid, opacity: 1 }).isOk()).toBe(true);
+  });
+
+  it('rejects opacity outside 0-1', () => {
+    expect(createOverlaySettings({ ...baseValid, opacity: 1.1 }).isErr()).toBe(true);
+    expect(createOverlaySettings({ ...baseValid, opacity: -0.1 }).isErr()).toBe(true);
+  });
+
+  it('rejects maxLines < 1', () => {
+    expect(createOverlaySettings({ ...baseValid, maxLines: 0 }).isErr()).toBe(true);
+  });
+
+  it('rejects non-integer maxLines', () => {
+    expect(createOverlaySettings({ ...baseValid, maxLines: 1.5 }).isErr()).toBe(true);
+  });
+
+  it('rejects non-positive fontScale', () => {
+    expect(createOverlaySettings({ ...baseValid, fontScale: 0 }).isErr()).toBe(true);
+    expect(createOverlaySettings({ ...baseValid, fontScale: -1 }).isErr()).toBe(true);
+  });
+
+  it('rejects unknown positionPreset', () => {
+    const result = createOverlaySettings({
+      ...baseValid,
+      positionPreset: 'middle',
+    });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects when both showOriginalText and showTranslatedText are false', () => {
+    const result = createOverlaySettings({
+      ...baseValid,
+      showOriginalText: false,
+      showTranslatedText: false,
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+});

--- a/packages/extension/src/domain/profile/overlay-settings.ts
+++ b/packages/extension/src/domain/profile/overlay-settings.ts
@@ -1,0 +1,41 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors.js';
+
+/**
+ * 翻訳オーバーレイの表示設定 (DD-234)。
+ * - `positionPreset`: 表示位置 (上 / 下 / 浮動)
+ * - `opacity`: 0.0-1.0 (完全透過〜完全不透明)
+ * - `maxLines`: 1 以上の整数
+ * - `fontScale`: 正の実数
+ * - `showOriginalText` / `showTranslatedText`: 少なくとも 1 つは true
+ *   (両方 false だと何も表示されないため不変条件として禁止)
+ */
+const overlaySettingsSchema = z
+  .object({
+    positionPreset: z.enum(['top', 'bottom', 'floating']),
+    opacity: z.number().min(0).max(1),
+    maxLines: z.number().int().min(1),
+    fontScale: z.number().positive(),
+    showOriginalText: z.boolean(),
+    showTranslatedText: z.boolean(),
+  })
+  .refine((settings) => settings.showOriginalText || settings.showTranslatedText, {
+    message: 'at least one of showOriginalText / showTranslatedText must be true',
+  })
+  .brand<'OverlaySettings'>();
+
+export type OverlaySettings = z.infer<typeof overlaySettingsSchema>;
+
+export const createOverlaySettings = (params: unknown): Result<OverlaySettings, DomainError> => {
+  const result = overlaySettingsSchema.safeParse(params);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'OverlaySettings',
+        message: result.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/extension/src/domain/session/language-pair.test.ts
+++ b/packages/extension/src/domain/session/language-pair.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { createLanguagePair } from './language-pair.js';
+
+describe('LanguagePair', () => {
+  it('accepts a valid pair (en-US -> ja-JP)', () => {
+    const result = createLanguagePair({ source: 'en-US', target: 'ja-JP' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.source).toBe('en-US');
+      expect(result.value.target).toBe('ja-JP');
+    }
+  });
+
+  it('accepts 2-letter codes without region (en -> ja)', () => {
+    const result = createLanguagePair({ source: 'en', target: 'ja' });
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects identical source and target', () => {
+    const result = createLanguagePair({ source: 'en-US', target: 'en-US' });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('rejects malformed source', () => {
+    const result = createLanguagePair({ source: 'ENGLISH', target: 'ja-JP' });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects malformed target', () => {
+    const result = createLanguagePair({ source: 'en-US', target: 'jp' });
+    expect(result.isOk()).toBe(true); // "jp" (2 letters) is accepted by the schema
+    const badResult = createLanguagePair({ source: 'en-US', target: 'ja_JP' });
+    expect(badResult.isErr()).toBe(true);
+  });
+
+  it('rejects empty input', () => {
+    const result = createLanguagePair({ source: '', target: 'ja-JP' });
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/extension/src/domain/session/language-pair.ts
+++ b/packages/extension/src/domain/session/language-pair.ts
@@ -1,0 +1,39 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors.js';
+
+/**
+ * BCP-47 言語タグの簡易検証。言語コード (2-3 文字小文字) + 任意の地域コード
+ * (2 文字大文字) にマッチする。完全な BCP-47 サブタグ体系を網羅しない単純形式
+ * だが、MVP の範囲 (en-US / ja-JP 等) では十分。
+ */
+const bcp47Schema = z.string().regex(/^[a-z]{2,3}(?:-[A-Z]{2})?$/);
+
+const languagePairSchema = z
+  .object({
+    source: bcp47Schema,
+    target: bcp47Schema,
+  })
+  .refine((pair) => pair.source !== pair.target, {
+    message: 'source and target must differ',
+  })
+  .brand<'LanguagePair'>();
+
+/**
+ * ソースセッション集約 / 拡張プロファイル集約で共有される値オブジェクト (DD-232)。
+ * `source` は音声ソースの入力言語、`target` は翻訳先言語。同一言語ペア禁止。
+ */
+export type LanguagePair = z.infer<typeof languagePairSchema>;
+
+export const createLanguagePair = (params: unknown): Result<LanguagePair, DomainError> => {
+  const result = languagePairSchema.safeParse(params);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'LanguagePair',
+        message: result.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/extension/src/domain/session/session-identifier.test.ts
+++ b/packages/extension/src/domain/session/session-identifier.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { createSessionIdentifier, parseSessionIdentifier } from './session-identifier.js';
+
+const VALID_ULID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
+
+describe('SessionIdentifier', () => {
+  it('creates a fresh identifier shaped like ULID', () => {
+    const identifier = createSessionIdentifier();
+    expect(identifier).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+  });
+
+  it('creates unique identifiers on successive calls', () => {
+    const a = createSessionIdentifier();
+    const b = createSessionIdentifier();
+    expect(a).not.toBe(b);
+  });
+
+  it('parses a valid ULID string', () => {
+    const result = parseSessionIdentifier(VALID_ULID);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBe(VALID_ULID);
+  });
+
+  it('rejects non-ULID string', () => {
+    const result = parseSessionIdentifier('not-a-ulid');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('rejects empty string', () => {
+    expect(parseSessionIdentifier('').isErr()).toBe(true);
+  });
+
+  it('rejects non-string value', () => {
+    expect(parseSessionIdentifier(123).isErr()).toBe(true);
+  });
+});

--- a/packages/extension/src/domain/session/session-identifier.ts
+++ b/packages/extension/src/domain/session/session-identifier.ts
@@ -1,0 +1,32 @@
+import { err, ok, type Result } from 'neverthrow';
+import { ulid } from 'ulid';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors.js';
+
+/**
+ * ソースセッション集約 (DD-210) の自己識別子 (DD-230)。
+ * ULID を Zod `.brand()` で branded type 化する。
+ */
+const sessionIdentifierSchema = z.string().ulid().brand<'SessionIdentifier'>();
+
+export type SessionIdentifier = z.infer<typeof sessionIdentifierSchema>;
+
+/**
+ * 新規 `SessionIdentifier` を生成する。`ulid()` の契約上常に有効な ULID を返すため
+ * 内部の `parse` は成功する。
+ */
+export const createSessionIdentifier = (): SessionIdentifier =>
+  parseSessionIdentifier(ulid())._unsafeUnwrap();
+
+export const parseSessionIdentifier = (value: unknown): Result<SessionIdentifier, DomainError> => {
+  const result = sessionIdentifierSchema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'SessionIdentifier',
+        message: 'must be a ULID string',
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/extension/src/domain/session/session-state.test.ts
+++ b/packages/extension/src/domain/session/session-state.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { SESSION_STATES, parseSessionState } from './session-state.js';
+
+describe('SessionState', () => {
+  it('enumerates exactly 11 states (DD-233)', () => {
+    expect(SESSION_STATES).toHaveLength(11);
+    expect(SESSION_STATES).toEqual([
+      'idle',
+      'requesting_permission',
+      'connecting',
+      'capturing',
+      'transcribing',
+      'translating',
+      'paused',
+      'reconnecting',
+      'degraded',
+      'stopped',
+      'error',
+    ]);
+  });
+
+  it.each(SESSION_STATES)('accepts %s', (state) => {
+    const result = parseSessionState(state);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBe(state);
+  });
+
+  it('rejects unknown state', () => {
+    const result = parseSessionState('done');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('rejects non-string value', () => {
+    expect(parseSessionState(0).isErr()).toBe(true);
+  });
+});

--- a/packages/extension/src/domain/session/session-state.ts
+++ b/packages/extension/src/domain/session/session-state.ts
@@ -1,0 +1,39 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors.js';
+
+/**
+ * `SourceSession` 集約の状態値 (DD-233 / DD-210)。
+ * 設計文書: detailed-design.md §7.1 状態遷移図、domain.md §4.3.1 不変条件。
+ * 値は設計文書に合わせ snake_case を保持する (システム間の契約のため)。
+ */
+export const SESSION_STATES = [
+  'idle',
+  'requesting_permission',
+  'connecting',
+  'capturing',
+  'transcribing',
+  'translating',
+  'paused',
+  'reconnecting',
+  'degraded',
+  'stopped',
+  'error',
+] as const;
+
+const sessionStateSchema = z.enum(SESSION_STATES);
+
+export type SessionState = z.infer<typeof sessionStateSchema>;
+
+export const parseSessionState = (value: unknown): Result<SessionState, DomainError> => {
+  const result = sessionStateSchema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'SessionState',
+        message: `expected one of [${SESSION_STATES.join(', ')}]`,
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/extension/src/domain/session/source-identifier.test.ts
+++ b/packages/extension/src/domain/session/source-identifier.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { createSourceIdentifier, parseSourceIdentifier } from './source-identifier.js';
+
+const VALID_ULID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
+
+describe('SourceIdentifier', () => {
+  it('creates a fresh identifier shaped like ULID', () => {
+    const identifier = createSourceIdentifier();
+    expect(identifier).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+  });
+
+  it('parses a valid ULID', () => {
+    const result = parseSourceIdentifier(VALID_ULID);
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects invalid string', () => {
+    const result = parseSourceIdentifier('src_not_ulid');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('rejects non-string value', () => {
+    expect(parseSourceIdentifier(null).isErr()).toBe(true);
+  });
+});

--- a/packages/extension/src/domain/session/source-identifier.ts
+++ b/packages/extension/src/domain/session/source-identifier.ts
@@ -1,0 +1,29 @@
+import { err, ok, type Result } from 'neverthrow';
+import { ulid } from 'ulid';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors.js';
+
+/**
+ * 音声ソース (`AudioSource`) の識別子 (DD-231)。
+ * `SourceSession` は `sourceIdentifier` フィールドでこれを保持し、1 セッションが
+ * 複数の sourceIdentifier を持つことはない (DD-210 不変条件)。
+ */
+const sourceIdentifierSchema = z.string().ulid().brand<'SourceIdentifier'>();
+
+export type SourceIdentifier = z.infer<typeof sourceIdentifierSchema>;
+
+export const createSourceIdentifier = (): SourceIdentifier =>
+  parseSourceIdentifier(ulid())._unsafeUnwrap();
+
+export const parseSourceIdentifier = (value: unknown): Result<SourceIdentifier, DomainError> => {
+  const result = sourceIdentifierSchema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'SourceIdentifier',
+        message: 'must be a ULID string',
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/extension/src/domain/session/source-type.test.ts
+++ b/packages/extension/src/domain/session/source-type.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { SOURCE_TYPES, parseSourceType } from './source-type.js';
+
+describe('SourceType', () => {
+  it('accepts "tab"', () => {
+    const result = parseSourceType('tab');
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBe('tab');
+  });
+
+  it('accepts "microphone"', () => {
+    const result = parseSourceType('microphone');
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('accepts "desktop"', () => {
+    const result = parseSourceType('desktop');
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects unknown string', () => {
+    const result = parseSourceType('unknown');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('rejects non-string value', () => {
+    const result = parseSourceType(42);
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('exposes SOURCE_TYPES as the canonical enumeration', () => {
+    expect(SOURCE_TYPES).toEqual(['tab', 'microphone', 'desktop']);
+  });
+});

--- a/packages/extension/src/domain/session/source-type.ts
+++ b/packages/extension/src/domain/session/source-type.ts
@@ -1,0 +1,26 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors.js';
+
+/**
+ * 音声ソース種別 (DD-210 ソースセッション集約)。
+ * 設計文書: detailed-design.md §5.1 `SourceType`
+ */
+export const SOURCE_TYPES = ['tab', 'microphone', 'desktop'] as const;
+
+const sourceTypeSchema = z.enum(SOURCE_TYPES);
+
+export type SourceType = z.infer<typeof sourceTypeSchema>;
+
+export const parseSourceType = (value: unknown): Result<SourceType, DomainError> => {
+  const result = sourceTypeSchema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'SourceType',
+        message: `expected one of [${SOURCE_TYPES.join(', ')}]`,
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/extension/src/domain/transcript/segment-identifier.test.ts
+++ b/packages/extension/src/domain/transcript/segment-identifier.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { createSegmentIdentifier, parseSegmentIdentifier } from './segment-identifier.js';
+
+describe('SegmentIdentifier', () => {
+  it('creates a ULID-shaped identifier', () => {
+    expect(createSegmentIdentifier()).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+  });
+
+  it('parses a valid ULID', () => {
+    const result = parseSegmentIdentifier('01HZX8Y1R8M7D3Q2P4T5V6W7X8');
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects invalid format', () => {
+    const result = parseSegmentIdentifier('seg_abc');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+});

--- a/packages/extension/src/domain/transcript/segment-identifier.ts
+++ b/packages/extension/src/domain/transcript/segment-identifier.ts
@@ -1,0 +1,29 @@
+import { err, ok, type Result } from 'neverthrow';
+import { ulid } from 'ulid';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors.js';
+
+/**
+ * 字幕セグメントの識別子 (CLAUDE.md §命名規則)。
+ * 部分字幕と確定字幕は同じ `SegmentIdentifier` を共有し、`isFinal` / `revision`
+ * で区別する (DD-211 / DD-221 字幕ストリーム集約)。
+ */
+const segmentIdentifierSchema = z.string().ulid().brand<'SegmentIdentifier'>();
+
+export type SegmentIdentifier = z.infer<typeof segmentIdentifierSchema>;
+
+export const createSegmentIdentifier = (): SegmentIdentifier =>
+  parseSegmentIdentifier(ulid())._unsafeUnwrap();
+
+export const parseSegmentIdentifier = (value: unknown): Result<SegmentIdentifier, DomainError> => {
+  const result = segmentIdentifierSchema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'SegmentIdentifier',
+        message: 'must be a ULID string',
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/extension/src/domain/transcript/timestamp-range.test.ts
+++ b/packages/extension/src/domain/transcript/timestamp-range.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { createTimestampRange } from './timestamp-range.js';
+
+describe('TimestampRange', () => {
+  it('accepts start < end', () => {
+    const result = createTimestampRange({ startMs: 100, endMs: 250 });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.startMs).toBe(100);
+      expect(result.value.endMs).toBe(250);
+    }
+  });
+
+  it('accepts start == end (zero-duration segment)', () => {
+    const result = createTimestampRange({ startMs: 100, endMs: 100 });
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects start > end', () => {
+    const result = createTimestampRange({ startMs: 300, endMs: 100 });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('rejects negative offsets', () => {
+    const result = createTimestampRange({ startMs: -1, endMs: 100 });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects non-integer values', () => {
+    const result = createTimestampRange({ startMs: 1.5, endMs: 100 });
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/extension/src/domain/transcript/timestamp-range.ts
+++ b/packages/extension/src/domain/transcript/timestamp-range.ts
@@ -1,0 +1,32 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors.js';
+
+/**
+ * 字幕セグメントのタイムスタンプ範囲 (DD-235)。
+ * セッション開始からの milliseconds オフセット。`start <= end`。
+ */
+const timestampRangeSchema = z
+  .object({
+    startMs: z.number().int().nonnegative(),
+    endMs: z.number().int().nonnegative(),
+  })
+  .refine((range) => range.startMs <= range.endMs, {
+    message: 'startMs must be <= endMs',
+  })
+  .brand<'TimestampRange'>();
+
+export type TimestampRange = z.infer<typeof timestampRangeSchema>;
+
+export const createTimestampRange = (params: unknown): Result<TimestampRange, DomainError> => {
+  const result = timestampRangeSchema.safeParse(params);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'TimestampRange',
+        message: result.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/extension/src/domain/transcript/translation-identifier.test.ts
+++ b/packages/extension/src/domain/transcript/translation-identifier.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createTranslationIdentifier,
+  parseTranslationIdentifier,
+} from './translation-identifier.js';
+
+describe('TranslationIdentifier', () => {
+  it('creates a ULID-shaped identifier', () => {
+    expect(createTranslationIdentifier()).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+  });
+
+  it('parses a valid ULID', () => {
+    const result = parseTranslationIdentifier('01HZX8Y1R8M7D3Q2P4T5V6W7X8');
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects invalid format', () => {
+    const result = parseTranslationIdentifier(undefined);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+});

--- a/packages/extension/src/domain/transcript/translation-identifier.ts
+++ b/packages/extension/src/domain/transcript/translation-identifier.ts
@@ -1,0 +1,30 @@
+import { err, ok, type Result } from 'neverthrow';
+import { ulid } from 'ulid';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors.js';
+
+/**
+ * 翻訳セグメントの識別子 (DD-222)。
+ * 原文セグメント (`SegmentIdentifier`) に 1 対 1 で紐づく (DD-211 / DD-271)。
+ */
+const translationIdentifierSchema = z.string().ulid().brand<'TranslationIdentifier'>();
+
+export type TranslationIdentifier = z.infer<typeof translationIdentifierSchema>;
+
+export const createTranslationIdentifier = (): TranslationIdentifier =>
+  parseTranslationIdentifier(ulid())._unsafeUnwrap();
+
+export const parseTranslationIdentifier = (
+  value: unknown,
+): Result<TranslationIdentifier, DomainError> => {
+  const result = translationIdentifierSchema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'TranslationIdentifier',
+        message: 'must be a ULID string',
+      }),
+    );
+  }
+  return ok(result.data);
+};


### PR DESCRIPTION
## 概要

Phase 1 (ドメイン層) の第一弾として、値オブジェクト 8 種を TDD で実装。いずれも Zod `.brand()` による branded types、throw せず `Result<T, DomainError>` を返す設計 (CLAUDE.md §Phase 0 合意事項 IMPL-001/002 に準拠)。

## 実装内容

| IMPL | 値オブジェクト | 所属 | 不変条件 |
|---|---|---|---|
| 108 | `SourceType` | session | enum (tab / microphone / desktop) |
| 105 | `SessionState` | session | 11 状態 enum (snake_case 保持) |
| 101 | `SessionIdentifier` | session | ULID brand |
| 102 | `SourceIdentifier` | session | ULID brand |
| 104 | `LanguagePair` | session / profile | BCP-47 + source ≠ target |
| 103 | `SegmentIdentifier` / `TranslationIdentifier` | transcript | ULID brand |
| 107 | `TimestampRange` | transcript | startMs ≤ endMs、非負整数 |
| 106 | `OverlaySettings` | profile | 透明度 0-1 / 行数 1+ / 少なくとも 1 つの表示モード true |

## 設計上の判断

- `createXXX(params: unknown)` シグネチャで boundary parse を統一。外部入力 (Chrome メッセージ・ストレージ復元・UI form) を型安全に domain に取り込む。同時に `@typescript-eslint/consistent-type-assertions: never` と両立する
- `_unsafeUnwrap()` は `ulid()` 等 contract-safe な内部生成でのみ使用、外部入力の parse では使わない
- `SessionState` の値は設計文書に合わせ `snake_case` を保持（システム境界の契約）

## 関連設計

- `docs/in-progress/03-detailed-design/domain.md` §6 値オブジェクト (DD-230〜235)
- `docs/in-progress/03-detailed-design/detailed-design.md` §5.1 型定義
- CLAUDE.md §Phase 0 合意事項 IMPL-001/002

## 動作確認

- [x] `pnpm --filter @perapera/extension test` → 67 tests pass (11 test files)
  - errors 10 / source-type 6 / session-state 14 / session-identifier 6 / source-identifier 4 / language-pair 6 / segment-identifier 3 / translation-identifier 3 / timestamp-range 5 / overlay-settings 8 / smoke 2
- [x] `pnpm typecheck` 2 workspaces pass
- [x] `pnpm lint` 0 error / 0 warning
- [x] `pnpm fmt:check` clean
- [x] `actrun workflow run .github/workflows/ci.yml` → `state=completed`

## Phase 1 進捗

- `[x]` §3.1 値オブジェクト 8 項目 (本 PR)
- `[ ]` §3.2 集約とエンティティ (IMPL-110〜115) ← 次
- `[ ]` §3.3 ドメインサービス (IMPL-120〜123)
- `[ ]` §3.4 ドメインイベント (IMPL-130〜135)
- `[ ]` §3.5 リポジトリインターフェース (IMPL-140〜143)
- `[ ]` §3.6 仕様 / ポリシー (IMPL-150〜153)

## 付随変更

- `.gitignore` に `.claude/settings.local.json` を追加 (個人環境依存の Claude Code 権限設定)
- `src/domain/{transcript,profile}/.gitkeep` を削除 (実ファイル追加で不要に)