### PR TITLE
feat(domain): IMPL-110〜115 aggregates and entities

### DIFF
--- a/packages/extension/src/domain/export/export-identifier.test.ts
+++ b/packages/extension/src/domain/export/export-identifier.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { createExportIdentifier, parseExportIdentifier } from './export-identifier.js';
+
+describe('ExportIdentifier', () => {
+  it('creates a ULID-shaped identifier', () => {
+    expect(createExportIdentifier()).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+  });
+
+  it('parses a valid ULID', () => {
+    const result = parseExportIdentifier('01HZX8Y1R8M7D3Q2P4T5V6W7X8');
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects invalid format', () => {
+    expect(parseExportIdentifier('exp_bad').isErr()).toBe(true);
+  });
+});

--- a/packages/extension/src/domain/export/export-identifier.ts
+++ b/packages/extension/src/domain/export/export-identifier.ts
@@ -1,0 +1,28 @@
+import { err, ok, type Result } from 'neverthrow';
+import { ulid } from 'ulid';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors.js';
+
+/**
+ * エクスポートレコード (`ExportRecord`, DD-223) の識別子。
+ * 表示・エクスポートコンテキスト (DD-203)。
+ */
+const exportIdentifierSchema = z.string().ulid().brand<'ExportIdentifier'>();
+
+export type ExportIdentifier = z.infer<typeof exportIdentifierSchema>;
+
+export const createExportIdentifier = (): ExportIdentifier =>
+  parseExportIdentifier(ulid())._unsafeUnwrap();
+
+export const parseExportIdentifier = (value: unknown): Result<ExportIdentifier, DomainError> => {
+  const result = exportIdentifierSchema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'ExportIdentifier',
+        message: 'must be a ULID string',
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/extension/src/domain/export/export-record.test.ts
+++ b/packages/extension/src/domain/export/export-record.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { createExportRecord, EXPORT_FORMATS } from './export-record.js';
+
+const VALID_EXPORT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
+const VALID_SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X9';
+
+describe('ExportRecord', () => {
+  it('exposes TXT / JSON as the allowed formats (DD-273)', () => {
+    expect(EXPORT_FORMATS).toEqual(['txt', 'json']);
+  });
+
+  it.each(EXPORT_FORMATS)('creates a record with format=%s', (format) => {
+    const result = createExportRecord({
+      exportIdentifier: VALID_EXPORT_ID,
+      sessionIdentifier: VALID_SESSION_ID,
+      format,
+      includeOriginal: true,
+      includeTranslation: true,
+      createdAt: '2026-04-21T00:00:00.000Z',
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.format).toBe(format);
+    }
+  });
+
+  it('rejects unknown format', () => {
+    const result = createExportRecord({
+      exportIdentifier: VALID_EXPORT_ID,
+      sessionIdentifier: VALID_SESSION_ID,
+      format: 'pdf',
+      includeOriginal: true,
+      includeTranslation: true,
+      createdAt: '2026-04-21T00:00:00.000Z',
+    });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects when both includeOriginal and includeTranslation are false', () => {
+    const result = createExportRecord({
+      exportIdentifier: VALID_EXPORT_ID,
+      sessionIdentifier: VALID_SESSION_ID,
+      format: 'txt',
+      includeOriginal: false,
+      includeTranslation: false,
+      createdAt: '2026-04-21T00:00:00.000Z',
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('rejects invalid identifiers', () => {
+    expect(
+      createExportRecord({
+        exportIdentifier: 'bad',
+        sessionIdentifier: VALID_SESSION_ID,
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: true,
+        createdAt: '2026-04-21T00:00:00.000Z',
+      }).isErr(),
+    ).toBe(true);
+  });
+
+  it('rejects invalid createdAt', () => {
+    const result = createExportRecord({
+      exportIdentifier: VALID_EXPORT_ID,
+      sessionIdentifier: VALID_SESSION_ID,
+      format: 'json',
+      includeOriginal: true,
+      includeTranslation: true,
+      createdAt: 'not-a-date',
+    });
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/extension/src/domain/export/export-record.ts
+++ b/packages/extension/src/domain/export/export-record.ts
@@ -1,0 +1,80 @@
+import { err, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
+import { type DomainError, validationError } from '../shared/errors.js';
+import { parseExportIdentifier, type ExportIdentifier } from './export-identifier.js';
+
+/**
+ * エクスポート形式の列挙 (DD-273 ExportFormatSpecification)。
+ * TXT / JSON のみ許可する。
+ */
+export const EXPORT_FORMATS = ['txt', 'json'] as const;
+export type ExportFormat = (typeof EXPORT_FORMATS)[number];
+
+/**
+ * エクスポートレコード (DD-223、表示・エクスポートコンテキスト DD-203)。
+ * ライフサイクル: 利用者の明示操作で生成 → 出力完了。
+ *
+ * 不変条件:
+ * - `includeOriginal` / `includeTranslation` の少なくとも一方は true
+ *   (両方 false では出力するコンテンツが無い)
+ * - `format` は EXPORT_FORMATS のいずれか
+ * - `createdAt` は ISO 8601 UTC 文字列
+ */
+export type ExportRecord = Readonly<{
+  exportIdentifier: ExportIdentifier;
+  sessionIdentifier: SessionIdentifier;
+  format: ExportFormat;
+  includeOriginal: boolean;
+  includeTranslation: boolean;
+  createdAt: string;
+}>;
+
+const formatSchema = z.enum(EXPORT_FORMATS);
+const iso8601Schema = z.string().datetime();
+
+export const createExportRecord = (params: {
+  exportIdentifier: string;
+  sessionIdentifier: string;
+  format: string;
+  includeOriginal: boolean;
+  includeTranslation: boolean;
+  createdAt: string;
+}): Result<ExportRecord, DomainError> => {
+  const formatResult = formatSchema.safeParse(params.format);
+  if (!formatResult.success) {
+    return err(
+      validationError({
+        field: 'ExportRecord.format',
+        message: `expected one of [${EXPORT_FORMATS.join(', ')}]`,
+      }),
+    );
+  }
+  const createdAtResult = iso8601Schema.safeParse(params.createdAt);
+  if (!createdAtResult.success) {
+    return err(
+      validationError({
+        field: 'ExportRecord.createdAt',
+        message: 'must be ISO 8601 datetime',
+      }),
+    );
+  }
+  if (!params.includeOriginal && !params.includeTranslation) {
+    return err(
+      validationError({
+        field: 'ExportRecord',
+        message: 'at least one of includeOriginal / includeTranslation must be true',
+      }),
+    );
+  }
+  return parseExportIdentifier(params.exportIdentifier).andThen((exportIdentifier) =>
+    parseSessionIdentifier(params.sessionIdentifier).map((sessionIdentifier) => ({
+      exportIdentifier,
+      sessionIdentifier,
+      format: formatResult.data,
+      includeOriginal: params.includeOriginal,
+      includeTranslation: params.includeTranslation,
+      createdAt: createdAtResult.data,
+    })),
+  );
+};

--- a/packages/extension/src/domain/profile/extension-profile.test.ts
+++ b/packages/extension/src/domain/profile/extension-profile.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { createLanguagePair } from '../session/language-pair.js';
+import {
+  createExtensionProfile,
+  updateDefaultLanguagePair,
+  updateDefaultOverlaySettings,
+  toggleAutoDetect,
+} from './extension-profile.js';
+import { createOverlaySettings } from './overlay-settings.js';
+
+const PROFILE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
+const defaultLanguagePair = createLanguagePair({
+  source: 'en-US',
+  target: 'ja-JP',
+})._unsafeUnwrap();
+const defaultOverlaySettings = createOverlaySettings({
+  positionPreset: 'bottom',
+  opacity: 0.85,
+  maxLines: 2,
+  fontScale: 1,
+  showOriginalText: true,
+  showTranslatedText: true,
+})._unsafeUnwrap();
+
+const newProfile = () =>
+  createExtensionProfile({
+    profileIdentifier: PROFILE_ID,
+    defaultLanguagePair,
+    defaultOverlaySettings,
+    autoDetectEnabled: false,
+  })._unsafeUnwrap();
+
+describe('ExtensionProfile aggregate', () => {
+  describe('createExtensionProfile', () => {
+    it('creates a profile with given defaults', () => {
+      const result = createExtensionProfile({
+        profileIdentifier: PROFILE_ID,
+        defaultLanguagePair,
+        defaultOverlaySettings,
+        autoDetectEnabled: false,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.autoDetectEnabled).toBe(false);
+      }
+    });
+
+    it('rejects invalid profileIdentifier', () => {
+      const result = createExtensionProfile({
+        profileIdentifier: 'bad',
+        defaultLanguagePair,
+        defaultOverlaySettings,
+        autoDetectEnabled: false,
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('updateDefaultLanguagePair', () => {
+    it('replaces the default language pair', () => {
+      const newPair = createLanguagePair({ source: 'ja-JP', target: 'en-US' })._unsafeUnwrap();
+      const result = updateDefaultLanguagePair(newProfile(), newPair);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.defaultLanguagePair).toBe(newPair);
+    });
+  });
+
+  describe('updateDefaultOverlaySettings', () => {
+    it('replaces the default overlay settings', () => {
+      const newSettings = createOverlaySettings({
+        positionPreset: 'top',
+        opacity: 1,
+        maxLines: 3,
+        fontScale: 1.2,
+        showOriginalText: false,
+        showTranslatedText: true,
+      })._unsafeUnwrap();
+      const result = updateDefaultOverlaySettings(newProfile(), newSettings);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.defaultOverlaySettings).toBe(newSettings);
+    });
+  });
+
+  describe('toggleAutoDetect', () => {
+    it('sets autoDetectEnabled to the requested value', () => {
+      const enabled = toggleAutoDetect(newProfile(), true);
+      expect(enabled.isOk()).toBe(true);
+      if (enabled.isOk()) expect(enabled.value.autoDetectEnabled).toBe(true);
+
+      const disabled = toggleAutoDetect(enabled._unsafeUnwrap(), false);
+      expect(disabled.isOk()).toBe(true);
+      if (disabled.isOk()) expect(disabled.value.autoDetectEnabled).toBe(false);
+    });
+  });
+});

--- a/packages/extension/src/domain/profile/extension-profile.ts
+++ b/packages/extension/src/domain/profile/extension-profile.ts
@@ -1,0 +1,48 @@
+import { ok, type Result } from 'neverthrow';
+import { type LanguagePair } from '../session/language-pair.js';
+import { type DomainError } from '../shared/errors.js';
+import { type OverlaySettings } from './overlay-settings.js';
+import { parseProfileIdentifier, type ProfileIdentifier } from './profile-identifier.js';
+
+/**
+ * 拡張プロファイル集約ルート (DD-212)。
+ * 拡張全体の既定値 (言語ペア / オーバーレイ設定 / 自動言語判定) を保持する。
+ *
+ * 不変条件: 既定値は値オブジェクト (`LanguagePair` / `OverlaySettings`) の
+ * 時点でバリデーション済。本集約では識別子検証と更新操作を提供する。
+ */
+export type ExtensionProfile = Readonly<{
+  profileIdentifier: ProfileIdentifier;
+  defaultLanguagePair: LanguagePair;
+  defaultOverlaySettings: OverlaySettings;
+  autoDetectEnabled: boolean;
+}>;
+
+export const createExtensionProfile = (params: {
+  profileIdentifier: string;
+  defaultLanguagePair: LanguagePair;
+  defaultOverlaySettings: OverlaySettings;
+  autoDetectEnabled: boolean;
+}): Result<ExtensionProfile, DomainError> =>
+  parseProfileIdentifier(params.profileIdentifier).map((profileIdentifier) => ({
+    profileIdentifier,
+    defaultLanguagePair: params.defaultLanguagePair,
+    defaultOverlaySettings: params.defaultOverlaySettings,
+    autoDetectEnabled: params.autoDetectEnabled,
+  }));
+
+export const updateDefaultLanguagePair = (
+  profile: ExtensionProfile,
+  languagePair: LanguagePair,
+): Result<ExtensionProfile, DomainError> => ok({ ...profile, defaultLanguagePair: languagePair });
+
+export const updateDefaultOverlaySettings = (
+  profile: ExtensionProfile,
+  overlaySettings: OverlaySettings,
+): Result<ExtensionProfile, DomainError> =>
+  ok({ ...profile, defaultOverlaySettings: overlaySettings });
+
+export const toggleAutoDetect = (
+  profile: ExtensionProfile,
+  enabled: boolean,
+): Result<ExtensionProfile, DomainError> => ok({ ...profile, autoDetectEnabled: enabled });

--- a/packages/extension/src/domain/profile/profile-identifier.ts
+++ b/packages/extension/src/domain/profile/profile-identifier.ts
@@ -1,0 +1,27 @@
+import { err, ok, type Result } from 'neverthrow';
+import { ulid } from 'ulid';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors.js';
+
+/**
+ * 拡張プロファイル集約 (`ExtensionProfile`, DD-212) の識別子。
+ */
+const profileIdentifierSchema = z.string().ulid().brand<'ProfileIdentifier'>();
+
+export type ProfileIdentifier = z.infer<typeof profileIdentifierSchema>;
+
+export const createProfileIdentifier = (): ProfileIdentifier =>
+  parseProfileIdentifier(ulid())._unsafeUnwrap();
+
+export const parseProfileIdentifier = (value: unknown): Result<ProfileIdentifier, DomainError> => {
+  const result = profileIdentifierSchema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'ProfileIdentifier',
+        message: 'must be a ULID string',
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/extension/src/domain/session/source-session.test.ts
+++ b/packages/extension/src/domain/session/source-session.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+import { createLanguagePair } from './language-pair.js';
+import {
+  createSourceSession,
+  markSourceSessionDegraded,
+  pauseSourceSession,
+  recoverSourceSessionTranslation,
+  resumeSourceSession,
+  startSourceSession,
+  stopSourceSession,
+  transitionSourceSessionState,
+} from './source-session.js';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X9';
+const startedAt = '2026-04-21T00:00:00.000Z';
+const languagePair = createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap();
+
+const newSession = () =>
+  createSourceSession({
+    sessionIdentifier: SESSION_ID,
+    sourceIdentifier: SOURCE_ID,
+    sourceType: 'tab',
+    languagePair,
+    startedAt,
+  })._unsafeUnwrap();
+
+describe('SourceSession aggregate', () => {
+  describe('createSourceSession', () => {
+    it('creates a session in idle state', () => {
+      const result = createSourceSession({
+        sessionIdentifier: SESSION_ID,
+        sourceIdentifier: SOURCE_ID,
+        sourceType: 'tab',
+        languagePair,
+        startedAt,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.state).toBe('idle');
+        expect(result.value.stoppedAt).toBeNull();
+        expect(result.value.degradedReason).toBeNull();
+      }
+    });
+
+    it('rejects invalid identifiers', () => {
+      const result = createSourceSession({
+        sessionIdentifier: 'bad',
+        sourceIdentifier: SOURCE_ID,
+        sourceType: 'tab',
+        languagePair,
+        startedAt,
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects invalid sourceType', () => {
+      const result = createSourceSession({
+        sessionIdentifier: SESSION_ID,
+        sourceIdentifier: SOURCE_ID,
+        sourceType: 'unknown',
+        languagePair,
+        startedAt,
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects invalid startedAt', () => {
+      const result = createSourceSession({
+        sessionIdentifier: SESSION_ID,
+        sourceIdentifier: SOURCE_ID,
+        sourceType: 'tab',
+        languagePair,
+        startedAt: 'not-a-date',
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('startSourceSession', () => {
+    it('transitions idle → requesting_permission', () => {
+      const result = startSourceSession(newSession());
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.state).toBe('requesting_permission');
+    });
+
+    it('rejects start on non-idle state', () => {
+      const started = startSourceSession(newSession())._unsafeUnwrap();
+      const result = startSourceSession(started);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('session-state-transition');
+    });
+  });
+
+  describe('transitionSourceSessionState', () => {
+    it('permits requesting_permission → connecting', () => {
+      const started = startSourceSession(newSession())._unsafeUnwrap();
+      const result = transitionSourceSessionState(started, 'connecting');
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('permits connecting → capturing', () => {
+      const s = transitionSourceSessionState(
+        startSourceSession(newSession())._unsafeUnwrap(),
+        'connecting',
+      )._unsafeUnwrap();
+      const result = transitionSourceSessionState(s, 'capturing');
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('permits capturing → transcribing → translating → transcribing cycle', () => {
+      let session = newSession();
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'connecting')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'capturing')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'transcribing')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'translating')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'transcribing')._unsafeUnwrap();
+      expect(session.state).toBe('transcribing');
+    });
+
+    it('rejects illegal transition idle → capturing', () => {
+      const result = transitionSourceSessionState(newSession(), 'capturing');
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('session-state-transition');
+    });
+
+    it('permits reconnecting → capturing', () => {
+      let session = newSession();
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'connecting')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'capturing')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'reconnecting')._unsafeUnwrap();
+      const result = transitionSourceSessionState(session, 'capturing');
+      expect(result.isOk()).toBe(true);
+    });
+  });
+
+  describe('pauseSourceSession / resumeSourceSession', () => {
+    it('pauses from capturing', () => {
+      let session = newSession();
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'connecting')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'capturing')._unsafeUnwrap();
+      const paused = pauseSourceSession(session);
+      expect(paused.isOk()).toBe(true);
+      if (paused.isOk()) expect(paused.value.state).toBe('paused');
+    });
+
+    it('rejects pause from idle', () => {
+      const result = pauseSourceSession(newSession());
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('resume from paused → capturing', () => {
+      let session = newSession();
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'connecting')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'capturing')._unsafeUnwrap();
+      session = pauseSourceSession(session)._unsafeUnwrap();
+      const resumed = resumeSourceSession(session);
+      expect(resumed.isOk()).toBe(true);
+      if (resumed.isOk()) expect(resumed.value.state).toBe('capturing');
+    });
+
+    it('rejects resume on non-paused state', () => {
+      const result = resumeSourceSession(newSession());
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('markSourceSessionDegraded', () => {
+    it('transitions transcribing → degraded with reason', () => {
+      let session = newSession();
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'connecting')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'capturing')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'transcribing')._unsafeUnwrap();
+      const result = markSourceSessionDegraded(session, 'translation provider timed out');
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.state).toBe('degraded');
+        expect(result.value.degradedReason).toBe('translation provider timed out');
+      }
+    });
+
+    it('rejects degraded from idle (invariant: translation-failure-only)', () => {
+      const result = markSourceSessionDegraded(newSession(), 'reason');
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('session-state-transition');
+    });
+
+    it('recovers from degraded → transcribing', () => {
+      let session = newSession();
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'connecting')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'capturing')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'transcribing')._unsafeUnwrap();
+      session = markSourceSessionDegraded(session, 'temp error')._unsafeUnwrap();
+      const recovered = recoverSourceSessionTranslation(session);
+      expect(recovered.isOk()).toBe(true);
+      if (recovered.isOk()) {
+        expect(recovered.value.state).toBe('transcribing');
+        expect(recovered.value.degradedReason).toBeNull();
+      }
+    });
+  });
+
+  describe('stopSourceSession', () => {
+    it('transitions to stopped and records timestamp', () => {
+      let session = newSession();
+      session = startSourceSession(session)._unsafeUnwrap();
+      const result = stopSourceSession(session, {
+        stoppedAt: '2026-04-21T00:10:00.000Z',
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.state).toBe('stopped');
+        expect(result.value.stoppedAt).toBe('2026-04-21T00:10:00.000Z');
+      }
+    });
+
+    it('rejects resume after stopped (DD-210 invariant 4)', () => {
+      let session = newSession();
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = stopSourceSession(session, {
+        stoppedAt: '2026-04-21T00:10:00.000Z',
+      })._unsafeUnwrap();
+      const resumed = resumeSourceSession(session);
+      expect(resumed.isErr()).toBe(true);
+    });
+
+    it('rejects any transition after stopped', () => {
+      let session = newSession();
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = stopSourceSession(session, {
+        stoppedAt: '2026-04-21T00:10:00.000Z',
+      })._unsafeUnwrap();
+      expect(transitionSourceSessionState(session, 'capturing').isErr()).toBe(true);
+    });
+  });
+});

--- a/packages/extension/src/domain/session/source-session.ts
+++ b/packages/extension/src/domain/session/source-session.ts
@@ -1,0 +1,214 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import {
+  type DomainError,
+  sessionStateTransitionError,
+  validationError,
+} from '../shared/errors.js';
+import { type LanguagePair } from './language-pair.js';
+import { parseSessionIdentifier, type SessionIdentifier } from './session-identifier.js';
+import { type SessionState } from './session-state.js';
+import { parseSourceIdentifier, type SourceIdentifier } from './source-identifier.js';
+import { parseSourceType, type SourceType } from './source-type.js';
+
+/**
+ * ソースセッション集約ルート (DD-210 / DD-220)。
+ *
+ * 不変条件:
+ * 1. `sessionIdentifier` と `sourceIdentifier` の組は生成後不変
+ * 2. 状態遷移は §7 の state machine に従う (idle → requesting_permission → ...)
+ * 3. `degraded` は翻訳障害時のみ遷移可能 (transcribing / translating から)
+ * 4. `stopped` 後は再開不可 (terminal state)
+ *
+ * NOTE: 状態遷移表は本ファイル内に inline で保持しているが、
+ * IMPL-121 `SessionStateTransitionPolicy` 実装時にドメインサービスへ抽出する。
+ */
+export type SourceSession = Readonly<{
+  sessionIdentifier: SessionIdentifier;
+  sourceIdentifier: SourceIdentifier;
+  sourceType: SourceType;
+  state: SessionState;
+  languagePair: LanguagePair;
+  startedAt: string;
+  stoppedAt: string | null;
+  degradedReason: string | null;
+}>;
+
+const iso8601Schema = z.string().datetime();
+
+type TransitionContext = Readonly<{
+  degradedReason?: string;
+  stoppedAt?: string;
+}>;
+
+/**
+ * 許容される状態遷移テーブル。キーは遷移前、値は遷移先の配列。
+ * 状態機械の定義は detailed-design.md §7.1 / §7.2。
+ * `stopped` はどの稼働状態からも到達可能 (terminal) なため `canTransition`
+ * 側で特別扱いする (テーブルには列挙しない)。
+ */
+const ALLOWED_TRANSITIONS: Readonly<Record<SessionState, readonly SessionState[]>> = {
+  idle: ['requesting_permission'],
+  requesting_permission: ['connecting', 'error'],
+  connecting: ['capturing', 'error'],
+  capturing: ['transcribing', 'paused', 'reconnecting'],
+  transcribing: ['translating', 'paused', 'reconnecting', 'degraded'],
+  translating: ['transcribing', 'paused', 'reconnecting', 'degraded'],
+  paused: ['capturing'],
+  reconnecting: ['capturing', 'error'],
+  degraded: ['transcribing'],
+  error: [],
+  stopped: [],
+};
+
+const canTransition = (from: SessionState, to: SessionState): boolean => {
+  if (from === 'stopped') return false;
+  if (to === 'stopped') return true;
+  return ALLOWED_TRANSITIONS[from].includes(to);
+};
+
+const transitionGuard = (
+  current: SourceSession,
+  to: SessionState,
+  reason: string,
+): Result<SourceSession, DomainError> => {
+  if (!canTransition(current.state, to)) {
+    return err(
+      sessionStateTransitionError({
+        from: current.state,
+        to,
+        reason,
+      }),
+    );
+  }
+  return ok({ ...current, state: to, degradedReason: null });
+};
+
+export const createSourceSession = (params: {
+  sessionIdentifier: string;
+  sourceIdentifier: string;
+  sourceType: string;
+  languagePair: LanguagePair;
+  startedAt: string;
+}): Result<SourceSession, DomainError> => {
+  const startedAtResult = iso8601Schema.safeParse(params.startedAt);
+  if (!startedAtResult.success) {
+    return err(
+      validationError({
+        field: 'SourceSession.startedAt',
+        message: 'must be ISO 8601 datetime',
+      }),
+    );
+  }
+  return parseSessionIdentifier(params.sessionIdentifier).andThen((sessionIdentifier) =>
+    parseSourceIdentifier(params.sourceIdentifier).andThen((sourceIdentifier) =>
+      parseSourceType(params.sourceType).map(
+        (sourceType): SourceSession => ({
+          sessionIdentifier,
+          sourceIdentifier,
+          sourceType,
+          state: 'idle',
+          languagePair: params.languagePair,
+          startedAt: startedAtResult.data,
+          stoppedAt: null,
+          degradedReason: null,
+        }),
+      ),
+    ),
+  );
+};
+
+export const startSourceSession = (session: SourceSession): Result<SourceSession, DomainError> =>
+  transitionGuard(session, 'requesting_permission', 'start only allowed from idle');
+
+/**
+ * 汎用状態遷移。外部 (Relay イベント / Permission 結果 / Capture 成否) から
+ * 呼ばれる。`degraded` / `stopped` への遷移は専用ヘルパーを使うこと
+ * (理由・タイムスタンプの記録があるため)。
+ */
+export const transitionSourceSessionState = (
+  session: SourceSession,
+  target: SessionState,
+): Result<SourceSession, DomainError> => {
+  if (target === 'degraded' || target === 'stopped') {
+    return err(
+      sessionStateTransitionError({
+        from: session.state,
+        to: target,
+        reason: 'use dedicated helper (markSourceSessionDegraded / stopSourceSession)',
+      }),
+    );
+  }
+  return transitionGuard(
+    session,
+    target,
+    `direct transition ${session.state} → ${target} is not allowed`,
+  );
+};
+
+export const pauseSourceSession = (session: SourceSession): Result<SourceSession, DomainError> =>
+  transitionGuard(session, 'paused', 'pause only allowed from active states');
+
+export const resumeSourceSession = (session: SourceSession): Result<SourceSession, DomainError> =>
+  transitionGuard(session, 'capturing', 'resume only allowed from paused');
+
+export const markSourceSessionDegraded = (
+  session: SourceSession,
+  reason: string,
+): Result<SourceSession, DomainError> => {
+  if (!canTransition(session.state, 'degraded')) {
+    return err(
+      sessionStateTransitionError({
+        from: session.state,
+        to: 'degraded',
+        reason: 'degraded is only reachable from transcribing / translating',
+      }),
+    );
+  }
+  return ok({ ...session, state: 'degraded', degradedReason: reason });
+};
+
+export const recoverSourceSessionTranslation = (
+  session: SourceSession,
+): Result<SourceSession, DomainError> => {
+  if (session.state !== 'degraded') {
+    return err(
+      sessionStateTransitionError({
+        from: session.state,
+        to: 'transcribing',
+        reason: 'recover only allowed from degraded',
+      }),
+    );
+  }
+  return ok({ ...session, state: 'transcribing', degradedReason: null });
+};
+
+export const stopSourceSession = (
+  session: SourceSession,
+  context: TransitionContext & { stoppedAt: string },
+): Result<SourceSession, DomainError> => {
+  if (!canTransition(session.state, 'stopped')) {
+    return err(
+      sessionStateTransitionError({
+        from: session.state,
+        to: 'stopped',
+        reason: `cannot stop from ${session.state}`,
+      }),
+    );
+  }
+  const stoppedAtResult = iso8601Schema.safeParse(context.stoppedAt);
+  if (!stoppedAtResult.success) {
+    return err(
+      validationError({
+        field: 'SourceSession.stoppedAt',
+        message: 'must be ISO 8601 datetime',
+      }),
+    );
+  }
+  return ok({
+    ...session,
+    state: 'stopped',
+    stoppedAt: stoppedAtResult.data,
+    degradedReason: null,
+  });
+};

--- a/packages/extension/src/domain/transcript/transcript-segment.test.ts
+++ b/packages/extension/src/domain/transcript/transcript-segment.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import { createTimestampRange } from './timestamp-range.js';
+import {
+  createPartialTranscriptSegment,
+  finalizeTranscriptSegment,
+  updatePartialTranscriptSegment,
+} from './transcript-segment.js';
+
+const VALID_ULID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
+const timeRange = createTimestampRange({ startMs: 0, endMs: 1000 })._unsafeUnwrap();
+
+describe('TranscriptSegment', () => {
+  describe('createPartialTranscriptSegment', () => {
+    it('creates a partial segment with revision=1 and isFinal=false', () => {
+      const result = createPartialTranscriptSegment({
+        segmentIdentifier: VALID_ULID,
+        revision: 1,
+        text: 'hello',
+        timeRange,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.revision).toBe(1);
+        expect(result.value.isFinal).toBe(false);
+        expect(result.value.text).toBe('hello');
+      }
+    });
+
+    it('rejects revision < 1', () => {
+      const result = createPartialTranscriptSegment({
+        segmentIdentifier: VALID_ULID,
+        revision: 0,
+        text: 'hello',
+        timeRange,
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects empty text', () => {
+      const result = createPartialTranscriptSegment({
+        segmentIdentifier: VALID_ULID,
+        revision: 1,
+        text: '',
+        timeRange,
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('updatePartialTranscriptSegment', () => {
+    it('increments revision monotonically', () => {
+      const current = createPartialTranscriptSegment({
+        segmentIdentifier: VALID_ULID,
+        revision: 1,
+        text: 'he',
+        timeRange,
+      })._unsafeUnwrap();
+      const result = updatePartialTranscriptSegment(current, { revision: 2, text: 'hello' });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.revision).toBe(2);
+    });
+
+    it('rejects same or smaller revision', () => {
+      const current = createPartialTranscriptSegment({
+        segmentIdentifier: VALID_ULID,
+        revision: 3,
+        text: 'hello',
+        timeRange,
+      })._unsafeUnwrap();
+      expect(updatePartialTranscriptSegment(current, { revision: 3, text: 'x' }).isErr()).toBe(
+        true,
+      );
+      expect(updatePartialTranscriptSegment(current, { revision: 2, text: 'x' }).isErr()).toBe(
+        true,
+      );
+    });
+
+    it('rejects update on already-final segment', () => {
+      const partial = createPartialTranscriptSegment({
+        segmentIdentifier: VALID_ULID,
+        revision: 1,
+        text: 'hello',
+        timeRange,
+      })._unsafeUnwrap();
+      const final = finalizeTranscriptSegment(partial, {})._unsafeUnwrap();
+      const result = updatePartialTranscriptSegment(final, { revision: 2, text: 'x' });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    });
+  });
+
+  describe('finalizeTranscriptSegment', () => {
+    it('marks segment as final (isFinal=true)', () => {
+      const partial = createPartialTranscriptSegment({
+        segmentIdentifier: VALID_ULID,
+        revision: 2,
+        text: 'hello world',
+        timeRange,
+      })._unsafeUnwrap();
+      const result = finalizeTranscriptSegment(partial, {});
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.isFinal).toBe(true);
+        expect(result.value.text).toBe('hello world');
+      }
+    });
+
+    it('allows overriding text and timeRange at finalization', () => {
+      const partial = createPartialTranscriptSegment({
+        segmentIdentifier: VALID_ULID,
+        revision: 2,
+        text: 'hello',
+        timeRange,
+      })._unsafeUnwrap();
+      const newTimeRange = createTimestampRange({ startMs: 0, endMs: 1500 })._unsafeUnwrap();
+      const result = finalizeTranscriptSegment(partial, {
+        text: 'hello world',
+        timeRange: newTimeRange,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.text).toBe('hello world');
+        expect(result.value.timeRange.endMs).toBe(1500);
+      }
+    });
+
+    it('rejects finalize on already-final segment', () => {
+      const partial = createPartialTranscriptSegment({
+        segmentIdentifier: VALID_ULID,
+        revision: 1,
+        text: 'hello',
+        timeRange,
+      })._unsafeUnwrap();
+      const final = finalizeTranscriptSegment(partial, {})._unsafeUnwrap();
+      const result = finalizeTranscriptSegment(final, {});
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    });
+  });
+});

--- a/packages/extension/src/domain/transcript/transcript-segment.ts
+++ b/packages/extension/src/domain/transcript/transcript-segment.ts
@@ -1,0 +1,106 @@
+import { err, ok, type Result } from 'neverthrow';
+import { type DomainError, invariantViolationError, validationError } from '../shared/errors.js';
+import { parseSegmentIdentifier, type SegmentIdentifier } from './segment-identifier.js';
+import { type TimestampRange } from './timestamp-range.js';
+
+/**
+ * 字幕セグメントエンティティ (DD-221)。
+ *
+ * - `revision`: 部分字幕の更新回数 (1 始まり、単調増加)
+ * - `isFinal`: 確定字幕かどうか。false → true の遷移のみ可、逆方向不可
+ * - 確定後は revision / text / timeRange の更新不可
+ *   (再確定は別集約操作でやり直す)
+ */
+export type TranscriptSegment = Readonly<{
+  segmentIdentifier: SegmentIdentifier;
+  revision: number;
+  isFinal: boolean;
+  text: string;
+  timeRange: TimestampRange;
+}>;
+
+const validateText = (text: string): Result<string, DomainError> => {
+  if (text.length === 0) {
+    return err(validationError({ field: 'TranscriptSegment.text', message: 'must not be empty' }));
+  }
+  return ok(text);
+};
+
+const validateRevision = (revision: number): Result<number, DomainError> => {
+  if (!Number.isInteger(revision) || revision < 1) {
+    return err(
+      validationError({
+        field: 'TranscriptSegment.revision',
+        message: 'must be a positive integer',
+      }),
+    );
+  }
+  return ok(revision);
+};
+
+export const createPartialTranscriptSegment = (params: {
+  segmentIdentifier: string;
+  revision: number;
+  text: string;
+  timeRange: TimestampRange;
+}): Result<TranscriptSegment, DomainError> =>
+  parseSegmentIdentifier(params.segmentIdentifier).andThen((segmentIdentifier) =>
+    validateRevision(params.revision).andThen((revision) =>
+      validateText(params.text).map((text) => ({
+        segmentIdentifier,
+        revision,
+        isFinal: false,
+        text,
+        timeRange: params.timeRange,
+      })),
+    ),
+  );
+
+export const updatePartialTranscriptSegment = (
+  current: TranscriptSegment,
+  next: { revision: number; text: string; timeRange?: TimestampRange },
+): Result<TranscriptSegment, DomainError> => {
+  if (current.isFinal) {
+    return err(
+      invariantViolationError({
+        invariant: 'partial-update-on-final-segment',
+        details: `segment ${current.segmentIdentifier} is already finalized`,
+      }),
+    );
+  }
+  if (next.revision <= current.revision) {
+    return err(
+      invariantViolationError({
+        invariant: 'monotonic-revision',
+        details: `revision must increase: current=${String(current.revision)}, next=${String(next.revision)}`,
+      }),
+    );
+  }
+  return validateText(next.text).map((text) => ({
+    ...current,
+    revision: next.revision,
+    text,
+    timeRange: next.timeRange ?? current.timeRange,
+  }));
+};
+
+export const finalizeTranscriptSegment = (
+  current: TranscriptSegment,
+  override: { text?: string; timeRange?: TimestampRange },
+): Result<TranscriptSegment, DomainError> => {
+  if (current.isFinal) {
+    return err(
+      invariantViolationError({
+        invariant: 'single-finalization',
+        details: `segment ${current.segmentIdentifier} is already finalized`,
+      }),
+    );
+  }
+  const text = override.text ?? current.text;
+  return validateText(text).map(() => ({
+    ...current,
+    isFinal: true,
+    text,
+    timeRange: override.timeRange ?? current.timeRange,
+  }));
+};

--- a/packages/extension/src/domain/transcript/transcript-stream.test.ts
+++ b/packages/extension/src/domain/transcript/transcript-stream.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendPartialTranscriptSegment,
+  attachTranslationToSegment,
+  createTranscriptStream,
+  finalizeSegment,
+  getSegment,
+  getTranslation,
+} from './transcript-stream.js';
+import { createTimestampRange } from './timestamp-range.js';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
+const SEGMENT_A = '01HZX8Y2R8M7D3Q2P4T5V6W7X1';
+const SEGMENT_B = '01HZX8Y2R8M7D3Q2P4T5V6W7X2';
+const TRANSLATION_A = '01HZX8Y3R8M7D3Q2P4T5V6W7X1';
+
+const timeRange = createTimestampRange({ startMs: 0, endMs: 500 })._unsafeUnwrap();
+
+const newStream = () => createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+
+describe('TranscriptStream aggregate', () => {
+  describe('createTranscriptStream', () => {
+    it('creates an empty stream bound to a session', () => {
+      const result = createTranscriptStream({ sessionIdentifier: SESSION_ID });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.sessionIdentifier).toBe(SESSION_ID);
+      }
+    });
+
+    it('rejects invalid sessionIdentifier', () => {
+      expect(createTranscriptStream({ sessionIdentifier: 'bad' }).isErr()).toBe(true);
+    });
+  });
+
+  describe('appendPartialTranscriptSegment', () => {
+    it('adds a new partial segment', () => {
+      const result = appendPartialTranscriptSegment(newStream(), {
+        segmentIdentifier: SEGMENT_A,
+        revision: 1,
+        text: 'he',
+        timeRange,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(getSegment(result.value, SEGMENT_A)).toBeDefined();
+      }
+    });
+
+    it('updates an existing partial segment with a higher revision', () => {
+      let stream = newStream();
+      stream = appendPartialTranscriptSegment(stream, {
+        segmentIdentifier: SEGMENT_A,
+        revision: 1,
+        text: 'he',
+        timeRange,
+      })._unsafeUnwrap();
+      const result = appendPartialTranscriptSegment(stream, {
+        segmentIdentifier: SEGMENT_A,
+        revision: 2,
+        text: 'hello',
+        timeRange,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const seg = getSegment(result.value, SEGMENT_A);
+        expect(seg?.revision).toBe(2);
+        expect(seg?.text).toBe('hello');
+      }
+    });
+
+    it('rejects update with same or smaller revision', () => {
+      let stream = newStream();
+      stream = appendPartialTranscriptSegment(stream, {
+        segmentIdentifier: SEGMENT_A,
+        revision: 3,
+        text: 'hello',
+        timeRange,
+      })._unsafeUnwrap();
+      expect(
+        appendPartialTranscriptSegment(stream, {
+          segmentIdentifier: SEGMENT_A,
+          revision: 3,
+          text: 'x',
+          timeRange,
+        }).isErr(),
+      ).toBe(true);
+    });
+
+    it('rejects partial append on already-finalized segment', () => {
+      let stream = newStream();
+      stream = appendPartialTranscriptSegment(stream, {
+        segmentIdentifier: SEGMENT_A,
+        revision: 1,
+        text: 'hello',
+        timeRange,
+      })._unsafeUnwrap();
+      stream = finalizeSegment(stream, { segmentIdentifier: SEGMENT_A })._unsafeUnwrap();
+      const result = appendPartialTranscriptSegment(stream, {
+        segmentIdentifier: SEGMENT_A,
+        revision: 2,
+        text: 'hello',
+        timeRange,
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('finalizeSegment', () => {
+    it('finalizes an existing partial segment', () => {
+      let stream = newStream();
+      stream = appendPartialTranscriptSegment(stream, {
+        segmentIdentifier: SEGMENT_A,
+        revision: 2,
+        text: 'hello',
+        timeRange,
+      })._unsafeUnwrap();
+      const result = finalizeSegment(stream, { segmentIdentifier: SEGMENT_A });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(getSegment(result.value, SEGMENT_A)?.isFinal).toBe(true);
+      }
+    });
+
+    it('allows overriding text/timeRange at finalize', () => {
+      let stream = newStream();
+      stream = appendPartialTranscriptSegment(stream, {
+        segmentIdentifier: SEGMENT_A,
+        revision: 1,
+        text: 'he',
+        timeRange,
+      })._unsafeUnwrap();
+      const result = finalizeSegment(stream, {
+        segmentIdentifier: SEGMENT_A,
+        text: 'hello world',
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(getSegment(result.value, SEGMENT_A)?.text).toBe('hello world');
+      }
+    });
+
+    it('creates the segment directly when finalize is called without prior partial', () => {
+      const result = finalizeSegment(newStream(), {
+        segmentIdentifier: SEGMENT_B,
+        text: 'direct final',
+        timeRange,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(getSegment(result.value, SEGMENT_B)?.isFinal).toBe(true);
+      }
+    });
+
+    it('rejects finalize for an already-final segment (DD-211 invariant)', () => {
+      let stream = newStream();
+      stream = appendPartialTranscriptSegment(stream, {
+        segmentIdentifier: SEGMENT_A,
+        revision: 1,
+        text: 'hello',
+        timeRange,
+      })._unsafeUnwrap();
+      stream = finalizeSegment(stream, { segmentIdentifier: SEGMENT_A })._unsafeUnwrap();
+      const result = finalizeSegment(stream, { segmentIdentifier: SEGMENT_A });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    });
+
+    it('rejects finalize without text when no partial exists', () => {
+      const result = finalizeSegment(newStream(), { segmentIdentifier: SEGMENT_B });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('attachTranslationToSegment', () => {
+    it('attaches a translation to a finalized segment', () => {
+      let stream = newStream();
+      stream = appendPartialTranscriptSegment(stream, {
+        segmentIdentifier: SEGMENT_A,
+        revision: 1,
+        text: 'hello',
+        timeRange,
+      })._unsafeUnwrap();
+      stream = finalizeSegment(stream, { segmentIdentifier: SEGMENT_A })._unsafeUnwrap();
+      const result = attachTranslationToSegment(stream, {
+        translationIdentifier: TRANSLATION_A,
+        segmentIdentifier: SEGMENT_A,
+        targetLanguage: 'ja-JP',
+        text: 'こんにちは',
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const translation = getTranslation(result.value, SEGMENT_A);
+        expect(translation?.status).toBe('completed');
+      }
+    });
+
+    it('rejects attachment to a non-final segment (DD-211 / DD-271)', () => {
+      let stream = newStream();
+      stream = appendPartialTranscriptSegment(stream, {
+        segmentIdentifier: SEGMENT_A,
+        revision: 1,
+        text: 'hello',
+        timeRange,
+      })._unsafeUnwrap();
+      const result = attachTranslationToSegment(stream, {
+        translationIdentifier: TRANSLATION_A,
+        segmentIdentifier: SEGMENT_A,
+        targetLanguage: 'ja-JP',
+        text: 'こんにちは',
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    });
+
+    it('rejects attachment to a missing segment', () => {
+      const result = attachTranslationToSegment(newStream(), {
+        translationIdentifier: TRANSLATION_A,
+        segmentIdentifier: SEGMENT_A,
+        targetLanguage: 'ja-JP',
+        text: 'x',
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('not-found');
+    });
+
+    it('overwrites an existing translation (latest wins)', () => {
+      let stream = newStream();
+      stream = appendPartialTranscriptSegment(stream, {
+        segmentIdentifier: SEGMENT_A,
+        revision: 1,
+        text: 'hello',
+        timeRange,
+      })._unsafeUnwrap();
+      stream = finalizeSegment(stream, { segmentIdentifier: SEGMENT_A })._unsafeUnwrap();
+      stream = attachTranslationToSegment(stream, {
+        translationIdentifier: TRANSLATION_A,
+        segmentIdentifier: SEGMENT_A,
+        targetLanguage: 'ja-JP',
+        text: '初回',
+      })._unsafeUnwrap();
+      const result = attachTranslationToSegment(stream, {
+        translationIdentifier: TRANSLATION_A,
+        segmentIdentifier: SEGMENT_A,
+        targetLanguage: 'ja-JP',
+        text: '修正済',
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const translation = getTranslation(result.value, SEGMENT_A);
+        expect(translation?.status === 'completed' && translation.text).toBe('修正済');
+      }
+    });
+  });
+});

--- a/packages/extension/src/domain/transcript/transcript-stream.ts
+++ b/packages/extension/src/domain/transcript/transcript-stream.ts
@@ -1,0 +1,155 @@
+import { err, type Result } from 'neverthrow';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
+import { type DomainError, invariantViolationError, notFoundError } from '../shared/errors.js';
+import { parseSegmentIdentifier } from './segment-identifier.js';
+import type { TimestampRange } from './timestamp-range.js';
+import {
+  createPartialTranscriptSegment,
+  finalizeTranscriptSegment,
+  updatePartialTranscriptSegment,
+  type TranscriptSegment,
+} from './transcript-segment.js';
+import {
+  createCompletedTranslationSegment,
+  type TranslationSegment,
+} from './translation-segment.js';
+
+/**
+ * 字幕ストリーム集約ルート (DD-211)。
+ * 1 セッションに対して 1 本の字幕ストリームを束ね、segmentIdentifier ごとに
+ * `TranscriptSegment` と 0/1 の `TranslationSegment` を保持する。
+ *
+ * 不変条件:
+ * - 同一 `segmentIdentifier` の確定字幕は 1 回のみ (再 finalize 禁止)
+ * - `TranslationSegment` は確定済み字幕にのみ紐づく (DD-271)
+ * - 部分字幕 `revision` は同一 segment 内で単調増加
+ *
+ * データ構造は `Map<string, TranscriptSegment>` / `Map<string, TranslationSegment>`
+ * を Readonly でラップする (ドメイン層での immutability)。
+ */
+export type TranscriptStream = Readonly<{
+  sessionIdentifier: SessionIdentifier;
+  segments: ReadonlyMap<string, TranscriptSegment>;
+  translations: ReadonlyMap<string, TranslationSegment>;
+}>;
+
+export const createTranscriptStream = (params: {
+  sessionIdentifier: string;
+}): Result<TranscriptStream, DomainError> =>
+  parseSessionIdentifier(params.sessionIdentifier).map((sessionIdentifier) => ({
+    sessionIdentifier,
+    segments: new Map(),
+    translations: new Map(),
+  }));
+
+const withSegment = (stream: TranscriptStream, segment: TranscriptSegment): TranscriptStream => {
+  const nextSegments = new Map(stream.segments);
+  nextSegments.set(segment.segmentIdentifier, segment);
+  return { ...stream, segments: nextSegments };
+};
+
+const withTranslation = (
+  stream: TranscriptStream,
+  translation: TranslationSegment,
+): TranscriptStream => {
+  const nextTranslations = new Map(stream.translations);
+  nextTranslations.set(translation.segmentIdentifier, translation);
+  return { ...stream, translations: nextTranslations };
+};
+
+export const getSegment = (
+  stream: TranscriptStream,
+  segmentIdentifier: string,
+): TranscriptSegment | undefined => stream.segments.get(segmentIdentifier);
+
+export const getTranslation = (
+  stream: TranscriptStream,
+  segmentIdentifier: string,
+): TranslationSegment | undefined => stream.translations.get(segmentIdentifier);
+
+export const appendPartialTranscriptSegment = (
+  stream: TranscriptStream,
+  params: {
+    segmentIdentifier: string;
+    revision: number;
+    text: string;
+    timeRange: TimestampRange;
+  },
+): Result<TranscriptStream, DomainError> => {
+  const existing = stream.segments.get(params.segmentIdentifier);
+  if (existing === undefined) {
+    return createPartialTranscriptSegment(params).map((segment) => withSegment(stream, segment));
+  }
+  return updatePartialTranscriptSegment(existing, {
+    revision: params.revision,
+    text: params.text,
+    timeRange: params.timeRange,
+  }).map((segment) => withSegment(stream, segment));
+};
+
+export const finalizeSegment = (
+  stream: TranscriptStream,
+  params: { segmentIdentifier: string; text?: string; timeRange?: TimestampRange },
+): Result<TranscriptStream, DomainError> => {
+  const override: { text?: string; timeRange?: TimestampRange } = {};
+  if (params.text !== undefined) override.text = params.text;
+  if (params.timeRange !== undefined) override.timeRange = params.timeRange;
+
+  const existing = stream.segments.get(params.segmentIdentifier);
+  if (existing === undefined) {
+    if (params.text === undefined || params.timeRange === undefined) {
+      return err(
+        invariantViolationError({
+          invariant: 'finalize-without-partial-requires-full-payload',
+          details: `segment ${params.segmentIdentifier} has no prior partial; text and timeRange are required`,
+        }),
+      );
+    }
+    return createPartialTranscriptSegment({
+      segmentIdentifier: params.segmentIdentifier,
+      revision: 1,
+      text: params.text,
+      timeRange: params.timeRange,
+    })
+      .andThen((partial) => finalizeTranscriptSegment(partial, override))
+      .map((final) => withSegment(stream, final));
+  }
+  return finalizeTranscriptSegment(existing, override).map((segment) =>
+    withSegment(stream, segment),
+  );
+};
+
+export const attachTranslationToSegment = (
+  stream: TranscriptStream,
+  params: {
+    translationIdentifier: string;
+    segmentIdentifier: string;
+    targetLanguage: string;
+    text: string;
+  },
+): Result<TranscriptStream, DomainError> =>
+  parseSegmentIdentifier(params.segmentIdentifier).andThen((segmentIdentifier) => {
+    const segment = stream.segments.get(segmentIdentifier);
+    if (segment === undefined) {
+      return err(
+        notFoundError({
+          resourceType: 'TranscriptSegment',
+          identifier: segmentIdentifier,
+        }),
+      );
+    }
+    if (!segment.isFinal) {
+      return err(
+        invariantViolationError({
+          invariant: 'translation-requires-final-segment',
+          details: `segment ${segmentIdentifier} is not finalized`,
+        }),
+      );
+    }
+    return createCompletedTranslationSegment({
+      translationIdentifier: params.translationIdentifier,
+      segmentIdentifier,
+      targetLanguage: params.targetLanguage,
+      text: params.text,
+    }).map((translation) => withTranslation(stream, translation));
+  });

--- a/packages/extension/src/domain/transcript/translation-segment.test.ts
+++ b/packages/extension/src/domain/transcript/translation-segment.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createCompletedTranslationSegment,
+  createFailedTranslationSegment,
+} from './translation-segment.js';
+
+const VALID_ULID_A = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
+const VALID_ULID_B = '01HZX8Y1R8M7D3Q2P4T5V6W7X9';
+
+describe('TranslationSegment', () => {
+  describe('createCompletedTranslationSegment', () => {
+    it('creates a completed translation segment', () => {
+      const result = createCompletedTranslationSegment({
+        translationIdentifier: VALID_ULID_A,
+        segmentIdentifier: VALID_ULID_B,
+        targetLanguage: 'ja-JP',
+        text: 'こんにちは',
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.status).toBe('completed');
+        if (result.value.status === 'completed') {
+          expect(result.value.text).toBe('こんにちは');
+        }
+      }
+    });
+
+    it('rejects empty text', () => {
+      const result = createCompletedTranslationSegment({
+        translationIdentifier: VALID_ULID_A,
+        segmentIdentifier: VALID_ULID_B,
+        targetLanguage: 'ja-JP',
+        text: '',
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects invalid targetLanguage (BCP-47)', () => {
+      const result = createCompletedTranslationSegment({
+        translationIdentifier: VALID_ULID_A,
+        segmentIdentifier: VALID_ULID_B,
+        targetLanguage: 'NOT_A_LANG',
+        text: 'x',
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects invalid identifiers', () => {
+      expect(
+        createCompletedTranslationSegment({
+          translationIdentifier: 'not-ulid',
+          segmentIdentifier: VALID_ULID_B,
+          targetLanguage: 'ja-JP',
+          text: 'x',
+        }).isErr(),
+      ).toBe(true);
+      expect(
+        createCompletedTranslationSegment({
+          translationIdentifier: VALID_ULID_A,
+          segmentIdentifier: 'bad',
+          targetLanguage: 'ja-JP',
+          text: 'x',
+        }).isErr(),
+      ).toBe(true);
+    });
+  });
+
+  describe('createFailedTranslationSegment', () => {
+    it('creates a failed translation segment without text', () => {
+      const result = createFailedTranslationSegment({
+        translationIdentifier: VALID_ULID_A,
+        segmentIdentifier: VALID_ULID_B,
+        targetLanguage: 'ja-JP',
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.status).toBe('failed');
+      }
+    });
+  });
+});

--- a/packages/extension/src/domain/transcript/translation-segment.ts
+++ b/packages/extension/src/domain/transcript/translation-segment.ts
@@ -1,0 +1,88 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors.js';
+import { parseSegmentIdentifier, type SegmentIdentifier } from './segment-identifier.js';
+import {
+  parseTranslationIdentifier,
+  type TranslationIdentifier,
+} from './translation-identifier.js';
+
+/**
+ * 翻訳セグメントエンティティ (DD-222)。
+ *
+ * 確定字幕 (`TranscriptSegment.isFinal === true`) にのみ紐づく (DD-211 / DD-271)。
+ * status で discriminated union を構成し、`completed` は本文必須、`failed` は
+ * 本文を持たない (API-spec: 失敗は session.error で通知、text は空扱い)。
+ */
+export type TranslationSegment =
+  | Readonly<{
+      translationIdentifier: TranslationIdentifier;
+      segmentIdentifier: SegmentIdentifier;
+      targetLanguage: string;
+      status: 'completed';
+      text: string;
+    }>
+  | Readonly<{
+      translationIdentifier: TranslationIdentifier;
+      segmentIdentifier: SegmentIdentifier;
+      targetLanguage: string;
+      status: 'failed';
+    }>;
+
+const bcp47Schema = z.string().regex(/^[a-z]{2,3}(?:-[A-Z]{2})?$/);
+
+const validateTargetLanguage = (value: string): Result<string, DomainError> => {
+  const result = bcp47Schema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'TranslationSegment.targetLanguage',
+        message: 'must be a BCP-47 tag',
+      }),
+    );
+  }
+  return ok(result.data);
+};
+
+const validateText = (text: string): Result<string, DomainError> => {
+  if (text.length === 0) {
+    return err(validationError({ field: 'TranslationSegment.text', message: 'must not be empty' }));
+  }
+  return ok(text);
+};
+
+export const createCompletedTranslationSegment = (params: {
+  translationIdentifier: string;
+  segmentIdentifier: string;
+  targetLanguage: string;
+  text: string;
+}): Result<TranslationSegment, DomainError> =>
+  parseTranslationIdentifier(params.translationIdentifier).andThen((translationIdentifier) =>
+    parseSegmentIdentifier(params.segmentIdentifier).andThen((segmentIdentifier) =>
+      validateTargetLanguage(params.targetLanguage).andThen((targetLanguage) =>
+        validateText(params.text).map((text) => ({
+          translationIdentifier,
+          segmentIdentifier,
+          targetLanguage,
+          status: 'completed' as const,
+          text,
+        })),
+      ),
+    ),
+  );
+
+export const createFailedTranslationSegment = (params: {
+  translationIdentifier: string;
+  segmentIdentifier: string;
+  targetLanguage: string;
+}): Result<TranslationSegment, DomainError> =>
+  parseTranslationIdentifier(params.translationIdentifier).andThen((translationIdentifier) =>
+    parseSegmentIdentifier(params.segmentIdentifier).andThen((segmentIdentifier) =>
+      validateTargetLanguage(params.targetLanguage).map((targetLanguage) => ({
+        translationIdentifier,
+        segmentIdentifier,
+        targetLanguage,
+        status: 'failed' as const,
+      })),
+    ),
+  );


### PR DESCRIPTION
## 概要

Phase 1 §3.2 として集約ルート 3 種とエンティティ 3 種を TDD で実装。`Result<T, DomainError>` 返却・immutable record・boundary parse の設計原則を徹底 (CLAUDE.md §Phase 0 合意事項に準拠)。

## 実装内容

### エンティティ (3 種)

| IMPL | エンティティ | ファイル | 不変条件 |
|---|---|---|---|
| 112 | `TranscriptSegment` (DD-221) | `transcript/transcript-segment.ts` | revision 単調増加、isFinal は一方向、確定後更新不可 |
| 113 | `TranslationSegment` (DD-222) | `transcript/translation-segment.ts` | `completed` / `failed` の discriminated union |
| 115 | `ExportRecord` (DD-223) | `export/export-record.ts` | format=txt\|json、includeOriginal/includeTranslation 少なくとも一方 true |

### 集約ルート (3 種)

| IMPL | 集約 | 操作 | 主な不変条件 |
|---|---|---|---|
| 110 | `SourceSession` (DD-210) | create/start/transitionState/pause/resume/markDegraded/recoverTranslation/stop | 状態遷移テーブル準拠、degraded は翻訳障害時のみ、stopped は terminal、(session,source) ペア不変 |
| 111 | `TranscriptStream` (DD-211) | appendPartial/finalizeSegment/attachTranslation | segmentId 同一の確定字幕は 1 回のみ、翻訳は確定字幕のみに紐づく (DD-271)、revision 単調増加 |
| 114 | `ExtensionProfile` (DD-212) | updateDefaultLanguagePair/updateDefaultOverlaySettings/toggleAutoDetect | 値オブジェクトで事前バリデーション |

### 設計上の判断

- **状態遷移テーブル inline**: `SourceSession` の `ALLOWED_TRANSITIONS` は集約内に定義。IMPL-121 `SessionStateTransitionPolicy` 実装時にドメインサービスへ抽出予定
- **`stopped` の特別扱い**: `canTransition` で terminal 性と「任意稼働状態から stop 可能」を enforce (detailed-design.md §7.2)
- **Map immutability**: `TranscriptStream` は `ReadonlyMap` で segments/translations を保持。更新操作は新しい Map を生成
- **新規ディレクトリ**: `domain/export/` を作成 (DD-203 表示・エクスポートコンテキスト)
- **派生 Identifier**: `ProfileIdentifier` / `ExportIdentifier` を新規追加 (ULID brand)

### 動作確認

- [x] `pnpm --filter @perapera/extension test` → 132 tests pass (18 test files)
  - errors 10 / source-type 6 / session-state 14 / session-identifier 6 / source-identifier 4 / language-pair 6 / segment-identifier 3 / translation-identifier 3 / timestamp-range 5 / overlay-settings 8 / transcript-segment 9 / translation-segment 5 / export-identifier 3 / export-record 7 / source-session 21 / transcript-stream 15 / extension-profile 5 / smoke 2
- [x] `pnpm check` 全緑 (fmt / lint / typecheck / test)
- [x] `actrun workflow run .github/workflows/ci.yml` → `state=completed`

## Phase 1 進捗

- [x] §3.1 値オブジェクト (IMPL-101〜108)
- [x] §3.2 集約とエンティティ (IMPL-110〜115) ← 本 PR
- [ ] §3.3 ドメインサービス (IMPL-120〜123) ← 次
- [ ] §3.4 ドメインイベント (IMPL-130〜135)
- [ ] §3.5 リポジトリインターフェース (IMPL-140〜143)
- [ ] §3.6 仕様 / ポリシー (IMPL-150〜153)

## 関連設計

- `docs/in-progress/03-detailed-design/domain.md` §4 集約設計 / §5 エンティティ
- `docs/in-progress/03-detailed-design/detailed-design.md` §5.1 型定義 / §7 状態遷移