### PR TITLE
feat(domain): IMPL-120〜123 domain services

### DIFF
--- a/packages/extension/src/domain/services/export-assembly-service.test.ts
+++ b/packages/extension/src/domain/services/export-assembly-service.test.ts
@@ -1,0 +1,431 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendPartialTranscriptSegment,
+  attachTranslationToSegment,
+  createTranscriptStream,
+  finalizeSegment,
+  type TranscriptStream,
+} from '../transcript/transcript-stream.js';
+import {
+  createFailedTranslationSegment,
+  type TranslationSegment,
+} from '../transcript/translation-segment.js';
+import { createTimestampRange, type TimestampRange } from '../transcript/timestamp-range.js';
+import { assembleExport } from './export-assembly-service.js';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
+const SEGMENT_IDS = [
+  '01HZX8Y1R8M7D3Q2P4T5V6W7D1',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7D2',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7D3',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7D4',
+] as const;
+const TRANSLATION_IDS = [
+  '01HZX8Y1R8M7D3Q2P4T5V6W7E1',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7E2',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7E3',
+] as const;
+
+const range = (startMs: number, endMs: number): TimestampRange =>
+  createTimestampRange({ startMs, endMs })._unsafeUnwrap();
+
+const emptyStream = (): TranscriptStream =>
+  createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+
+type SegmentSpec = {
+  segmentIdentifier: string;
+  startMs: number;
+  endMs: number;
+  text: string;
+  isFinal?: boolean;
+  translation?: { translationIdentifier: string; targetLanguage: string; text: string } | 'failed';
+};
+
+const buildStream = (specs: readonly SegmentSpec[]): TranscriptStream => {
+  let stream = emptyStream();
+  for (const spec of specs) {
+    const isFinal = spec.isFinal ?? true;
+    stream = appendPartialTranscriptSegment(stream, {
+      segmentIdentifier: spec.segmentIdentifier,
+      revision: 1,
+      text: spec.text,
+      timeRange: range(spec.startMs, spec.endMs),
+    })._unsafeUnwrap();
+    if (isFinal) {
+      stream = finalizeSegment(stream, {
+        segmentIdentifier: spec.segmentIdentifier,
+      })._unsafeUnwrap();
+      if (spec.translation !== undefined) {
+        if (spec.translation === 'failed') {
+          const failed: TranslationSegment = createFailedTranslationSegment({
+            translationIdentifier: TRANSLATION_IDS[0],
+            segmentIdentifier: spec.segmentIdentifier,
+            targetLanguage: 'ja-JP',
+          })._unsafeUnwrap();
+          const merged = new Map(stream.translations);
+          merged.set(failed.segmentIdentifier, failed);
+          stream = { ...stream, translations: merged };
+        } else {
+          stream = attachTranslationToSegment(stream, {
+            translationIdentifier: spec.translation.translationIdentifier,
+            segmentIdentifier: spec.segmentIdentifier,
+            targetLanguage: spec.translation.targetLanguage,
+            text: spec.translation.text,
+          })._unsafeUnwrap();
+        }
+      }
+    }
+  }
+  return stream;
+};
+
+describe('ExportAssemblyService (DD-242)', () => {
+  describe('guard clauses', () => {
+    it('returns validation error when both includeOriginal and includeTranslation are false', () => {
+      const result = assembleExport(emptyStream(), {
+        format: 'txt',
+        includeOriginal: false,
+        includeTranslation: false,
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('validation');
+    });
+  });
+
+  describe('TXT format', () => {
+    it('returns empty string for an empty stream', () => {
+      const result = assembleExport(emptyStream(), {
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: true,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toBe('');
+    });
+
+    it('formats a single final segment with original only', () => {
+      const stream = buildStream([
+        { segmentIdentifier: SEGMENT_IDS[0], startMs: 0, endMs: 1500, text: 'hello' },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: false,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toBe('[00:00.000] hello');
+    });
+
+    it('formats original + completed translation in two lines', () => {
+      const stream = buildStream([
+        {
+          segmentIdentifier: SEGMENT_IDS[0],
+          startMs: 0,
+          endMs: 1500,
+          text: 'hello',
+          translation: {
+            translationIdentifier: TRANSLATION_IDS[0],
+            targetLanguage: 'ja-JP',
+            text: 'こんにちは',
+          },
+        },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: true,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe('[00:00.000] hello\n→ [ja-JP] こんにちは');
+      }
+    });
+
+    it('formats translation only when includeOriginal is false', () => {
+      const stream = buildStream([
+        {
+          segmentIdentifier: SEGMENT_IDS[0],
+          startMs: 500,
+          endMs: 2000,
+          text: 'hello',
+          translation: {
+            translationIdentifier: TRANSLATION_IDS[0],
+            targetLanguage: 'ja-JP',
+            text: 'こんにちは',
+          },
+        },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'txt',
+        includeOriginal: false,
+        includeTranslation: true,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toBe('→ [ja-JP] こんにちは');
+    });
+
+    it('sorts segments by startMs ascending', () => {
+      const stream = buildStream([
+        { segmentIdentifier: SEGMENT_IDS[0], startMs: 5000, endMs: 6000, text: 'third' },
+        { segmentIdentifier: SEGMENT_IDS[1], startMs: 500, endMs: 1500, text: 'second' },
+        { segmentIdentifier: SEGMENT_IDS[2], startMs: 0, endMs: 400, text: 'first' },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: false,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe('[00:00.000] first\n[00:00.500] second\n[00:05.000] third');
+      }
+    });
+
+    it('excludes non-finalized (partial) segments', () => {
+      const stream = buildStream([
+        { segmentIdentifier: SEGMENT_IDS[0], startMs: 0, endMs: 1000, text: 'final one' },
+        {
+          segmentIdentifier: SEGMENT_IDS[1],
+          startMs: 1200,
+          endMs: 2000,
+          text: 'partial one',
+          isFinal: false,
+        },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: false,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toBe('[00:00.000] final one');
+    });
+
+    it('excludes failed translations but keeps the original line', () => {
+      const stream = buildStream([
+        {
+          segmentIdentifier: SEGMENT_IDS[0],
+          startMs: 0,
+          endMs: 1000,
+          text: 'hello',
+          translation: 'failed',
+        },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: true,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toBe('[00:00.000] hello');
+    });
+
+    it('skips segments with only failed translation when includeOriginal is false', () => {
+      const stream = buildStream([
+        {
+          segmentIdentifier: SEGMENT_IDS[0],
+          startMs: 0,
+          endMs: 1000,
+          text: 'hello',
+          translation: 'failed',
+        },
+        {
+          segmentIdentifier: SEGMENT_IDS[1],
+          startMs: 2000,
+          endMs: 3000,
+          text: 'world',
+          translation: {
+            translationIdentifier: TRANSLATION_IDS[0],
+            targetLanguage: 'ja-JP',
+            text: 'せかい',
+          },
+        },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'txt',
+        includeOriginal: false,
+        includeTranslation: true,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toBe('→ [ja-JP] せかい');
+    });
+
+    it.each([
+      [0, '00:00.000'],
+      [59999, '00:59.999'],
+      [60000, '01:00.000'],
+      [3600000, '60:00.000'],
+    ])('formats timestamp prefix for startMs=%i as [%s]', (startMs, formatted) => {
+      const stream = buildStream([
+        { segmentIdentifier: SEGMENT_IDS[0], startMs, endMs: startMs + 1000, text: 't' },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: false,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toBe(`[${formatted}] t`);
+    });
+  });
+
+  describe('JSON format', () => {
+    it('returns a well-formed JSON with empty segments for an empty stream', () => {
+      const result = assembleExport(emptyStream(), {
+        format: 'json',
+        includeOriginal: true,
+        includeTranslation: true,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe(`{"sessionIdentifier":"${SESSION_ID}","segments":[]}`);
+      }
+    });
+
+    it('includes text and translation fields when both flags are true', () => {
+      const stream = buildStream([
+        {
+          segmentIdentifier: SEGMENT_IDS[0],
+          startMs: 0,
+          endMs: 1500,
+          text: 'hello',
+          translation: {
+            translationIdentifier: TRANSLATION_IDS[0],
+            targetLanguage: 'ja-JP',
+            text: 'こんにちは',
+          },
+        },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'json',
+        includeOriginal: true,
+        includeTranslation: true,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const expected = `{"sessionIdentifier":"${SESSION_ID}","segments":[{"segmentIdentifier":"${SEGMENT_IDS[0]}","startMs":0,"endMs":1500,"text":"hello","translation":{"targetLanguage":"ja-JP","text":"こんにちは"}}]}`;
+        expect(result.value).toBe(expected);
+      }
+    });
+
+    it('omits text field when includeOriginal is false', () => {
+      const stream = buildStream([
+        {
+          segmentIdentifier: SEGMENT_IDS[0],
+          startMs: 0,
+          endMs: 1500,
+          text: 'hello',
+          translation: {
+            translationIdentifier: TRANSLATION_IDS[0],
+            targetLanguage: 'ja-JP',
+            text: 'こんにちは',
+          },
+        },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'json',
+        includeOriginal: false,
+        includeTranslation: true,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).not.toMatch(/"text":"hello"/);
+        expect(result.value).toMatch(
+          /"translation":\{"targetLanguage":"ja-JP","text":"こんにちは"\}/,
+        );
+      }
+    });
+
+    it('omits translation field when includeTranslation is false', () => {
+      const stream = buildStream([
+        {
+          segmentIdentifier: SEGMENT_IDS[0],
+          startMs: 0,
+          endMs: 1500,
+          text: 'hello',
+          translation: {
+            translationIdentifier: TRANSLATION_IDS[0],
+            targetLanguage: 'ja-JP',
+            text: 'こんにちは',
+          },
+        },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'json',
+        includeOriginal: true,
+        includeTranslation: false,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).not.toMatch(/"translation"/);
+        expect(result.value).toMatch(/"text":"hello"/);
+      }
+    });
+
+    it('omits translation field when translation status is failed', () => {
+      const stream = buildStream([
+        {
+          segmentIdentifier: SEGMENT_IDS[0],
+          startMs: 0,
+          endMs: 1500,
+          text: 'hello',
+          translation: 'failed',
+        },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'json',
+        includeOriginal: true,
+        includeTranslation: true,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).not.toMatch(/"translation"/);
+      }
+    });
+
+    it('sorts segments by startMs ascending in JSON output', () => {
+      const stream = buildStream([
+        { segmentIdentifier: SEGMENT_IDS[0], startMs: 5000, endMs: 6000, text: 'c' },
+        { segmentIdentifier: SEGMENT_IDS[1], startMs: 500, endMs: 1500, text: 'b' },
+        { segmentIdentifier: SEGMENT_IDS[2], startMs: 0, endMs: 400, text: 'a' },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'json',
+        includeOriginal: true,
+        includeTranslation: false,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const idxA = result.value.indexOf('"text":"a"');
+        const idxB = result.value.indexOf('"text":"b"');
+        const idxC = result.value.indexOf('"text":"c"');
+        expect(idxA).toBeGreaterThan(-1);
+        expect(idxA).toBeLessThan(idxB);
+        expect(idxB).toBeLessThan(idxC);
+      }
+    });
+
+    it('excludes partial (non-finalized) segments from JSON output', () => {
+      const stream = buildStream([
+        { segmentIdentifier: SEGMENT_IDS[0], startMs: 0, endMs: 1000, text: 'final' },
+        {
+          segmentIdentifier: SEGMENT_IDS[1],
+          startMs: 1200,
+          endMs: 2000,
+          text: 'partial',
+          isFinal: false,
+        },
+      ]);
+      const result = assembleExport(stream, {
+        format: 'json',
+        includeOriginal: true,
+        includeTranslation: false,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toMatch(/"text":"final"/);
+        expect(result.value).not.toMatch(/"text":"partial"/);
+      }
+    });
+  });
+});

--- a/packages/extension/src/domain/services/export-assembly-service.ts
+++ b/packages/extension/src/domain/services/export-assembly-service.ts
@@ -1,0 +1,114 @@
+import { err, ok, type Result } from 'neverthrow';
+import { type ExportFormat } from '../export/export-record.js';
+import { type TranscriptSegment } from '../transcript/transcript-segment.js';
+import { type TranscriptStream } from '../transcript/transcript-stream.js';
+import { type TranslationSegment } from '../transcript/translation-segment.js';
+import { type DomainError, validationError } from '../shared/errors.js';
+
+/**
+ * エクスポート整形サービス (DD-242)。
+ *
+ * `TranscriptStream` と出力オプションを受け、TXT / JSON 文字列を返す。
+ * 確定字幕 (`TranscriptSegment.isFinal === true`) のみを対象とし、`startMs`
+ * 昇順にソートする。failed の翻訳は本文を持たないため翻訳出力から除外する。
+ */
+export type ExportAssemblyOptions = Readonly<{
+  format: ExportFormat;
+  includeOriginal: boolean;
+  includeTranslation: boolean;
+}>;
+
+type CompletedTranslation = Readonly<{ targetLanguage: string; text: string }>;
+
+type Row = Readonly<{
+  segment: TranscriptSegment;
+  translation: CompletedTranslation | null;
+}>;
+
+const formatTimestampPrefix = (ms: number): string => {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  const millis = ms % 1000;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}.${String(millis).padStart(3, '0')}`;
+};
+
+const pickCompletedTranslation = (
+  translation: TranslationSegment | undefined,
+): CompletedTranslation | null => {
+  if (translation === undefined) return null;
+  if (translation.status !== 'completed') return null;
+  return { targetLanguage: translation.targetLanguage, text: translation.text };
+};
+
+const collectRows = (stream: TranscriptStream, options: ExportAssemblyOptions): Row[] => {
+  const finals: TranscriptSegment[] = [];
+  for (const segment of stream.segments.values()) {
+    if (segment.isFinal) finals.push(segment);
+  }
+  finals.sort((a, b) => a.timeRange.startMs - b.timeRange.startMs);
+  return finals.map((segment) => ({
+    segment,
+    translation: options.includeTranslation
+      ? pickCompletedTranslation(stream.translations.get(segment.segmentIdentifier))
+      : null,
+  }));
+};
+
+const formatTxt = (rows: readonly Row[], options: ExportAssemblyOptions): string => {
+  const lines: string[] = [];
+  for (const row of rows) {
+    if (options.includeOriginal) {
+      lines.push(`[${formatTimestampPrefix(row.segment.timeRange.startMs)}] ${row.segment.text}`);
+    }
+    if (row.translation !== null) {
+      lines.push(`→ [${row.translation.targetLanguage}] ${row.translation.text}`);
+    }
+  }
+  return lines.join('\n');
+};
+
+type JsonSegmentEntry = {
+  segmentIdentifier: string;
+  startMs: number;
+  endMs: number;
+  text?: string;
+  translation?: CompletedTranslation;
+};
+
+const formatJson = (
+  rows: readonly Row[],
+  stream: TranscriptStream,
+  options: ExportAssemblyOptions,
+): string => {
+  const segments: JsonSegmentEntry[] = rows.map((row) => {
+    const entry: JsonSegmentEntry = {
+      segmentIdentifier: row.segment.segmentIdentifier,
+      startMs: row.segment.timeRange.startMs,
+      endMs: row.segment.timeRange.endMs,
+    };
+    if (options.includeOriginal) entry.text = row.segment.text;
+    if (row.translation !== null) entry.translation = row.translation;
+    return entry;
+  });
+  return JSON.stringify({ sessionIdentifier: stream.sessionIdentifier, segments });
+};
+
+export const assembleExport = (
+  stream: TranscriptStream,
+  options: ExportAssemblyOptions,
+): Result<string, DomainError> => {
+  if (!options.includeOriginal && !options.includeTranslation) {
+    return err(
+      validationError({
+        field: 'ExportAssemblyOptions',
+        message: 'at least one of includeOriginal / includeTranslation must be true',
+      }),
+    );
+  }
+  const rows = collectRows(stream, options);
+  if (options.format === 'txt') {
+    return ok(formatTxt(rows, options));
+  }
+  return ok(formatJson(rows, stream, options));
+};

--- a/packages/extension/src/domain/services/language-routing-policy.test.ts
+++ b/packages/extension/src/domain/services/language-routing-policy.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { createExtensionProfile, type ExtensionProfile } from '../profile/extension-profile.js';
+import { createOverlaySettings } from '../profile/overlay-settings.js';
+import { createLanguagePair, type LanguagePair } from '../session/language-pair.js';
+import { resolveEffectiveLanguagePair } from './language-routing-policy.js';
+
+const PROFILE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
+
+const overlay = createOverlaySettings({
+  positionPreset: 'bottom',
+  opacity: 0.8,
+  maxLines: 2,
+  fontScale: 1,
+  showOriginalText: true,
+  showTranslatedText: true,
+})._unsafeUnwrap();
+
+const defaultPair = (source: string, target: string): LanguagePair =>
+  createLanguagePair({ source, target })._unsafeUnwrap();
+
+const makeProfile = (params: {
+  defaultPair: LanguagePair;
+  autoDetectEnabled: boolean;
+}): ExtensionProfile =>
+  createExtensionProfile({
+    profileIdentifier: PROFILE_ID,
+    defaultLanguagePair: params.defaultPair,
+    defaultOverlaySettings: overlay,
+    autoDetectEnabled: params.autoDetectEnabled,
+  })._unsafeUnwrap();
+
+describe('LanguageRoutingPolicy (DD-243)', () => {
+  describe('override is the highest priority', () => {
+    it('returns override even when autoDetect is enabled and detectedSource is provided', () => {
+      const profile = makeProfile({
+        defaultPair: defaultPair('en-US', 'ja-JP'),
+        autoDetectEnabled: true,
+      });
+      const override = defaultPair('fr-FR', 'de-DE');
+      const result = resolveEffectiveLanguagePair({
+        profile,
+        override,
+        detectedSource: 'es-ES',
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toEqual(override);
+    });
+
+    it('returns override when autoDetect is enabled but detectedSource is absent', () => {
+      const profile = makeProfile({
+        defaultPair: defaultPair('en-US', 'ja-JP'),
+        autoDetectEnabled: true,
+      });
+      const override = defaultPair('fr-FR', 'de-DE');
+      const result = resolveEffectiveLanguagePair({ profile, override });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toEqual(override);
+    });
+
+    it('returns override when autoDetect is disabled', () => {
+      const profile = makeProfile({
+        defaultPair: defaultPair('en-US', 'ja-JP'),
+        autoDetectEnabled: false,
+      });
+      const override = defaultPair('fr-FR', 'de-DE');
+      const result = resolveEffectiveLanguagePair({ profile, override });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toEqual(override);
+    });
+  });
+
+  describe('auto-detect mode', () => {
+    it('swaps source to detectedSource while keeping profile default target', () => {
+      const profile = makeProfile({
+        defaultPair: defaultPair('en-US', 'ja-JP'),
+        autoDetectEnabled: true,
+      });
+      const result = resolveEffectiveLanguagePair({
+        profile,
+        detectedSource: 'fr-FR',
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.source).toBe('fr-FR');
+        expect(result.value.target).toBe('ja-JP');
+      }
+    });
+
+    it('returns validation error when detectedSource is not a BCP-47 tag', () => {
+      const profile = makeProfile({
+        defaultPair: defaultPair('en-US', 'ja-JP'),
+        autoDetectEnabled: true,
+      });
+      const result = resolveEffectiveLanguagePair({
+        profile,
+        detectedSource: 'NOT_A_TAG',
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('validation');
+    });
+
+    it('returns validation error when detectedSource equals the profile target (same language pair forbidden)', () => {
+      const profile = makeProfile({
+        defaultPair: defaultPair('en-US', 'ja-JP'),
+        autoDetectEnabled: true,
+      });
+      const result = resolveEffectiveLanguagePair({
+        profile,
+        detectedSource: 'ja-JP',
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('validation');
+    });
+
+    it('accepts a detected variant that differs from target (en-GB vs en-US is distinct)', () => {
+      const profile = makeProfile({
+        defaultPair: defaultPair('fr-FR', 'en-US'),
+        autoDetectEnabled: true,
+      });
+      const result = resolveEffectiveLanguagePair({
+        profile,
+        detectedSource: 'en-GB',
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.source).toBe('en-GB');
+        expect(result.value.target).toBe('en-US');
+      }
+    });
+  });
+
+  describe('fallback to profile default', () => {
+    it('returns profile default when autoDetect is enabled but detectedSource is absent', () => {
+      const profile = makeProfile({
+        defaultPair: defaultPair('en-US', 'ja-JP'),
+        autoDetectEnabled: true,
+      });
+      const result = resolveEffectiveLanguagePair({ profile });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toEqual(profile.defaultLanguagePair);
+    });
+
+    it('returns profile default when autoDetect is disabled (detectedSource ignored)', () => {
+      const profile = makeProfile({
+        defaultPair: defaultPair('en-US', 'ja-JP'),
+        autoDetectEnabled: false,
+      });
+      const result = resolveEffectiveLanguagePair({
+        profile,
+        detectedSource: 'fr-FR',
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toEqual(profile.defaultLanguagePair);
+    });
+  });
+});

--- a/packages/extension/src/domain/services/language-routing-policy.ts
+++ b/packages/extension/src/domain/services/language-routing-policy.ts
@@ -1,0 +1,37 @@
+import { ok, type Result } from 'neverthrow';
+import { type ExtensionProfile } from '../profile/extension-profile.js';
+import { createLanguagePair, type LanguagePair } from '../session/language-pair.js';
+import { type DomainError } from '../shared/errors.js';
+
+/**
+ * 言語ルーティングポリシー (DD-243)。
+ *
+ * 自動判定有無と既定設定から、ソースセッションで使う有効な `LanguagePair` を
+ * 決定する。優先度:
+ *
+ * 1. `override` が提供されていればそれを返す (セッション固有の明示指定)
+ * 2. `profile.autoDetectEnabled === true` かつ `detectedSource` 提供時は
+ *    `{ source: detectedSource, target: profile.defaultLanguagePair.target }`
+ *    を新規 `LanguagePair` として生成 (BCP-47 + 同言語禁止の検証は VO に委譲)
+ * 3. 上記に該当しなければ `profile.defaultLanguagePair` を返す
+ */
+export type LanguageRoutingInput = Readonly<{
+  profile: ExtensionProfile;
+  override?: LanguagePair;
+  detectedSource?: string;
+}>;
+
+export const resolveEffectiveLanguagePair = (
+  input: LanguageRoutingInput,
+): Result<LanguagePair, DomainError> => {
+  if (input.override !== undefined) {
+    return ok(input.override);
+  }
+  if (input.profile.autoDetectEnabled && input.detectedSource !== undefined) {
+    return createLanguagePair({
+      source: input.detectedSource,
+      target: input.profile.defaultLanguagePair.target,
+    });
+  }
+  return ok(input.profile.defaultLanguagePair);
+};

--- a/packages/extension/src/domain/services/session-concurrency-policy.test.ts
+++ b/packages/extension/src/domain/services/session-concurrency-policy.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+import { createLanguagePair } from '../session/language-pair.js';
+import {
+  createSourceSession,
+  markSourceSessionDegraded,
+  pauseSourceSession,
+  startSourceSession,
+  stopSourceSession,
+  transitionSourceSessionState,
+  type SourceSession,
+} from '../session/source-session.js';
+import { SESSION_STATES, type SessionState } from '../session/session-state.js';
+import {
+  MAX_CONCURRENT_ACTIVE_SESSIONS,
+  countActiveSessions,
+  isActiveSession,
+  validateSessionConcurrency,
+} from './session-concurrency-policy.js';
+
+const SESSION_IDS = [
+  '01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7A3',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7A4',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7A5',
+] as const;
+
+const SOURCE_IDS = [
+  '01HZX8Y1R8M7D3Q2P4T5V6W7B1',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7B2',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7B3',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7B4',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7B5',
+] as const;
+
+const languagePair = createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap();
+const startedAt = '2026-04-21T00:00:00.000Z';
+const stoppedAt = '2026-04-21T00:05:00.000Z';
+
+const makeSession = (index: number): SourceSession =>
+  createSourceSession({
+    sessionIdentifier: SESSION_IDS[index]!,
+    sourceIdentifier: SOURCE_IDS[index]!,
+    sourceType: 'tab',
+    languagePair,
+    startedAt,
+  })._unsafeUnwrap();
+
+const withState = (index: number, targetState: SessionState): SourceSession => {
+  let session = makeSession(index);
+  switch (targetState) {
+    case 'idle':
+      return session;
+    case 'requesting_permission':
+      return startSourceSession(session)._unsafeUnwrap();
+    case 'connecting':
+      session = startSourceSession(session)._unsafeUnwrap();
+      return transitionSourceSessionState(session, 'connecting')._unsafeUnwrap();
+    case 'capturing':
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'connecting')._unsafeUnwrap();
+      return transitionSourceSessionState(session, 'capturing')._unsafeUnwrap();
+    case 'transcribing':
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'connecting')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'capturing')._unsafeUnwrap();
+      return transitionSourceSessionState(session, 'transcribing')._unsafeUnwrap();
+    case 'translating':
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'connecting')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'capturing')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'transcribing')._unsafeUnwrap();
+      return transitionSourceSessionState(session, 'translating')._unsafeUnwrap();
+    case 'paused':
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'connecting')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'capturing')._unsafeUnwrap();
+      return pauseSourceSession(session)._unsafeUnwrap();
+    case 'reconnecting':
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'connecting')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'capturing')._unsafeUnwrap();
+      return transitionSourceSessionState(session, 'reconnecting')._unsafeUnwrap();
+    case 'degraded':
+      session = startSourceSession(session)._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'connecting')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'capturing')._unsafeUnwrap();
+      session = transitionSourceSessionState(session, 'transcribing')._unsafeUnwrap();
+      return markSourceSessionDegraded(session, 'test-degraded')._unsafeUnwrap();
+    case 'error':
+      session = startSourceSession(session)._unsafeUnwrap();
+      return transitionSourceSessionState(session, 'error')._unsafeUnwrap();
+    case 'stopped':
+      session = startSourceSession(session)._unsafeUnwrap();
+      return stopSourceSession(session, { stoppedAt })._unsafeUnwrap();
+  }
+};
+
+describe('SessionConcurrencyPolicy (DD-240)', () => {
+  it('exposes MAX_CONCURRENT_ACTIVE_SESSIONS = 3 (DD-270)', () => {
+    expect(MAX_CONCURRENT_ACTIVE_SESSIONS).toBe(3);
+  });
+
+  describe('isActiveSession', () => {
+    const ACTIVE: readonly SessionState[] = [
+      'idle',
+      'requesting_permission',
+      'connecting',
+      'capturing',
+      'transcribing',
+      'translating',
+      'paused',
+      'reconnecting',
+      'degraded',
+      'error',
+    ];
+    const TERMINAL: readonly SessionState[] = ['stopped'];
+
+    it.each(ACTIVE)('treats %s as active', (state) => {
+      const session = withState(0, state);
+      expect(isActiveSession(session)).toBe(true);
+    });
+
+    it.each(TERMINAL)('treats %s as non-active (terminal)', (state) => {
+      const session = withState(0, state);
+      expect(isActiveSession(session)).toBe(false);
+    });
+
+    it('covers all 11 SessionState variants in the categorization', () => {
+      // 念のため全状態を ACTIVE ∪ TERMINAL で覆い尽くしているか確認
+      const covered = new Set<SessionState>([...ACTIVE, ...TERMINAL]);
+      for (const state of SESSION_STATES) {
+        expect(covered.has(state)).toBe(true);
+      }
+    });
+  });
+
+  describe('countActiveSessions', () => {
+    it('returns 0 for empty input', () => {
+      expect(countActiveSessions([])).toBe(0);
+    });
+
+    it('counts only active sessions, ignoring stopped ones', () => {
+      const sessions: readonly SourceSession[] = [
+        withState(0, 'capturing'),
+        withState(1, 'stopped'),
+        withState(2, 'transcribing'),
+      ];
+      expect(countActiveSessions(sessions)).toBe(2);
+    });
+
+    it('returns 0 when all sessions are stopped', () => {
+      const sessions: readonly SourceSession[] = [withState(0, 'stopped'), withState(1, 'stopped')];
+      expect(countActiveSessions(sessions)).toBe(0);
+    });
+  });
+
+  describe('validateSessionConcurrency', () => {
+    it('returns ok for empty active session list', () => {
+      const result = validateSessionConcurrency([]);
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('returns ok when active count is 1', () => {
+      const result = validateSessionConcurrency([withState(0, 'capturing')]);
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('returns ok when active count is 2 (below limit)', () => {
+      const result = validateSessionConcurrency([
+        withState(0, 'capturing'),
+        withState(1, 'transcribing'),
+      ]);
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('returns err with invariant-violation when active count reaches the limit', () => {
+      const result = validateSessionConcurrency([
+        withState(0, 'capturing'),
+        withState(1, 'transcribing'),
+        withState(2, 'translating'),
+      ]);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe('invariant-violation');
+        if (result.error.kind === 'invariant-violation') {
+          expect(result.error.invariant).toBe('concurrent-session-limit');
+          expect(result.error.details).toContain('3');
+        }
+      }
+    });
+
+    it('returns err when active count exceeds the limit', () => {
+      const result = validateSessionConcurrency([
+        withState(0, 'capturing'),
+        withState(1, 'transcribing'),
+        withState(2, 'translating'),
+        withState(3, 'paused'),
+      ]);
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('ignores stopped sessions when evaluating the limit (2 active + 10 stopped → ok)', () => {
+      const result = validateSessionConcurrency([
+        withState(0, 'capturing'),
+        withState(1, 'transcribing'),
+        withState(2, 'stopped'),
+        withState(3, 'stopped'),
+        withState(4, 'stopped'),
+      ]);
+      expect(result.isOk()).toBe(true);
+    });
+  });
+});

--- a/packages/extension/src/domain/services/session-concurrency-policy.ts
+++ b/packages/extension/src/domain/services/session-concurrency-policy.ts
@@ -1,0 +1,47 @@
+import { err, ok, type Result } from 'neverthrow';
+import { type SourceSession } from '../session/source-session.js';
+import { type SessionState } from '../session/session-state.js';
+import { type DomainError, invariantViolationError } from '../shared/errors.js';
+
+/**
+ * セッション並行度ポリシー (DD-240)。
+ *
+ * 設計文書: domain.md DD-240, DD-270 (ConcurrentSessionLimitSpecification)。
+ * `SourceSession` が同時にアクティブに保持できる数の上限 (3) を保証する。
+ *
+ * アクティブ = `stopped` 以外の状態。`error` も「acknowledge() → stopped」で
+ * 終了させるまではリソースを保持しているため稼働中として扱う。
+ *
+ * IMPL-150 `ConcurrentSessionLimitSpecification` 実装時に、`isActiveSession` /
+ * `countActiveSessions` を述語 spec へ移動し、本ポリシーはそれを利用する形に
+ * リファクタされる予定。
+ */
+export const MAX_CONCURRENT_ACTIVE_SESSIONS = 3 as const;
+
+const TERMINAL_STATES: ReadonlySet<SessionState> = new Set(['stopped']);
+
+export const isActiveSession = (session: SourceSession): boolean =>
+  !TERMINAL_STATES.has(session.state);
+
+export const countActiveSessions = (sessions: readonly SourceSession[]): number =>
+  sessions.reduce((count, session) => (isActiveSession(session) ? count + 1 : count), 0);
+
+/**
+ * セッション追加前の事前条件チェック。既存アクティブ数が上限未満なら OK。
+ * use-case.md §10.1 `StartSourceSessionUseCase` のシーケンスで
+ * `Policy.validate()` として呼ばれる想定。
+ */
+export const validateSessionConcurrency = (
+  existingSessions: readonly SourceSession[],
+): Result<void, DomainError> => {
+  const activeCount = countActiveSessions(existingSessions);
+  if (activeCount >= MAX_CONCURRENT_ACTIVE_SESSIONS) {
+    return err(
+      invariantViolationError({
+        invariant: 'concurrent-session-limit',
+        details: `active session count ${String(activeCount)} would exceed limit ${String(MAX_CONCURRENT_ACTIVE_SESSIONS)}`,
+      }),
+    );
+  }
+  return ok(undefined);
+};

--- a/packages/extension/src/domain/services/session-state-transition-policy.test.ts
+++ b/packages/extension/src/domain/services/session-state-transition-policy.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { SESSION_STATES, type SessionState } from '../session/session-state.js';
+import {
+  ALLOWED_TRANSITIONS,
+  canTransitionSessionState,
+  validateSessionStateTransition,
+} from './session-state-transition-policy.js';
+
+/**
+ * 状態遷移表 (detailed-design.md §7.2) を網羅的に検証する。
+ * ALLOWED_TRANSITIONS は「遷移前 → 許容される遷移先配列」のテーブルで、
+ * `stopped` への遷移は任意稼働状態から可能なので個別扱い。
+ */
+
+const ALLOWED_PAIRS: readonly (readonly [SessionState, SessionState])[] = [
+  ['idle', 'requesting_permission'],
+  ['requesting_permission', 'connecting'],
+  ['requesting_permission', 'error'],
+  ['connecting', 'capturing'],
+  ['connecting', 'error'],
+  ['capturing', 'transcribing'],
+  ['capturing', 'paused'],
+  ['capturing', 'reconnecting'],
+  ['transcribing', 'translating'],
+  ['transcribing', 'paused'],
+  ['transcribing', 'reconnecting'],
+  ['transcribing', 'degraded'],
+  ['translating', 'transcribing'],
+  ['translating', 'paused'],
+  ['translating', 'reconnecting'],
+  ['translating', 'degraded'],
+  ['paused', 'capturing'],
+  ['reconnecting', 'capturing'],
+  ['reconnecting', 'error'],
+  ['degraded', 'transcribing'],
+];
+
+const ACTIVE_STATES: readonly SessionState[] = [
+  'idle',
+  'requesting_permission',
+  'connecting',
+  'capturing',
+  'transcribing',
+  'translating',
+  'paused',
+  'reconnecting',
+  'degraded',
+  'error',
+];
+
+describe('SessionStateTransitionPolicy (DD-241)', () => {
+  describe('ALLOWED_TRANSITIONS table', () => {
+    it('covers all 11 states as keys', () => {
+      for (const state of SESSION_STATES) {
+        expect(ALLOWED_TRANSITIONS).toHaveProperty(state);
+      }
+    });
+
+    it('defines stopped as terminal (no outgoing transitions)', () => {
+      expect(ALLOWED_TRANSITIONS.stopped).toEqual([]);
+    });
+
+    it('defines error as terminal in the table (stop is handled separately)', () => {
+      expect(ALLOWED_TRANSITIONS.error).toEqual([]);
+    });
+  });
+
+  describe('canTransitionSessionState', () => {
+    it.each(ALLOWED_PAIRS)('permits %s → %s', (from, to) => {
+      expect(canTransitionSessionState(from, to)).toBe(true);
+    });
+
+    it.each(ACTIVE_STATES)('permits %s → stopped (universal stop)', (from) => {
+      expect(canTransitionSessionState(from, 'stopped')).toBe(true);
+    });
+
+    it('rejects stopped → stopped', () => {
+      expect(canTransitionSessionState('stopped', 'stopped')).toBe(false);
+    });
+
+    it.each(SESSION_STATES)('rejects stopped → %s (terminal)', (to) => {
+      expect(canTransitionSessionState('stopped', to)).toBe(false);
+    });
+
+    it('rejects idle → capturing (illegal shortcut)', () => {
+      expect(canTransitionSessionState('idle', 'capturing')).toBe(false);
+    });
+
+    it('rejects capturing → degraded (degraded requires transcribing/translating)', () => {
+      expect(canTransitionSessionState('capturing', 'degraded')).toBe(false);
+    });
+
+    it('rejects degraded → translating (only → transcribing permitted)', () => {
+      expect(canTransitionSessionState('degraded', 'translating')).toBe(false);
+    });
+
+    it('rejects paused → transcribing (must return via capturing)', () => {
+      expect(canTransitionSessionState('paused', 'transcribing')).toBe(false);
+    });
+  });
+
+  describe('validateSessionStateTransition', () => {
+    it('returns ok for permitted transition', () => {
+      const result = validateSessionStateTransition('idle', 'requesting_permission', 'start');
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('returns session-state-transition error for forbidden transition', () => {
+      const result = validateSessionStateTransition('idle', 'capturing', 'shortcut not allowed');
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe('session-state-transition');
+        if (result.error.kind === 'session-state-transition') {
+          expect(result.error.from).toBe('idle');
+          expect(result.error.to).toBe('capturing');
+          expect(result.error.reason).toBe('shortcut not allowed');
+        }
+      }
+    });
+
+    it('preserves custom reason in the error payload', () => {
+      const reason = 'custom failure context provided by caller';
+      const result = validateSessionStateTransition('stopped', 'capturing', reason);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr() && result.error.kind === 'session-state-transition') {
+        expect(result.error.reason).toBe(reason);
+      }
+    });
+
+    it('rejects any transition from stopped (terminal state)', () => {
+      for (const to of SESSION_STATES) {
+        const result = validateSessionStateTransition('stopped', to, 'from terminal');
+        expect(result.isErr()).toBe(true);
+      }
+    });
+
+    it('permits universal stop from all active states', () => {
+      for (const from of ACTIVE_STATES) {
+        const result = validateSessionStateTransition(from, 'stopped', 'user stop');
+        expect(result.isOk()).toBe(true);
+      }
+    });
+  });
+});

--- a/packages/extension/src/domain/services/session-state-transition-policy.ts
+++ b/packages/extension/src/domain/services/session-state-transition-policy.ts
@@ -1,0 +1,45 @@
+import { err, ok, type Result } from 'neverthrow';
+import { type SessionState } from '../session/session-state.js';
+import { type DomainError, sessionStateTransitionError } from '../shared/errors.js';
+
+/**
+ * ソースセッション状態遷移ポリシー (DD-241)。
+ *
+ * `SourceSession` 集約の状態遷移可否判定を集約から切り出した純粋関数群。
+ * 状態遷移表は detailed-design.md §7.2 に準拠する。
+ *
+ * 特別扱い:
+ * - `stopped` はいずれの状態からも到達可能 (terminal state)。テーブルには列挙しない
+ * - `stopped` からはいかなる状態にも遷移できない
+ * - `error` はテーブル上で遷移先なし (`stop` 操作でのみ `stopped` へ)
+ */
+export const ALLOWED_TRANSITIONS: Readonly<Record<SessionState, readonly SessionState[]>> = {
+  idle: ['requesting_permission'],
+  requesting_permission: ['connecting', 'error'],
+  connecting: ['capturing', 'error'],
+  capturing: ['transcribing', 'paused', 'reconnecting'],
+  transcribing: ['translating', 'paused', 'reconnecting', 'degraded'],
+  translating: ['transcribing', 'paused', 'reconnecting', 'degraded'],
+  paused: ['capturing'],
+  reconnecting: ['capturing', 'error'],
+  degraded: ['transcribing'],
+  error: [],
+  stopped: [],
+};
+
+export const canTransitionSessionState = (from: SessionState, to: SessionState): boolean => {
+  if (from === 'stopped') return false;
+  if (to === 'stopped') return true;
+  return ALLOWED_TRANSITIONS[from].includes(to);
+};
+
+export const validateSessionStateTransition = (
+  from: SessionState,
+  to: SessionState,
+  reason: string,
+): Result<void, DomainError> => {
+  if (!canTransitionSessionState(from, to)) {
+    return err(sessionStateTransitionError({ from, to, reason }));
+  }
+  return ok(undefined);
+};

--- a/packages/extension/src/domain/session/source-session.ts
+++ b/packages/extension/src/domain/session/source-session.ts
@@ -1,6 +1,10 @@
 import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
 import {
+  canTransitionSessionState,
+  validateSessionStateTransition,
+} from '../services/session-state-transition-policy.js';
+import {
   type DomainError,
   sessionStateTransitionError,
   validationError,
@@ -20,8 +24,7 @@ import { parseSourceType, type SourceType } from './source-type.js';
  * 3. `degraded` は翻訳障害時のみ遷移可能 (transcribing / translating から)
  * 4. `stopped` 後は再開不可 (terminal state)
  *
- * NOTE: 状態遷移表は本ファイル内に inline で保持しているが、
- * IMPL-121 `SessionStateTransitionPolicy` 実装時にドメインサービスへ抽出する。
+ * 状態遷移表は `domain/services/session-state-transition-policy.ts` (DD-241) に集約する。
  */
 export type SourceSession = Readonly<{
   sessionIdentifier: SessionIdentifier;
@@ -41,48 +44,16 @@ type TransitionContext = Readonly<{
   stoppedAt?: string;
 }>;
 
-/**
- * 許容される状態遷移テーブル。キーは遷移前、値は遷移先の配列。
- * 状態機械の定義は detailed-design.md §7.1 / §7.2。
- * `stopped` はどの稼働状態からも到達可能 (terminal) なため `canTransition`
- * 側で特別扱いする (テーブルには列挙しない)。
- */
-const ALLOWED_TRANSITIONS: Readonly<Record<SessionState, readonly SessionState[]>> = {
-  idle: ['requesting_permission'],
-  requesting_permission: ['connecting', 'error'],
-  connecting: ['capturing', 'error'],
-  capturing: ['transcribing', 'paused', 'reconnecting'],
-  transcribing: ['translating', 'paused', 'reconnecting', 'degraded'],
-  translating: ['transcribing', 'paused', 'reconnecting', 'degraded'],
-  paused: ['capturing'],
-  reconnecting: ['capturing', 'error'],
-  degraded: ['transcribing'],
-  error: [],
-  stopped: [],
-};
-
-const canTransition = (from: SessionState, to: SessionState): boolean => {
-  if (from === 'stopped') return false;
-  if (to === 'stopped') return true;
-  return ALLOWED_TRANSITIONS[from].includes(to);
-};
-
 const transitionGuard = (
   current: SourceSession,
   to: SessionState,
   reason: string,
-): Result<SourceSession, DomainError> => {
-  if (!canTransition(current.state, to)) {
-    return err(
-      sessionStateTransitionError({
-        from: current.state,
-        to,
-        reason,
-      }),
-    );
-  }
-  return ok({ ...current, state: to, degradedReason: null });
-};
+): Result<SourceSession, DomainError> =>
+  validateSessionStateTransition(current.state, to, reason).map(() => ({
+    ...current,
+    state: to,
+    degradedReason: null,
+  }));
 
 export const createSourceSession = (params: {
   sessionIdentifier: string;
@@ -156,7 +127,7 @@ export const markSourceSessionDegraded = (
   session: SourceSession,
   reason: string,
 ): Result<SourceSession, DomainError> => {
-  if (!canTransition(session.state, 'degraded')) {
+  if (!canTransitionSessionState(session.state, 'degraded')) {
     return err(
       sessionStateTransitionError({
         from: session.state,
@@ -187,7 +158,7 @@ export const stopSourceSession = (
   session: SourceSession,
   context: TransitionContext & { stoppedAt: string },
 ): Result<SourceSession, DomainError> => {
-  if (!canTransition(session.state, 'stopped')) {
+  if (!canTransitionSessionState(session.state, 'stopped')) {
     return err(
       sessionStateTransitionError({
         from: session.state,


### PR DESCRIPTION
## Summary

Phase 1 §3.3 として 4 ドメインサービスを TDD で実装し、Phase 1 ドメイン層を完成させる。全て純粋関数で `Result<T, DomainError>` を返す (CLAUDE.md §Phase 0 合意事項 IMPL-001/002 に準拠)。

- **IMPL-121 `SessionStateTransitionPolicy` (DD-241)**: `source-session.ts` の inline 状態遷移ロジックを `domain/services/` へ抽出。`ALLOWED_TRANSITIONS` テーブル + `canTransitionSessionState` / `validateSessionStateTransition` を公開。既存 API (`startSourceSession` 等) は完全維持、既存 21 テストも修正なしで緑。
- **IMPL-120 `SessionConcurrencyPolicy` (DD-240 / DD-270)**: `MAX_CONCURRENT_ACTIVE_SESSIONS = 3` / `isActiveSession` / `countActiveSessions` / `validateSessionConcurrency`。アクティブ = `stopped` 以外の 10 状態。上限到達時は `invariantViolationError({ invariant: 'concurrent-session-limit' })`。
- **IMPL-123 `LanguageRoutingPolicy` (DD-243)**: `resolveEffectiveLanguagePair({ profile, override?, detectedSource? })`。優先度 override > auto-detect + detectedSource > profile default。BCP-47 検証と同言語禁止は `createLanguagePair` VO に委譲。
- **IMPL-122 `ExportAssemblyService` (DD-242)**: `assembleExport(stream, { format, includeOriginal, includeTranslation })`。確定字幕のみ、`startMs` 昇順、failed 翻訳除外。TXT `[MM:SS.mmm] 原文\n→ [targetLanguage] 翻訳` / JSON structured output。

### 設計上の判断

- 新規 `domain/services/` を作成し services → session / transcript / profile / export / shared の片方向依存
- IMPL-121 抽出で `source-session.ts` は 215 行 → 186 行 (55 行削除、13 行追加)
- IMPL-150 `ConcurrentSessionLimitSpecification` (後続タスク) は本 Policy 内の `isActiveSession` / `countActiveSessions` を述語 spec へ抽出予定。Policy = 違反時に DomainError を組み立てる、Spec = 純粋述語

## Test plan

- [x] `pnpm --filter @perapera/extension test` → 237 tests pass (22 test files、既存 132 から +105 新規)
- [x] `pnpm --filter @perapera/extension test:coverage`
  - `domain/services/` 全 4 ファイル: statements/functions/lines **100%**、branches 97.91%
  - 全体: 95.97% / 97.54% / 98.52% (Phase 1 目標「状態遷移・バリデーション 90%+」を大幅達成)
- [x] `pnpm check` (fmt:check + lint + typecheck + test) 全緑
- [ ] CI `All Green` 通過