### PR TITLE
feat(domain): IMPL-130〜135 domain events

### DIFF
--- a/packages/extension/src/domain/events/domain-events.test.ts
+++ b/packages/extension/src/domain/events/domain-events.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import { createLanguagePair } from '../session/language-pair.js';
+import { createSourceSession } from '../session/source-session.js';
+import { createPartialTranscriptSegment } from '../transcript/transcript-segment.js';
+import { createTimestampRange } from '../transcript/timestamp-range.js';
+import { createCompletedTranslationSegment } from '../transcript/translation-segment.js';
+import {
+  sourceSessionDegraded,
+  sourceSessionStarted,
+  sourceSessionStopped,
+  transcriptFinalized,
+  transcriptPartialUpdated,
+  translationCompleted,
+  type DomainEvent,
+} from './domain-events.js';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+const TRANSLATION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7E1';
+const STARTED_AT = '2026-04-21T00:00:00.000Z';
+const FINALIZED_AT = '2026-04-21T00:00:05.000Z';
+const OCCURRED_AT = '2026-04-21T00:01:00.000Z';
+const STOPPED_AT = '2026-04-21T00:10:00.000Z';
+
+const languagePair = createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap();
+
+const buildSession = () =>
+  createSourceSession({
+    sessionIdentifier: SESSION_ID,
+    sourceIdentifier: SOURCE_ID,
+    sourceType: 'tab',
+    languagePair,
+    startedAt: STARTED_AT,
+  })._unsafeUnwrap();
+
+const buildFinalSegment = () =>
+  createPartialTranscriptSegment({
+    segmentIdentifier: SEGMENT_ID,
+    revision: 1,
+    text: 'hello',
+    timeRange: createTimestampRange({ startMs: 0, endMs: 1500 })._unsafeUnwrap(),
+  })._unsafeUnwrap();
+
+const buildCompletedTranslation = () => {
+  const translation = createCompletedTranslationSegment({
+    translationIdentifier: TRANSLATION_ID,
+    segmentIdentifier: SEGMENT_ID,
+    targetLanguage: 'ja-JP',
+    text: 'こんにちは',
+  })._unsafeUnwrap();
+  if (translation.status !== 'completed') {
+    throw new Error('expected completed translation');
+  }
+  return translation;
+};
+
+describe('Domain events', () => {
+  describe('sourceSessionStarted (DD-250)', () => {
+    it('captures identifiers, sourceType, and startedAt from the session', () => {
+      const event = sourceSessionStarted(buildSession());
+      expect(event.type).toBe('source-session-started');
+      expect(event.sessionIdentifier).toBe(SESSION_ID);
+      expect(event.sourceIdentifier).toBe(SOURCE_ID);
+      expect(event.sourceType).toBe('tab');
+      expect(event.startedAt).toBe(STARTED_AT);
+    });
+  });
+
+  describe('transcriptPartialUpdated (DD-251)', () => {
+    it('captures sessionIdentifier, segmentIdentifier, revision, and text', () => {
+      const session = buildSession();
+      const segment = buildFinalSegment();
+      const event = transcriptPartialUpdated({
+        sessionIdentifier: session.sessionIdentifier,
+        segment,
+      });
+      expect(event.type).toBe('transcript-partial-updated');
+      expect(event.sessionIdentifier).toBe(SESSION_ID);
+      expect(event.segmentIdentifier).toBe(SEGMENT_ID);
+      expect(event.revision).toBe(1);
+      expect(event.text).toBe('hello');
+    });
+  });
+
+  describe('transcriptFinalized (DD-252)', () => {
+    it('captures segment text and the finalizedAt timestamp', () => {
+      const session = buildSession();
+      const segment = buildFinalSegment();
+      const event = transcriptFinalized({
+        sessionIdentifier: session.sessionIdentifier,
+        segment,
+        finalizedAt: FINALIZED_AT,
+      });
+      expect(event.type).toBe('transcript-finalized');
+      expect(event.sessionIdentifier).toBe(SESSION_ID);
+      expect(event.segmentIdentifier).toBe(SEGMENT_ID);
+      expect(event.text).toBe('hello');
+      expect(event.finalizedAt).toBe(FINALIZED_AT);
+    });
+  });
+
+  describe('translationCompleted (DD-253)', () => {
+    it('captures translationIdentifier, segmentIdentifier, and text', () => {
+      const session = buildSession();
+      const translation = buildCompletedTranslation();
+      const event = translationCompleted({
+        sessionIdentifier: session.sessionIdentifier,
+        translation,
+      });
+      expect(event.type).toBe('translation-completed');
+      expect(event.sessionIdentifier).toBe(SESSION_ID);
+      expect(event.segmentIdentifier).toBe(SEGMENT_ID);
+      expect(event.translationIdentifier).toBe(TRANSLATION_ID);
+      expect(event.text).toBe('こんにちは');
+    });
+  });
+
+  describe('sourceSessionDegraded (DD-254)', () => {
+    it('captures reason and occurredAt', () => {
+      const session = buildSession();
+      const event = sourceSessionDegraded({
+        sessionIdentifier: session.sessionIdentifier,
+        reason: 'translation provider timeout',
+        occurredAt: OCCURRED_AT,
+      });
+      expect(event.type).toBe('source-session-degraded');
+      expect(event.sessionIdentifier).toBe(SESSION_ID);
+      expect(event.reason).toBe('translation provider timeout');
+      expect(event.occurredAt).toBe(OCCURRED_AT);
+    });
+  });
+
+  describe('sourceSessionStopped (DD-255)', () => {
+    it('captures stoppedAt and reason when user explicitly stops', () => {
+      const session = buildSession();
+      const event = sourceSessionStopped({
+        sessionIdentifier: session.sessionIdentifier,
+        stoppedAt: STOPPED_AT,
+        reason: 'user_requested_stop',
+      });
+      expect(event.type).toBe('source-session-stopped');
+      expect(event.sessionIdentifier).toBe(SESSION_ID);
+      expect(event.stoppedAt).toBe(STOPPED_AT);
+      expect(event.reason).toBe('user_requested_stop');
+    });
+
+    it('allows reason to be null for implicit shutdown cases', () => {
+      const session = buildSession();
+      const event = sourceSessionStopped({
+        sessionIdentifier: session.sessionIdentifier,
+        stoppedAt: STOPPED_AT,
+        reason: null,
+      });
+      expect(event.reason).toBeNull();
+    });
+  });
+
+  describe('DomainEvent discriminated union', () => {
+    it('narrows payload via the type discriminator', () => {
+      const events: DomainEvent[] = [
+        sourceSessionStarted(buildSession()),
+        transcriptPartialUpdated({
+          sessionIdentifier: buildSession().sessionIdentifier,
+          segment: buildFinalSegment(),
+        }),
+      ];
+
+      const started = events.find((e) => e.type === 'source-session-started');
+      expect(started).toBeDefined();
+      if (started?.type === 'source-session-started') {
+        // Within this guard, TypeScript narrows `started` to SourceSessionStarted;
+        // access of `sourceType` (field specific to this variant) verifies the union.
+        expect(started.sourceType).toBe('tab');
+      }
+
+      const partial = events.find((e) => e.type === 'transcript-partial-updated');
+      expect(partial).toBeDefined();
+      if (partial?.type === 'transcript-partial-updated') {
+        expect(partial.revision).toBe(1);
+      }
+    });
+  });
+});

--- a/packages/extension/src/domain/events/domain-events.ts
+++ b/packages/extension/src/domain/events/domain-events.ts
@@ -1,0 +1,146 @@
+import { type SessionIdentifier } from '../session/session-identifier.js';
+import { type SourceIdentifier } from '../session/source-identifier.js';
+import { type SourceSession } from '../session/source-session.js';
+import { type SourceType } from '../session/source-type.js';
+import { type SegmentIdentifier } from '../transcript/segment-identifier.js';
+import { type TranscriptSegment } from '../transcript/transcript-segment.js';
+import { type TranslationIdentifier } from '../transcript/translation-identifier.js';
+import { type TranslationSegment } from '../transcript/translation-segment.js';
+
+/**
+ * ドメインイベント (DD-250〜DD-255)。
+ *
+ * 集約のメソッド呼び出し後にユースケース層が発行する immutable record。
+ * 表示層 / 保存層 / 運用ログが購読する。詳細は domain.md §8。
+ *
+ * factory は純粋関数として実装する。不変条件 (TranscriptFinalized は確定済
+ * segment を受ける、TranslationCompleted は completed 翻訳を受ける等) は
+ * 既に集約・エンティティ側で保証されているため、factory では再検証しない。
+ * 型レベルで narrow できるものは discriminated union の `Extract` で制約する。
+ */
+
+type CompletedTranslationSegment = Extract<TranslationSegment, { status: 'completed' }>;
+
+// DD-250
+export type SourceSessionStarted = Readonly<{
+  type: 'source-session-started';
+  sessionIdentifier: SessionIdentifier;
+  sourceIdentifier: SourceIdentifier;
+  sourceType: SourceType;
+  startedAt: string;
+}>;
+
+export const sourceSessionStarted = (session: SourceSession): SourceSessionStarted => ({
+  type: 'source-session-started',
+  sessionIdentifier: session.sessionIdentifier,
+  sourceIdentifier: session.sourceIdentifier,
+  sourceType: session.sourceType,
+  startedAt: session.startedAt,
+});
+
+// DD-251
+export type TranscriptPartialUpdated = Readonly<{
+  type: 'transcript-partial-updated';
+  sessionIdentifier: SessionIdentifier;
+  segmentIdentifier: SegmentIdentifier;
+  revision: number;
+  text: string;
+}>;
+
+export const transcriptPartialUpdated = (params: {
+  sessionIdentifier: SessionIdentifier;
+  segment: TranscriptSegment;
+}): TranscriptPartialUpdated => ({
+  type: 'transcript-partial-updated',
+  sessionIdentifier: params.sessionIdentifier,
+  segmentIdentifier: params.segment.segmentIdentifier,
+  revision: params.segment.revision,
+  text: params.segment.text,
+});
+
+// DD-252
+export type TranscriptFinalized = Readonly<{
+  type: 'transcript-finalized';
+  sessionIdentifier: SessionIdentifier;
+  segmentIdentifier: SegmentIdentifier;
+  text: string;
+  finalizedAt: string;
+}>;
+
+export const transcriptFinalized = (params: {
+  sessionIdentifier: SessionIdentifier;
+  segment: TranscriptSegment;
+  finalizedAt: string;
+}): TranscriptFinalized => ({
+  type: 'transcript-finalized',
+  sessionIdentifier: params.sessionIdentifier,
+  segmentIdentifier: params.segment.segmentIdentifier,
+  text: params.segment.text,
+  finalizedAt: params.finalizedAt,
+});
+
+// DD-253
+export type TranslationCompleted = Readonly<{
+  type: 'translation-completed';
+  sessionIdentifier: SessionIdentifier;
+  segmentIdentifier: SegmentIdentifier;
+  translationIdentifier: TranslationIdentifier;
+  text: string;
+}>;
+
+export const translationCompleted = (params: {
+  sessionIdentifier: SessionIdentifier;
+  translation: CompletedTranslationSegment;
+}): TranslationCompleted => ({
+  type: 'translation-completed',
+  sessionIdentifier: params.sessionIdentifier,
+  segmentIdentifier: params.translation.segmentIdentifier,
+  translationIdentifier: params.translation.translationIdentifier,
+  text: params.translation.text,
+});
+
+// DD-254
+export type SourceSessionDegraded = Readonly<{
+  type: 'source-session-degraded';
+  sessionIdentifier: SessionIdentifier;
+  reason: string;
+  occurredAt: string;
+}>;
+
+export const sourceSessionDegraded = (params: {
+  sessionIdentifier: SessionIdentifier;
+  reason: string;
+  occurredAt: string;
+}): SourceSessionDegraded => ({
+  type: 'source-session-degraded',
+  sessionIdentifier: params.sessionIdentifier,
+  reason: params.reason,
+  occurredAt: params.occurredAt,
+});
+
+// DD-255
+export type SourceSessionStopped = Readonly<{
+  type: 'source-session-stopped';
+  sessionIdentifier: SessionIdentifier;
+  stoppedAt: string;
+  reason: string | null;
+}>;
+
+export const sourceSessionStopped = (params: {
+  sessionIdentifier: SessionIdentifier;
+  stoppedAt: string;
+  reason: string | null;
+}): SourceSessionStopped => ({
+  type: 'source-session-stopped',
+  sessionIdentifier: params.sessionIdentifier,
+  stoppedAt: params.stoppedAt,
+  reason: params.reason,
+});
+
+export type DomainEvent =
+  | SourceSessionStarted
+  | TranscriptPartialUpdated
+  | TranscriptFinalized
+  | TranslationCompleted
+  | SourceSessionDegraded
+  | SourceSessionStopped;


### PR DESCRIPTION
## Summary

Phase 1 §3.4 として 6 ドメインイベント (DD-250〜DD-255) を TDD で実装。集約のメソッド呼び出し後にユースケース層が発行する immutable record として、表示層 / 保存層 / 運用ログが購読する契約型を定義。

- **IMPL-130 `SourceSessionStarted` (DD-250)** — セッション開始時
- **IMPL-131 `TranscriptPartialUpdated` (DD-251)** — 部分字幕更新時
- **IMPL-132 `TranscriptFinalized` (DD-252)** — 確定字幕生成時
- **IMPL-133 `TranslationCompleted` (DD-253)** — 翻訳完了時
- **IMPL-134 `SourceSessionDegraded` (DD-254)** — 翻訳障害で劣化運転へ移行時
- **IMPL-135 `SourceSessionStopped` (DD-255)** — セッション停止時

### 設計上の判断

- 1 ファイル `domain/events/domain-events.ts` に 6 型 + 6 factory + `DomainEvent` union を集約 (`shared/errors.ts` と同じ集約パターン)
- factory は純粋関数として実装し、不変条件は既に集約・エンティティ側で保証されている前提。`translationCompleted` は型レベルで `Extract<TranslationSegment, { status: 'completed' }>` を要求し静的検査で failed 誤渡しを防ぐ
- `SourceSessionStopped.reason` は `string | null`。ユーザー停止 / システム停止の両方を許容
- `type` discriminator を全イベントに付与し `DomainEvent` union で narrow 可能

### 依存方向

`domain/events/` → `domain/session/` / `domain/transcript/` / `domain/shared/` の片方向依存。集約から events への逆依存は無し (集約はイベントを返さない設計)。

## Test plan

- [x] `pnpm --filter @perapera/extension test` → 245 tests pass (23 test files、既存 237 から +8 新規)
- [x] `pnpm check` (fmt:check + lint + typecheck + test) 全緑
- [ ] CI `All Green` 通過