### PR TITLE
feat(domain): IMPL-140〜143 repository interfaces

### DIFF
--- a/packages/extension/src/domain/repositories/export-record-repository.test.ts
+++ b/packages/extension/src/domain/repositories/export-record-repository.test.ts
@@ -1,0 +1,89 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { createExportRecord, type ExportRecord } from '../export/export-record.js';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
+import { invariantViolationError, type DomainError } from '../shared/errors.js';
+import { type ExportRecordRepository } from './export-record-repository.js';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const EXPORT_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7F1';
+const EXPORT_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7F2';
+
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const buildRecord = (exportId: string): ExportRecord =>
+  createExportRecord({
+    exportIdentifier: exportId,
+    sessionIdentifier: SESSION_ID,
+    format: 'txt',
+    includeOriginal: true,
+    includeTranslation: true,
+    createdAt: '2026-04-21T00:00:00.000Z',
+  })._unsafeUnwrap();
+
+describe('ExportRecordRepository (DD-263)', () => {
+  describe('type contract', () => {
+    it('accepts an object literal that implements all required methods', () => {
+      const mock: ExportRecordRepository = {
+        save: () => okAsync(undefined),
+        findBySessionId: () => okAsync([]),
+      };
+      expect(typeof mock.save).toBe('function');
+      expect(typeof mock.findBySessionId).toBe('function');
+    });
+  });
+
+  describe('save', () => {
+    it('resolves to ok(void) on the success path', async () => {
+      const mock: ExportRecordRepository = {
+        save: () => okAsync(undefined),
+        findBySessionId: () => okAsync([]),
+      };
+      const result = await mock.save(buildRecord(EXPORT_ID_1));
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('can return an invariantViolationError on storage failure', async () => {
+      const mock: ExportRecordRepository = {
+        save: () =>
+          errAsync<void, DomainError>(
+            invariantViolationError({
+              invariant: 'export-persistence',
+              details: 'storage quota exceeded',
+            }),
+          ),
+        findBySessionId: () => okAsync([]),
+      };
+      const result = await mock.save(buildRecord(EXPORT_ID_1));
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    });
+  });
+
+  describe('findBySessionId', () => {
+    it('returns an empty array when no export history exists (ok([]), not an error)', async () => {
+      const mock: ExportRecordRepository = {
+        save: () => okAsync(undefined),
+        findBySessionId: () => okAsync([]),
+      };
+      const result = await mock.findBySessionId(sessionIdentifier);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toEqual([]);
+    });
+
+    it('returns all export records associated with the session, preserving insertion order', async () => {
+      const records: readonly ExportRecord[] = [buildRecord(EXPORT_ID_1), buildRecord(EXPORT_ID_2)];
+      const mock: ExportRecordRepository = {
+        save: () => okAsync(undefined),
+        findBySessionId: () => okAsync(records),
+      };
+      const result = await mock.findBySessionId(sessionIdentifier);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(2);
+        expect(result.value[0]?.exportIdentifier).toBe(EXPORT_ID_1);
+        expect(result.value[1]?.exportIdentifier).toBe(EXPORT_ID_2);
+      }
+    });
+  });
+});

--- a/packages/extension/src/domain/repositories/export-record-repository.ts
+++ b/packages/extension/src/domain/repositories/export-record-repository.ts
@@ -1,0 +1,24 @@
+import { type ResultAsync } from 'neverthrow';
+import { type ExportRecord } from '../export/export-record.js';
+import { type SessionIdentifier } from '../session/session-identifier.js';
+import { type DomainError } from '../shared/errors.js';
+
+/**
+ * エクスポート履歴リポジトリ (DD-263)。
+ *
+ * `ExportRecord` エンティティの永続化契約。MVP では IndexedDB 内の
+ * `export_records` object store にマッピングされる (DB-004)。
+ *
+ * エラー:
+ * - `save`: storage 書き込み失敗時は
+ *   `invariantViolationError({ invariant: 'export-persistence', ... })` を想定
+ * - `findBySessionId`: **0 件は `ok([])` で返す**。セッション自体の存在確認は
+ *   別レイヤーの責務であり、本リポジトリは「当該セッションに紐づく履歴」のみを
+ *   扱う。空履歴は正常ケース
+ */
+export type ExportRecordRepository = Readonly<{
+  save: (record: ExportRecord) => ResultAsync<void, DomainError>;
+  findBySessionId: (
+    sessionIdentifier: SessionIdentifier,
+  ) => ResultAsync<readonly ExportRecord[], DomainError>;
+}>;

--- a/packages/extension/src/domain/repositories/extension-profile-repository.test.ts
+++ b/packages/extension/src/domain/repositories/extension-profile-repository.test.ts
@@ -1,0 +1,81 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { createExtensionProfile, type ExtensionProfile } from '../profile/extension-profile.js';
+import { createOverlaySettings } from '../profile/overlay-settings.js';
+import { createLanguagePair } from '../session/language-pair.js';
+import { notFoundError, type DomainError } from '../shared/errors.js';
+import { type ExtensionProfileRepository } from './extension-profile-repository.js';
+
+const PROFILE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
+
+const buildProfile = (): ExtensionProfile =>
+  createExtensionProfile({
+    profileIdentifier: PROFILE_ID,
+    defaultLanguagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    defaultOverlaySettings: createOverlaySettings({
+      positionPreset: 'bottom',
+      opacity: 0.8,
+      maxLines: 2,
+      fontScale: 1,
+      showOriginalText: true,
+      showTranslatedText: true,
+    })._unsafeUnwrap(),
+    autoDetectEnabled: false,
+  })._unsafeUnwrap();
+
+describe('ExtensionProfileRepository (DD-262)', () => {
+  describe('type contract', () => {
+    it('accepts an object literal that implements all required methods as a valid ExtensionProfileRepository', () => {
+      const mock: ExtensionProfileRepository = {
+        getDefault: () => okAsync(buildProfile()),
+        save: () => okAsync(undefined),
+      };
+      expect(typeof mock.getDefault).toBe('function');
+      expect(typeof mock.save).toBe('function');
+    });
+  });
+
+  describe('getDefault', () => {
+    it('returns the stored ExtensionProfile on the success path', async () => {
+      const profile = buildProfile();
+      const mock: ExtensionProfileRepository = {
+        getDefault: () => okAsync(profile),
+        save: () => okAsync(undefined),
+      };
+      const result = await mock.getDefault();
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toBe(profile);
+    });
+
+    it('returns a notFoundError when the default profile is not initialized', async () => {
+      const mock: ExtensionProfileRepository = {
+        getDefault: () =>
+          errAsync<ExtensionProfile, DomainError>(
+            notFoundError({ resourceType: 'ExtensionProfile', identifier: 'default' }),
+          ),
+        save: () => okAsync(undefined),
+      };
+      const result = await mock.getDefault();
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe('not-found');
+        if (result.error.kind === 'not-found') {
+          expect(result.error.resourceType).toBe('ExtensionProfile');
+          expect(result.error.identifier).toBe('default');
+        }
+      }
+    });
+  });
+
+  describe('save', () => {
+    it('resolves to ok(void) on the success path (upsert semantics)', async () => {
+      const mock: ExtensionProfileRepository = {
+        getDefault: () => okAsync(buildProfile()),
+        save: () => okAsync(undefined),
+      };
+      const result = await mock.save(buildProfile());
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toBeUndefined();
+    });
+  });
+});

--- a/packages/extension/src/domain/repositories/extension-profile-repository.ts
+++ b/packages/extension/src/domain/repositories/extension-profile-repository.ts
@@ -1,0 +1,24 @@
+import { type ResultAsync } from 'neverthrow';
+import { type ExtensionProfile } from '../profile/extension-profile.js';
+import { type DomainError } from '../shared/errors.js';
+
+/**
+ * 拡張プロファイルリポジトリ (DD-262)。
+ *
+ * 拡張全体の既定値 (言語ペア / オーバーレイ設定 / 自動判定有無) を保持する
+ * `ExtensionProfile` 集約の永続化契約。MVP ではシングルプロファイル想定で
+ * `chrome.storage.local` にマッピングされる (DD-107 ChromeLocalSettingsStore)。
+ *
+ * エラー:
+ * - `getDefault`: 初回起動・未初期化時は
+ *   `notFoundError({ resourceType: 'ExtensionProfile', identifier: 'default' })`
+ *   を Err で返す。呼び出し側は初期化 UseCase で seed する
+ * - `save`: storage quota 超過等の書き込み失敗時は
+ *   `invariantViolationError({ invariant: 'profile-persistence', ... })` を想定
+ *
+ * `save` は upsert (冪等) — create / update の両方で本メソッドを呼ぶ。
+ */
+export type ExtensionProfileRepository = Readonly<{
+  getDefault: () => ResultAsync<ExtensionProfile, DomainError>;
+  save: (profile: ExtensionProfile) => ResultAsync<void, DomainError>;
+}>;

--- a/packages/extension/src/domain/repositories/index.ts
+++ b/packages/extension/src/domain/repositories/index.ts
@@ -1,0 +1,4 @@
+export type { ExtensionProfileRepository } from './extension-profile-repository.js';
+export type { ExportRecordRepository } from './export-record-repository.js';
+export type { SourceSessionRepository } from './source-session-repository.js';
+export type { TranscriptStreamRepository } from './transcript-stream-repository.js';

--- a/packages/extension/src/domain/repositories/source-session-repository.test.ts
+++ b/packages/extension/src/domain/repositories/source-session-repository.test.ts
@@ -1,0 +1,117 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { createLanguagePair } from '../session/language-pair.js';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
+import { createSourceSession, type SourceSession } from '../session/source-session.js';
+import { notFoundError, type DomainError } from '../shared/errors.js';
+import { type SourceSessionRepository } from './source-session-repository.js';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SESSION_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const SOURCE_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7B2';
+
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+const languagePair = createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap();
+
+const buildSession = (sessionId: string, sourceId: string): SourceSession =>
+  createSourceSession({
+    sessionIdentifier: sessionId,
+    sourceIdentifier: sourceId,
+    sourceType: 'tab',
+    languagePair,
+    startedAt: '2026-04-21T00:00:00.000Z',
+  })._unsafeUnwrap();
+
+describe('SourceSessionRepository (DD-260)', () => {
+  describe('type contract', () => {
+    it('accepts an object literal that implements findById, findActiveSessions, and save', () => {
+      const mock: SourceSessionRepository = {
+        findById: () => okAsync(buildSession(SESSION_ID, SOURCE_ID)),
+        findActiveSessions: () => okAsync([]),
+        save: () => okAsync(undefined),
+      };
+      expect(typeof mock.findById).toBe('function');
+      expect(typeof mock.findActiveSessions).toBe('function');
+      expect(typeof mock.save).toBe('function');
+    });
+  });
+
+  describe('findById', () => {
+    it('returns the matching SourceSession on the success path', async () => {
+      const session = buildSession(SESSION_ID, SOURCE_ID);
+      const mock: SourceSessionRepository = {
+        findById: () => okAsync(session),
+        findActiveSessions: () => okAsync([]),
+        save: () => okAsync(undefined),
+      };
+      const result = await mock.findById(sessionIdentifier);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toBe(session);
+    });
+
+    it('returns notFoundError when the session does not exist', async () => {
+      const mock: SourceSessionRepository = {
+        findById: (id) =>
+          errAsync<SourceSession, DomainError>(
+            notFoundError({ resourceType: 'SourceSession', identifier: id }),
+          ),
+        findActiveSessions: () => okAsync([]),
+        save: () => okAsync(undefined),
+      };
+      const result = await mock.findById(sessionIdentifier);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe('not-found');
+        if (result.error.kind === 'not-found') {
+          expect(result.error.resourceType).toBe('SourceSession');
+          expect(result.error.identifier).toBe(SESSION_ID);
+        }
+      }
+    });
+  });
+
+  describe('findActiveSessions', () => {
+    it('returns an empty readonly array when no sessions are active (ok([]), not an error)', async () => {
+      const mock: SourceSessionRepository = {
+        findById: () => okAsync(buildSession(SESSION_ID, SOURCE_ID)),
+        findActiveSessions: () => okAsync([]),
+        save: () => okAsync(undefined),
+      };
+      const result = await mock.findActiveSessions();
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toEqual([]);
+    });
+
+    it('returns all active sessions (multiple entries allowed)', async () => {
+      const sessions: readonly SourceSession[] = [
+        buildSession(SESSION_ID, SOURCE_ID),
+        buildSession(SESSION_ID_2, SOURCE_ID_2),
+      ];
+      const mock: SourceSessionRepository = {
+        findById: () => okAsync(sessions[0]!),
+        findActiveSessions: () => okAsync(sessions),
+        save: () => okAsync(undefined),
+      };
+      const result = await mock.findActiveSessions();
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(2);
+        expect(result.value[0]?.sessionIdentifier).toBe(SESSION_ID);
+        expect(result.value[1]?.sessionIdentifier).toBe(SESSION_ID_2);
+      }
+    });
+  });
+
+  describe('save', () => {
+    it('resolves to ok(void) on the success path (upsert for create and update)', async () => {
+      const mock: SourceSessionRepository = {
+        findById: () => okAsync(buildSession(SESSION_ID, SOURCE_ID)),
+        findActiveSessions: () => okAsync([]),
+        save: () => okAsync(undefined),
+      };
+      const result = await mock.save(buildSession(SESSION_ID, SOURCE_ID));
+      expect(result.isOk()).toBe(true);
+    });
+  });
+});

--- a/packages/extension/src/domain/repositories/source-session-repository.ts
+++ b/packages/extension/src/domain/repositories/source-session-repository.ts
@@ -1,0 +1,30 @@
+import { type ResultAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../session/session-identifier.js';
+import { type SourceSession } from '../session/source-session.js';
+import { type DomainError } from '../shared/errors.js';
+
+/**
+ * ソースセッションリポジトリ (DD-260)。
+ *
+ * `SourceSession` 集約ルートの永続化契約。MVP では IndexedDB 内の `sessions`
+ * object store にマッピングされる (DB-001)。`save` は create / update 双方で
+ * 呼ばれる upsert セマンティクスを持つ。
+ *
+ * エラー:
+ * - `findById`: 指定セッションが存在しない場合
+ *   `notFoundError({ resourceType: 'SourceSession', identifier })` を Err で返す
+ * - `findActiveSessions`: **0 件は `ok([])` で返す** (active セッションなしは
+ *   正常ケース)。storage 読み込み整合失敗時は
+ *   `invariantViolationError({ invariant: 'storage-read-integrity', ... })` を想定
+ * - `save`: storage quota 超過等の書き込み失敗時は
+ *   `invariantViolationError` を想定
+ *
+ * アクティブの定義は `domain/services/session-concurrency-policy.ts` の
+ * `isActiveSession` に準拠 (`stopped` 以外の状態)。実装側が該当ロジックを
+ * 再利用する。
+ */
+export type SourceSessionRepository = Readonly<{
+  findById: (sessionIdentifier: SessionIdentifier) => ResultAsync<SourceSession, DomainError>;
+  findActiveSessions: () => ResultAsync<readonly SourceSession[], DomainError>;
+  save: (session: SourceSession) => ResultAsync<void, DomainError>;
+}>;

--- a/packages/extension/src/domain/repositories/transcript-stream-repository.test.ts
+++ b/packages/extension/src/domain/repositories/transcript-stream-repository.test.ts
@@ -1,0 +1,146 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
+import { invariantViolationError, notFoundError, type DomainError } from '../shared/errors.js';
+import { createTimestampRange } from '../transcript/timestamp-range.js';
+import {
+  createPartialTranscriptSegment,
+  finalizeTranscriptSegment,
+  type TranscriptSegment,
+} from '../transcript/transcript-segment.js';
+import { createTranscriptStream, type TranscriptStream } from '../transcript/transcript-stream.js';
+import {
+  createCompletedTranslationSegment,
+  type TranslationSegment,
+} from '../transcript/translation-segment.js';
+import { type TranscriptStreamRepository } from './transcript-stream-repository.js';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+const TRANSLATION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7E1';
+
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const buildStream = (): TranscriptStream =>
+  createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+
+const buildPartialSegment = (): TranscriptSegment =>
+  createPartialTranscriptSegment({
+    segmentIdentifier: SEGMENT_ID,
+    revision: 1,
+    text: 'hello',
+    timeRange: createTimestampRange({ startMs: 0, endMs: 1500 })._unsafeUnwrap(),
+  })._unsafeUnwrap();
+
+const buildFinalSegment = (): TranscriptSegment =>
+  finalizeTranscriptSegment(buildPartialSegment(), {})._unsafeUnwrap();
+
+const buildCompletedTranslation = (): TranslationSegment =>
+  createCompletedTranslationSegment({
+    translationIdentifier: TRANSLATION_ID,
+    segmentIdentifier: SEGMENT_ID,
+    targetLanguage: 'ja-JP',
+    text: 'こんにちは',
+  })._unsafeUnwrap();
+
+const okMock: TranscriptStreamRepository = {
+  findBySessionId: () => okAsync(buildStream()),
+  appendPartial: () => okAsync(undefined),
+  appendFinal: () => okAsync(undefined),
+  appendTranslation: () => okAsync(undefined),
+};
+
+describe('TranscriptStreamRepository (DD-261)', () => {
+  describe('type contract', () => {
+    it('accepts an object literal that implements all four required methods', () => {
+      expect(typeof okMock.findBySessionId).toBe('function');
+      expect(typeof okMock.appendPartial).toBe('function');
+      expect(typeof okMock.appendFinal).toBe('function');
+      expect(typeof okMock.appendTranslation).toBe('function');
+    });
+  });
+
+  describe('findBySessionId', () => {
+    it('returns the TranscriptStream on the success path', async () => {
+      const stream = buildStream();
+      const mock: TranscriptStreamRepository = {
+        ...okMock,
+        findBySessionId: () => okAsync(stream),
+      };
+      const result = await mock.findBySessionId(sessionIdentifier);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toBe(stream);
+    });
+
+    it('returns notFoundError when no stream exists for the session', async () => {
+      const mock: TranscriptStreamRepository = {
+        ...okMock,
+        findBySessionId: (id) =>
+          errAsync<TranscriptStream, DomainError>(
+            notFoundError({ resourceType: 'TranscriptStream', identifier: id }),
+          ),
+      };
+      const result = await mock.findBySessionId(sessionIdentifier);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe('not-found');
+        if (result.error.kind === 'not-found') {
+          expect(result.error.resourceType).toBe('TranscriptStream');
+        }
+      }
+    });
+  });
+
+  describe('appendPartial', () => {
+    it('resolves to ok(void) on the success path', async () => {
+      const result = await okMock.appendPartial(sessionIdentifier, buildPartialSegment());
+      expect(result.isOk()).toBe(true);
+    });
+  });
+
+  describe('appendFinal', () => {
+    it('resolves to ok(void) when given a finalized segment', async () => {
+      const result = await okMock.appendFinal(sessionIdentifier, buildFinalSegment());
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('can return invariantViolationError as a defensive guard for non-final segments', async () => {
+      const mock: TranscriptStreamRepository = {
+        ...okMock,
+        appendFinal: () =>
+          errAsync<void, DomainError>(
+            invariantViolationError({
+              invariant: 'append-final-requires-final-segment',
+              details: 'segment.isFinal must be true',
+            }),
+          ),
+      };
+      const result = await mock.appendFinal(sessionIdentifier, buildPartialSegment());
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    });
+  });
+
+  describe('appendTranslation', () => {
+    it('resolves to ok(void) for a completed translation attached to a final segment', async () => {
+      const result = await okMock.appendTranslation(sessionIdentifier, buildCompletedTranslation());
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('can return invariantViolationError when the target final segment is missing', async () => {
+      const mock: TranscriptStreamRepository = {
+        ...okMock,
+        appendTranslation: () =>
+          errAsync<void, DomainError>(
+            invariantViolationError({
+              invariant: 'translation-requires-final-segment',
+              details: 'no matching finalized segment in stream',
+            }),
+          ),
+      };
+      const result = await mock.appendTranslation(sessionIdentifier, buildCompletedTranslation());
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    });
+  });
+});

--- a/packages/extension/src/domain/repositories/transcript-stream-repository.ts
+++ b/packages/extension/src/domain/repositories/transcript-stream-repository.ts
@@ -1,0 +1,45 @@
+import { type ResultAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../session/session-identifier.js';
+import { type DomainError } from '../shared/errors.js';
+import { type TranscriptSegment } from '../transcript/transcript-segment.js';
+import { type TranscriptStream } from '../transcript/transcript-stream.js';
+import { type TranslationSegment } from '../transcript/translation-segment.js';
+
+/**
+ * 字幕ストリームリポジトリ (DD-261)。
+ *
+ * `TranscriptStream` 集約の永続化契約。MVP では IndexedDB 内の
+ * `transcript_segments` / `translation_segments` object store にマッピングされる
+ * (DB-002 / DB-003)。append-only 設計 (CLAUDE.md §データ保存方針) に従い、
+ * 集約全体を置き換える `save` は提供せず、細粒度 append 操作のみを公開する。
+ *
+ * ドメイン不変条件 (`domain/transcript/transcript-stream.ts` 参照) は集約側で
+ * 既に保証されているため、リポジトリは完全なエンティティ値を受け取る契約。
+ * infrastructure 側の防御チェックとして以下を期待する:
+ *
+ * - `appendFinal`: `segment.isFinal === true` を検証。違反時
+ *   `invariantViolationError({ invariant: 'append-final-requires-final-segment' })`
+ * - `appendTranslation`: 対応する final segment が存在することを検証。
+ *   違反時 `invariantViolationError({ invariant: 'translation-requires-final-segment' })`
+ *
+ * エラー:
+ * - `findBySessionId`: セッションに紐づくストリーム未作成時
+ *   `notFoundError({ resourceType: 'TranscriptStream', identifier: sessionIdentifier })`
+ */
+export type TranscriptStreamRepository = Readonly<{
+  findBySessionId: (
+    sessionIdentifier: SessionIdentifier,
+  ) => ResultAsync<TranscriptStream, DomainError>;
+  appendPartial: (
+    sessionIdentifier: SessionIdentifier,
+    segment: TranscriptSegment,
+  ) => ResultAsync<void, DomainError>;
+  appendFinal: (
+    sessionIdentifier: SessionIdentifier,
+    segment: TranscriptSegment,
+  ) => ResultAsync<void, DomainError>;
+  appendTranslation: (
+    sessionIdentifier: SessionIdentifier,
+    translation: TranslationSegment,
+  ) => ResultAsync<void, DomainError>;
+}>;


### PR DESCRIPTION
## Summary

Phase 1 §3.5 として 4 リポジトリインターフェース (DD-260〜263) をドメイン層の永続化ポートとして定義。infrastructure 層 (IndexedDB / chrome.storage.local) が実装する抽象型。オニオンアーキテクチャに従い、ドメイン層は外部依存を持たず interface のみを宣言。

- **IMPL-142 `ExtensionProfileRepository` (DD-262)** — `getDefault` / `save` (upsert)
- **IMPL-143 `ExportRecordRepository` (DD-263)** — `save` / `findBySessionId` (0 件 = `ok([])`)
- **IMPL-140 `SourceSessionRepository` (DD-260)** — `findById` / `findActiveSessions` / `save` (upsert)
- **IMPL-141 `TranscriptStreamRepository` (DD-261)** — `findBySessionId` / `appendPartial` / `appendFinal` / `appendTranslation` (append-only 設計)

### 設計上の判断

- **配置**: `domain/repositories/` (Phase 2 の出力ポート `domain/ports/` と用語分離)
- **interface 定義**: TypeScript `type` で関数プロパティ集合 (オブジェクトリテラルによる mock 生成容易、class 階層回避)
- **非同期性**: 全メソッドを `ResultAsync<T, DomainError>` 返却で統一 (既存 `Result` を返す domain service と `.andThen` で合成可能)
- **not-found ハンドリング**: `findById` / `findBySessionId` / `getDefault` は未存在時 `notFoundError` を Err (`undefined` は返さない)
- **list 系**: 0 件を `ok([])` で正常ケースとして返却
- **append 系**: 完全なドメインエンティティを引数に取る (primitive をばらさない)
- **barrel export**: `index.ts` で `export type { Foo } from './foo.js'` の個別 re-export 形式

### 依存方向

`domain/repositories/` → `domain/session/` / `domain/transcript/` / `domain/profile/` / `domain/export/` / `domain/shared/` の片方向。application / infrastructure への逆依存なし (オニオン原則)。

## Test plan

- [x] `pnpm --filter @perapera/extension test` → 268 tests pass (27 test files、既存 245 から +23 新規)
- [x] `pnpm --filter @perapera/extension test:coverage`
  - `domain/repositories/` 全 4 ファイル: statements/branches/functions/lines **100%**
  - 全体: 96.27% / 97.69% / 98.64% / 96.27% (Phase 1 目標 90%+ 大幅達成)
- [x] `pnpm check` (fmt:check + lint + typecheck + test) 全緑
- [ ] CI `All Green` 通過