### PR TITLE
feat(domain): IMPL-150〜153 specifications and policy refactor

### DIFF
--- a/packages/extension/src/domain/events/domain-events.test.ts
+++ b/packages/extension/src/domain/events/domain-events.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from '../session/language-pair.js';
-import { createSourceSession } from '../session/source-session.js';
-import { createPartialTranscriptSegment } from '../transcript/transcript-segment.js';
-import { createTimestampRange } from '../transcript/timestamp-range.js';
-import { createCompletedTranslationSegment } from '../transcript/translation-segment.js';
+import { createLanguagePair } from '../session/language-pair';
+import { createSourceSession } from '../session/source-session';
+import { createPartialTranscriptSegment } from '../transcript/transcript-segment';
+import { createTimestampRange } from '../transcript/timestamp-range';
+import { createCompletedTranslationSegment } from '../transcript/translation-segment';
 import {
   sourceSessionDegraded,
   sourceSessionStarted,
@@ -12,7 +12,7 @@ import {
   transcriptPartialUpdated,
   translationCompleted,
   type DomainEvent,
-} from './domain-events.js';
+} from './domain-events';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';

--- a/packages/extension/src/domain/events/domain-events.ts
+++ b/packages/extension/src/domain/events/domain-events.ts
@@ -1,11 +1,11 @@
-import { type SessionIdentifier } from '../session/session-identifier.js';
-import { type SourceIdentifier } from '../session/source-identifier.js';
-import { type SourceSession } from '../session/source-session.js';
-import { type SourceType } from '../session/source-type.js';
-import { type SegmentIdentifier } from '../transcript/segment-identifier.js';
-import { type TranscriptSegment } from '../transcript/transcript-segment.js';
-import { type TranslationIdentifier } from '../transcript/translation-identifier.js';
-import { type TranslationSegment } from '../transcript/translation-segment.js';
+import { type SessionIdentifier } from '../session/session-identifier';
+import { type SourceIdentifier } from '../session/source-identifier';
+import { type SourceSession } from '../session/source-session';
+import { type SourceType } from '../session/source-type';
+import { type SegmentIdentifier } from '../transcript/segment-identifier';
+import { type TranscriptSegment } from '../transcript/transcript-segment';
+import { type TranslationIdentifier } from '../transcript/translation-identifier';
+import { type TranslationSegment } from '../transcript/translation-segment';
 
 /**
  * ドメインイベント (DD-250〜DD-255)。

--- a/packages/extension/src/domain/export/export-identifier.test.ts
+++ b/packages/extension/src/domain/export/export-identifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createExportIdentifier, parseExportIdentifier } from './export-identifier.js';
+import { createExportIdentifier, parseExportIdentifier } from './export-identifier';
 
 describe('ExportIdentifier', () => {
   it('creates a ULID-shaped identifier', () => {

--- a/packages/extension/src/domain/export/export-identifier.ts
+++ b/packages/extension/src/domain/export/export-identifier.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
 import { ulid } from 'ulid';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * エクスポートレコード (`ExportRecord`, DD-223) の識別子。

--- a/packages/extension/src/domain/export/export-record.test.ts
+++ b/packages/extension/src/domain/export/export-record.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createExportRecord, EXPORT_FORMATS } from './export-record.js';
+import { createExportRecord, EXPORT_FORMATS } from './export-record';
 
 const VALID_EXPORT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 const VALID_SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X9';

--- a/packages/extension/src/domain/export/export-record.ts
+++ b/packages/extension/src/domain/export/export-record.ts
@@ -1,8 +1,8 @@
 import { err, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
-import { type DomainError, validationError } from '../shared/errors.js';
-import { parseExportIdentifier, type ExportIdentifier } from './export-identifier.js';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier';
+import { type DomainError, validationError } from '../shared/errors';
+import { parseExportIdentifier, type ExportIdentifier } from './export-identifier';
 
 /**
  * エクスポート形式の列挙 (DD-273 ExportFormatSpecification)。

--- a/packages/extension/src/domain/profile/extension-profile.test.ts
+++ b/packages/extension/src/domain/profile/extension-profile.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from '../session/language-pair.js';
+import { createLanguagePair } from '../session/language-pair';
 import {
   createExtensionProfile,
   updateDefaultLanguagePair,
   updateDefaultOverlaySettings,
   toggleAutoDetect,
-} from './extension-profile.js';
-import { createOverlaySettings } from './overlay-settings.js';
+} from './extension-profile';
+import { createOverlaySettings } from './overlay-settings';
 
 const PROFILE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 const defaultLanguagePair = createLanguagePair({

--- a/packages/extension/src/domain/profile/extension-profile.ts
+++ b/packages/extension/src/domain/profile/extension-profile.ts
@@ -1,8 +1,8 @@
 import { ok, type Result } from 'neverthrow';
-import { type LanguagePair } from '../session/language-pair.js';
-import { type DomainError } from '../shared/errors.js';
-import { type OverlaySettings } from './overlay-settings.js';
-import { parseProfileIdentifier, type ProfileIdentifier } from './profile-identifier.js';
+import { type LanguagePair } from '../session/language-pair';
+import { type DomainError } from '../shared/errors';
+import { type OverlaySettings } from './overlay-settings';
+import { parseProfileIdentifier, type ProfileIdentifier } from './profile-identifier';
 
 /**
  * 拡張プロファイル集約ルート (DD-212)。

--- a/packages/extension/src/domain/profile/overlay-settings.test.ts
+++ b/packages/extension/src/domain/profile/overlay-settings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createOverlaySettings } from './overlay-settings.js';
+import { createOverlaySettings } from './overlay-settings';
 
 const baseValid = {
   positionPreset: 'bottom' as const,

--- a/packages/extension/src/domain/profile/overlay-settings.ts
+++ b/packages/extension/src/domain/profile/overlay-settings.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 翻訳オーバーレイの表示設定 (DD-234)。

--- a/packages/extension/src/domain/profile/profile-identifier.ts
+++ b/packages/extension/src/domain/profile/profile-identifier.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
 import { ulid } from 'ulid';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 拡張プロファイル集約 (`ExtensionProfile`, DD-212) の識別子。

--- a/packages/extension/src/domain/repositories/export-record-repository.test.ts
+++ b/packages/extension/src/domain/repositories/export-record-repository.test.ts
@@ -1,9 +1,9 @@
 import { errAsync, okAsync } from 'neverthrow';
 import { describe, expect, it } from 'vitest';
-import { createExportRecord, type ExportRecord } from '../export/export-record.js';
-import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
-import { invariantViolationError, type DomainError } from '../shared/errors.js';
-import { type ExportRecordRepository } from './export-record-repository.js';
+import { createExportRecord, type ExportRecord } from '../export/export-record';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier';
+import { invariantViolationError, type DomainError } from '../shared/errors';
+import { type ExportRecordRepository } from './export-record-repository';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const EXPORT_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7F1';

--- a/packages/extension/src/domain/repositories/export-record-repository.ts
+++ b/packages/extension/src/domain/repositories/export-record-repository.ts
@@ -1,7 +1,7 @@
 import { type ResultAsync } from 'neverthrow';
-import { type ExportRecord } from '../export/export-record.js';
-import { type SessionIdentifier } from '../session/session-identifier.js';
-import { type DomainError } from '../shared/errors.js';
+import { type ExportRecord } from '../export/export-record';
+import { type SessionIdentifier } from '../session/session-identifier';
+import { type DomainError } from '../shared/errors';
 
 /**
  * エクスポート履歴リポジトリ (DD-263)。

--- a/packages/extension/src/domain/repositories/extension-profile-repository.test.ts
+++ b/packages/extension/src/domain/repositories/extension-profile-repository.test.ts
@@ -1,10 +1,10 @@
 import { errAsync, okAsync } from 'neverthrow';
 import { describe, expect, it } from 'vitest';
-import { createExtensionProfile, type ExtensionProfile } from '../profile/extension-profile.js';
-import { createOverlaySettings } from '../profile/overlay-settings.js';
-import { createLanguagePair } from '../session/language-pair.js';
-import { notFoundError, type DomainError } from '../shared/errors.js';
-import { type ExtensionProfileRepository } from './extension-profile-repository.js';
+import { createExtensionProfile, type ExtensionProfile } from '../profile/extension-profile';
+import { createOverlaySettings } from '../profile/overlay-settings';
+import { createLanguagePair } from '../session/language-pair';
+import { notFoundError, type DomainError } from '../shared/errors';
+import { type ExtensionProfileRepository } from './extension-profile-repository';
 
 const PROFILE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
 

--- a/packages/extension/src/domain/repositories/extension-profile-repository.ts
+++ b/packages/extension/src/domain/repositories/extension-profile-repository.ts
@@ -1,6 +1,6 @@
 import { type ResultAsync } from 'neverthrow';
-import { type ExtensionProfile } from '../profile/extension-profile.js';
-import { type DomainError } from '../shared/errors.js';
+import { type ExtensionProfile } from '../profile/extension-profile';
+import { type DomainError } from '../shared/errors';
 
 /**
  * 拡張プロファイルリポジトリ (DD-262)。

--- a/packages/extension/src/domain/repositories/index.ts
+++ b/packages/extension/src/domain/repositories/index.ts
@@ -1,4 +1,4 @@
-export type { ExtensionProfileRepository } from './extension-profile-repository.js';
-export type { ExportRecordRepository } from './export-record-repository.js';
-export type { SourceSessionRepository } from './source-session-repository.js';
-export type { TranscriptStreamRepository } from './transcript-stream-repository.js';
+export type { ExtensionProfileRepository } from './extension-profile-repository';
+export type { ExportRecordRepository } from './export-record-repository';
+export type { SourceSessionRepository } from './source-session-repository';
+export type { TranscriptStreamRepository } from './transcript-stream-repository';

--- a/packages/extension/src/domain/repositories/source-session-repository.test.ts
+++ b/packages/extension/src/domain/repositories/source-session-repository.test.ts
@@ -1,10 +1,10 @@
 import { errAsync, okAsync } from 'neverthrow';
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from '../session/language-pair.js';
-import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
-import { createSourceSession, type SourceSession } from '../session/source-session.js';
-import { notFoundError, type DomainError } from '../shared/errors.js';
-import { type SourceSessionRepository } from './source-session-repository.js';
+import { createLanguagePair } from '../session/language-pair';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier';
+import { createSourceSession, type SourceSession } from '../session/source-session';
+import { notFoundError, type DomainError } from '../shared/errors';
+import { type SourceSessionRepository } from './source-session-repository';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const SESSION_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';

--- a/packages/extension/src/domain/repositories/source-session-repository.ts
+++ b/packages/extension/src/domain/repositories/source-session-repository.ts
@@ -1,7 +1,7 @@
 import { type ResultAsync } from 'neverthrow';
-import { type SessionIdentifier } from '../session/session-identifier.js';
-import { type SourceSession } from '../session/source-session.js';
-import { type DomainError } from '../shared/errors.js';
+import { type SessionIdentifier } from '../session/session-identifier';
+import { type SourceSession } from '../session/source-session';
+import { type DomainError } from '../shared/errors';
 
 /**
  * ソースセッションリポジトリ (DD-260)。

--- a/packages/extension/src/domain/repositories/transcript-stream-repository.test.ts
+++ b/packages/extension/src/domain/repositories/transcript-stream-repository.test.ts
@@ -1,19 +1,19 @@
 import { errAsync, okAsync } from 'neverthrow';
 import { describe, expect, it } from 'vitest';
-import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
-import { invariantViolationError, notFoundError, type DomainError } from '../shared/errors.js';
-import { createTimestampRange } from '../transcript/timestamp-range.js';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier';
+import { invariantViolationError, notFoundError, type DomainError } from '../shared/errors';
+import { createTimestampRange } from '../transcript/timestamp-range';
 import {
   createPartialTranscriptSegment,
   finalizeTranscriptSegment,
   type TranscriptSegment,
-} from '../transcript/transcript-segment.js';
-import { createTranscriptStream, type TranscriptStream } from '../transcript/transcript-stream.js';
+} from '../transcript/transcript-segment';
+import { createTranscriptStream, type TranscriptStream } from '../transcript/transcript-stream';
 import {
   createCompletedTranslationSegment,
   type TranslationSegment,
-} from '../transcript/translation-segment.js';
-import { type TranscriptStreamRepository } from './transcript-stream-repository.js';
+} from '../transcript/translation-segment';
+import { type TranscriptStreamRepository } from './transcript-stream-repository';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';

--- a/packages/extension/src/domain/repositories/transcript-stream-repository.ts
+++ b/packages/extension/src/domain/repositories/transcript-stream-repository.ts
@@ -1,9 +1,9 @@
 import { type ResultAsync } from 'neverthrow';
-import { type SessionIdentifier } from '../session/session-identifier.js';
-import { type DomainError } from '../shared/errors.js';
-import { type TranscriptSegment } from '../transcript/transcript-segment.js';
-import { type TranscriptStream } from '../transcript/transcript-stream.js';
-import { type TranslationSegment } from '../transcript/translation-segment.js';
+import { type SessionIdentifier } from '../session/session-identifier';
+import { type DomainError } from '../shared/errors';
+import { type TranscriptSegment } from '../transcript/transcript-segment';
+import { type TranscriptStream } from '../transcript/transcript-stream';
+import { type TranslationSegment } from '../transcript/translation-segment';
 
 /**
  * 字幕ストリームリポジトリ (DD-261)。

--- a/packages/extension/src/domain/services/export-assembly-service.test.ts
+++ b/packages/extension/src/domain/services/export-assembly-service.test.ts
@@ -5,13 +5,13 @@ import {
   createTranscriptStream,
   finalizeSegment,
   type TranscriptStream,
-} from '../transcript/transcript-stream.js';
+} from '../transcript/transcript-stream';
 import {
   createFailedTranslationSegment,
   type TranslationSegment,
-} from '../transcript/translation-segment.js';
-import { createTimestampRange, type TimestampRange } from '../transcript/timestamp-range.js';
-import { assembleExport } from './export-assembly-service.js';
+} from '../transcript/translation-segment';
+import { createTimestampRange, type TimestampRange } from '../transcript/timestamp-range';
+import { assembleExport } from './export-assembly-service';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
 const SEGMENT_IDS = [

--- a/packages/extension/src/domain/services/export-assembly-service.ts
+++ b/packages/extension/src/domain/services/export-assembly-service.ts
@@ -1,9 +1,9 @@
 import { err, ok, type Result } from 'neverthrow';
-import { type ExportFormat } from '../export/export-record.js';
-import { type TranscriptSegment } from '../transcript/transcript-segment.js';
-import { type TranscriptStream } from '../transcript/transcript-stream.js';
-import { type TranslationSegment } from '../transcript/translation-segment.js';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type ExportFormat } from '../export/export-record';
+import { type TranscriptSegment } from '../transcript/transcript-segment';
+import { type TranscriptStream } from '../transcript/transcript-stream';
+import { type TranslationSegment } from '../transcript/translation-segment';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * エクスポート整形サービス (DD-242)。

--- a/packages/extension/src/domain/services/language-routing-policy.test.ts
+++ b/packages/extension/src/domain/services/language-routing-policy.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { createExtensionProfile, type ExtensionProfile } from '../profile/extension-profile.js';
-import { createOverlaySettings } from '../profile/overlay-settings.js';
-import { createLanguagePair, type LanguagePair } from '../session/language-pair.js';
-import { resolveEffectiveLanguagePair } from './language-routing-policy.js';
+import { createExtensionProfile, type ExtensionProfile } from '../profile/extension-profile';
+import { createOverlaySettings } from '../profile/overlay-settings';
+import { createLanguagePair, type LanguagePair } from '../session/language-pair';
+import { resolveEffectiveLanguagePair } from './language-routing-policy';
 
 const PROFILE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
 

--- a/packages/extension/src/domain/services/language-routing-policy.ts
+++ b/packages/extension/src/domain/services/language-routing-policy.ts
@@ -1,7 +1,7 @@
 import { ok, type Result } from 'neverthrow';
-import { type ExtensionProfile } from '../profile/extension-profile.js';
-import { createLanguagePair, type LanguagePair } from '../session/language-pair.js';
-import { type DomainError } from '../shared/errors.js';
+import { type ExtensionProfile } from '../profile/extension-profile';
+import { createLanguagePair, type LanguagePair } from '../session/language-pair';
+import { type DomainError } from '../shared/errors';
 
 /**
  * 言語ルーティングポリシー (DD-243)。

--- a/packages/extension/src/domain/services/session-concurrency-policy.test.ts
+++ b/packages/extension/src/domain/services/session-concurrency-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from '../session/language-pair.js';
+import { createLanguagePair } from '../session/language-pair';
 import {
   createSourceSession,
   markSourceSessionDegraded,
@@ -8,9 +8,9 @@ import {
   stopSourceSession,
   transitionSourceSessionState,
   type SourceSession,
-} from '../session/source-session.js';
-import { type SessionState } from '../session/session-state.js';
-import { validateSessionConcurrency } from './session-concurrency-policy.js';
+} from '../session/source-session';
+import { type SessionState } from '../session/session-state';
+import { validateSessionConcurrency } from './session-concurrency-policy';
 
 const SESSION_IDS = [
   '01HZX8Y1R8M7D3Q2P4T5V6W7A1',

--- a/packages/extension/src/domain/services/session-concurrency-policy.ts
+++ b/packages/extension/src/domain/services/session-concurrency-policy.ts
@@ -1,47 +1,36 @@
 import { err, ok, type Result } from 'neverthrow';
 import { type SourceSession } from '../session/source-session.js';
-import { type SessionState } from '../session/session-state.js';
 import { type DomainError, invariantViolationError } from '../shared/errors.js';
+import {
+  MAX_CONCURRENT_ACTIVE_SESSIONS,
+  countActiveSessions,
+  satisfiesConcurrentSessionLimit,
+} from '../specifications/concurrent-session-limit-specification.js';
 
 /**
  * セッション並行度ポリシー (DD-240)。
  *
- * 設計文書: domain.md DD-240, DD-270 (ConcurrentSessionLimitSpecification)。
- * `SourceSession` が同時にアクティブに保持できる数の上限 (3) を保証する。
+ * Specification (DD-270, `domain/specifications/concurrent-session-limit-specification.ts`)
+ * を利用して不変条件を検証し、違反時に `DomainError` を組み立てる責務を持つ。
  *
- * アクティブ = `stopped` 以外の状態。`error` も「acknowledge() → stopped」で
- * 終了させるまではリソースを保持しているため稼働中として扱う。
+ * 使用箇所: `StartSourceSessionUseCase` の事前条件チェック
+ * (use-case.md §10.1 `Policy.validate()`)。
  *
- * IMPL-150 `ConcurrentSessionLimitSpecification` 実装時に、`isActiveSession` /
- * `countActiveSessions` を述語 spec へ移動し、本ポリシーはそれを利用する形に
- * リファクタされる予定。
- */
-export const MAX_CONCURRENT_ACTIVE_SESSIONS = 3 as const;
-
-const TERMINAL_STATES: ReadonlySet<SessionState> = new Set(['stopped']);
-
-export const isActiveSession = (session: SourceSession): boolean =>
-  !TERMINAL_STATES.has(session.state);
-
-export const countActiveSessions = (sessions: readonly SourceSession[]): number =>
-  sessions.reduce((count, session) => (isActiveSession(session) ? count + 1 : count), 0);
-
-/**
- * セッション追加前の事前条件チェック。既存アクティブ数が上限未満なら OK。
- * use-case.md §10.1 `StartSourceSessionUseCase` のシーケンスで
- * `Policy.validate()` として呼ばれる想定。
+ * 責務分担:
+ * - Specification = 純粋述語 (`satisfiesConcurrentSessionLimit` 等)
+ * - Policy = 違反時に `invariantViolationError` を組み立てる本モジュール
  */
 export const validateSessionConcurrency = (
   existingSessions: readonly SourceSession[],
 ): Result<void, DomainError> => {
-  const activeCount = countActiveSessions(existingSessions);
-  if (activeCount >= MAX_CONCURRENT_ACTIVE_SESSIONS) {
-    return err(
-      invariantViolationError({
-        invariant: 'concurrent-session-limit',
-        details: `active session count ${String(activeCount)} would exceed limit ${String(MAX_CONCURRENT_ACTIVE_SESSIONS)}`,
-      }),
-    );
+  if (satisfiesConcurrentSessionLimit(existingSessions)) {
+    return ok(undefined);
   }
-  return ok(undefined);
+  const activeCount = countActiveSessions(existingSessions);
+  return err(
+    invariantViolationError({
+      invariant: 'concurrent-session-limit',
+      details: `active session count ${String(activeCount)} would exceed limit ${String(MAX_CONCURRENT_ACTIVE_SESSIONS)}`,
+    }),
+  );
 };

--- a/packages/extension/src/domain/services/session-concurrency-policy.ts
+++ b/packages/extension/src/domain/services/session-concurrency-policy.ts
@@ -1,11 +1,11 @@
 import { err, ok, type Result } from 'neverthrow';
-import { type SourceSession } from '../session/source-session.js';
-import { type DomainError, invariantViolationError } from '../shared/errors.js';
+import { type SourceSession } from '../session/source-session';
+import { type DomainError, invariantViolationError } from '../shared/errors';
 import {
   MAX_CONCURRENT_ACTIVE_SESSIONS,
   countActiveSessions,
   satisfiesConcurrentSessionLimit,
-} from '../specifications/concurrent-session-limit-specification.js';
+} from '../specifications/concurrent-session-limit-specification';
 
 /**
  * セッション並行度ポリシー (DD-240)。

--- a/packages/extension/src/domain/services/session-state-transition-policy.test.ts
+++ b/packages/extension/src/domain/services/session-state-transition-policy.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { SESSION_STATES, type SessionState } from '../session/session-state.js';
+import { SESSION_STATES, type SessionState } from '../session/session-state';
 import {
   ALLOWED_TRANSITIONS,
   canTransitionSessionState,
   validateSessionStateTransition,
-} from './session-state-transition-policy.js';
+} from './session-state-transition-policy';
 
 /**
  * 状態遷移表 (detailed-design.md §7.2) を網羅的に検証する。

--- a/packages/extension/src/domain/services/session-state-transition-policy.ts
+++ b/packages/extension/src/domain/services/session-state-transition-policy.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from 'neverthrow';
-import { type SessionState } from '../session/session-state.js';
-import { type DomainError, sessionStateTransitionError } from '../shared/errors.js';
+import { type SessionState } from '../session/session-state';
+import { type DomainError, sessionStateTransitionError } from '../shared/errors';
 
 /**
  * ソースセッション状態遷移ポリシー (DD-241)。

--- a/packages/extension/src/domain/session/language-pair.test.ts
+++ b/packages/extension/src/domain/session/language-pair.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from './language-pair.js';
+import { createLanguagePair } from './language-pair';
 
 describe('LanguagePair', () => {
   it('accepts a valid pair (en-US -> ja-JP)', () => {

--- a/packages/extension/src/domain/session/language-pair.ts
+++ b/packages/extension/src/domain/session/language-pair.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * BCP-47 言語タグの簡易検証。言語コード (2-3 文字小文字) + 任意の地域コード

--- a/packages/extension/src/domain/session/session-identifier.test.ts
+++ b/packages/extension/src/domain/session/session-identifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createSessionIdentifier, parseSessionIdentifier } from './session-identifier.js';
+import { createSessionIdentifier, parseSessionIdentifier } from './session-identifier';
 
 const VALID_ULID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 

--- a/packages/extension/src/domain/session/session-identifier.ts
+++ b/packages/extension/src/domain/session/session-identifier.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
 import { ulid } from 'ulid';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * ソースセッション集約 (DD-210) の自己識別子 (DD-230)。

--- a/packages/extension/src/domain/session/session-state.test.ts
+++ b/packages/extension/src/domain/session/session-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { SESSION_STATES, parseSessionState } from './session-state.js';
+import { SESSION_STATES, parseSessionState } from './session-state';
 
 describe('SessionState', () => {
   it('enumerates exactly 11 states (DD-233)', () => {

--- a/packages/extension/src/domain/session/session-state.ts
+++ b/packages/extension/src/domain/session/session-state.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * `SourceSession` 集約の状態値 (DD-233 / DD-210)。

--- a/packages/extension/src/domain/session/source-identifier.test.ts
+++ b/packages/extension/src/domain/session/source-identifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createSourceIdentifier, parseSourceIdentifier } from './source-identifier.js';
+import { createSourceIdentifier, parseSourceIdentifier } from './source-identifier';
 
 const VALID_ULID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 

--- a/packages/extension/src/domain/session/source-identifier.ts
+++ b/packages/extension/src/domain/session/source-identifier.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
 import { ulid } from 'ulid';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 音声ソース (`AudioSource`) の識別子 (DD-231)。

--- a/packages/extension/src/domain/session/source-session.test.ts
+++ b/packages/extension/src/domain/session/source-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from './language-pair.js';
+import { createLanguagePair } from './language-pair';
 import {
   createSourceSession,
   markSourceSessionDegraded,
@@ -9,7 +9,7 @@ import {
   startSourceSession,
   stopSourceSession,
   transitionSourceSessionState,
-} from './source-session.js';
+} from './source-session';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X9';

--- a/packages/extension/src/domain/session/source-session.ts
+++ b/packages/extension/src/domain/session/source-session.ts
@@ -3,17 +3,13 @@ import { z } from 'zod';
 import {
   canTransitionSessionState,
   validateSessionStateTransition,
-} from '../services/session-state-transition-policy.js';
-import {
-  type DomainError,
-  sessionStateTransitionError,
-  validationError,
-} from '../shared/errors.js';
-import { type LanguagePair } from './language-pair.js';
-import { parseSessionIdentifier, type SessionIdentifier } from './session-identifier.js';
-import { type SessionState } from './session-state.js';
-import { parseSourceIdentifier, type SourceIdentifier } from './source-identifier.js';
-import { parseSourceType, type SourceType } from './source-type.js';
+} from '../services/session-state-transition-policy';
+import { type DomainError, sessionStateTransitionError, validationError } from '../shared/errors';
+import { type LanguagePair } from './language-pair';
+import { parseSessionIdentifier, type SessionIdentifier } from './session-identifier';
+import { type SessionState } from './session-state';
+import { parseSourceIdentifier, type SourceIdentifier } from './source-identifier';
+import { parseSourceType, type SourceType } from './source-type';
 
 /**
  * ソースセッション集約ルート (DD-210 / DD-220)。

--- a/packages/extension/src/domain/session/source-type.test.ts
+++ b/packages/extension/src/domain/session/source-type.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { SOURCE_TYPES, parseSourceType } from './source-type.js';
+import { SOURCE_TYPES, parseSourceType } from './source-type';
 
 describe('SourceType', () => {
   it('accepts "tab"', () => {

--- a/packages/extension/src/domain/session/source-type.ts
+++ b/packages/extension/src/domain/session/source-type.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 音声ソース種別 (DD-210 ソースセッション集約)。

--- a/packages/extension/src/domain/shared/errors.test.ts
+++ b/packages/extension/src/domain/shared/errors.test.ts
@@ -6,7 +6,7 @@ import {
   sessionStateTransitionError,
   validationError,
   type DomainError,
-} from './errors.js';
+} from './errors';
 
 describe('DomainError factories', () => {
   it('creates a session-state-transition error', () => {

--- a/packages/extension/src/domain/specifications/concurrent-session-limit-specification.test.ts
+++ b/packages/extension/src/domain/specifications/concurrent-session-limit-specification.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from '../session/language-pair.js';
+import { createLanguagePair } from '../session/language-pair';
 import {
   createSourceSession,
   markSourceSessionDegraded,
@@ -8,14 +8,14 @@ import {
   stopSourceSession,
   transitionSourceSessionState,
   type SourceSession,
-} from '../session/source-session.js';
-import { SESSION_STATES, type SessionState } from '../session/session-state.js';
+} from '../session/source-session';
+import { SESSION_STATES, type SessionState } from '../session/session-state';
 import {
   MAX_CONCURRENT_ACTIVE_SESSIONS,
   countActiveSessions,
   isActiveSession,
   satisfiesConcurrentSessionLimit,
-} from './concurrent-session-limit-specification.js';
+} from './concurrent-session-limit-specification';
 
 const SESSION_IDS = [
   '01HZX8Y1R8M7D3Q2P4T5V6W7A1',

--- a/packages/extension/src/domain/specifications/concurrent-session-limit-specification.test.ts
+++ b/packages/extension/src/domain/specifications/concurrent-session-limit-specification.test.ts
@@ -9,8 +9,13 @@ import {
   transitionSourceSessionState,
   type SourceSession,
 } from '../session/source-session.js';
-import { type SessionState } from '../session/session-state.js';
-import { validateSessionConcurrency } from './session-concurrency-policy.js';
+import { SESSION_STATES, type SessionState } from '../session/session-state.js';
+import {
+  MAX_CONCURRENT_ACTIVE_SESSIONS,
+  countActiveSessions,
+  isActiveSession,
+  satisfiesConcurrentSessionLimit,
+} from './concurrent-session-limit-specification.js';
 
 const SESSION_IDS = [
   '01HZX8Y1R8M7D3Q2P4T5V6W7A1',
@@ -91,61 +96,104 @@ const withState = (index: number, targetState: SessionState): SourceSession => {
   }
 };
 
-describe('SessionConcurrencyPolicy (DD-240)', () => {
-  describe('validateSessionConcurrency', () => {
-    it('returns ok for empty active session list', () => {
-      const result = validateSessionConcurrency([]);
-      expect(result.isOk()).toBe(true);
+describe('ConcurrentSessionLimitSpecification (DD-270)', () => {
+  it('exposes MAX_CONCURRENT_ACTIVE_SESSIONS = 3', () => {
+    expect(MAX_CONCURRENT_ACTIVE_SESSIONS).toBe(3);
+  });
+
+  describe('isActiveSession', () => {
+    const ACTIVE: readonly SessionState[] = [
+      'idle',
+      'requesting_permission',
+      'connecting',
+      'capturing',
+      'transcribing',
+      'translating',
+      'paused',
+      'reconnecting',
+      'degraded',
+      'error',
+    ];
+    const TERMINAL: readonly SessionState[] = ['stopped'];
+
+    it.each(ACTIVE)('treats %s as active', (state) => {
+      expect(isActiveSession(withState(0, state))).toBe(true);
     });
 
-    it('returns ok when active count is 1', () => {
-      const result = validateSessionConcurrency([withState(0, 'capturing')]);
-      expect(result.isOk()).toBe(true);
+    it.each(TERMINAL)('treats %s as non-active (terminal)', (state) => {
+      expect(isActiveSession(withState(0, state))).toBe(false);
     });
 
-    it('returns ok when active count is 2 (below limit)', () => {
-      const result = validateSessionConcurrency([
-        withState(0, 'capturing'),
-        withState(1, 'transcribing'),
-      ]);
-      expect(result.isOk()).toBe(true);
-    });
-
-    it('returns err with invariant-violation when active count reaches the limit', () => {
-      const result = validateSessionConcurrency([
-        withState(0, 'capturing'),
-        withState(1, 'transcribing'),
-        withState(2, 'translating'),
-      ]);
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect(result.error.kind).toBe('invariant-violation');
-        if (result.error.kind === 'invariant-violation') {
-          expect(result.error.invariant).toBe('concurrent-session-limit');
-          expect(result.error.details).toContain('3');
-        }
+    it('covers all 11 SessionState variants in the categorization', () => {
+      const covered = new Set<SessionState>([...ACTIVE, ...TERMINAL]);
+      for (const state of SESSION_STATES) {
+        expect(covered.has(state)).toBe(true);
       }
     });
+  });
 
-    it('returns err when active count exceeds the limit', () => {
-      const result = validateSessionConcurrency([
-        withState(0, 'capturing'),
-        withState(1, 'transcribing'),
-        withState(2, 'translating'),
-        withState(3, 'paused'),
-      ]);
-      expect(result.isErr()).toBe(true);
+  describe('countActiveSessions', () => {
+    it('returns 0 for an empty input', () => {
+      expect(countActiveSessions([])).toBe(0);
     });
 
-    it('ignores stopped sessions when evaluating the limit (2 active + 10 stopped → ok)', () => {
-      const result = validateSessionConcurrency([
+    it('counts only active sessions, ignoring stopped ones', () => {
+      const sessions: readonly SourceSession[] = [
         withState(0, 'capturing'),
-        withState(1, 'transcribing'),
-        withState(2, 'stopped'),
-        withState(3, 'stopped'),
-        withState(4, 'stopped'),
-      ]);
-      expect(result.isOk()).toBe(true);
+        withState(1, 'stopped'),
+        withState(2, 'transcribing'),
+      ];
+      expect(countActiveSessions(sessions)).toBe(2);
+    });
+
+    it('returns 0 when all sessions are stopped', () => {
+      const sessions: readonly SourceSession[] = [withState(0, 'stopped'), withState(1, 'stopped')];
+      expect(countActiveSessions(sessions)).toBe(0);
+    });
+  });
+
+  describe('satisfiesConcurrentSessionLimit', () => {
+    it('returns true for an empty session list', () => {
+      expect(satisfiesConcurrentSessionLimit([])).toBe(true);
+    });
+
+    it('returns true when active count is below the limit', () => {
+      expect(
+        satisfiesConcurrentSessionLimit([withState(0, 'capturing'), withState(1, 'transcribing')]),
+      ).toBe(true);
+    });
+
+    it('returns false when active count equals the limit (adding one more would exceed)', () => {
+      expect(
+        satisfiesConcurrentSessionLimit([
+          withState(0, 'capturing'),
+          withState(1, 'transcribing'),
+          withState(2, 'translating'),
+        ]),
+      ).toBe(false);
+    });
+
+    it('returns false when active count exceeds the limit', () => {
+      expect(
+        satisfiesConcurrentSessionLimit([
+          withState(0, 'capturing'),
+          withState(1, 'transcribing'),
+          withState(2, 'translating'),
+          withState(3, 'paused'),
+        ]),
+      ).toBe(false);
+    });
+
+    it('ignores stopped sessions when counting', () => {
+      expect(
+        satisfiesConcurrentSessionLimit([
+          withState(0, 'capturing'),
+          withState(1, 'transcribing'),
+          withState(2, 'stopped'),
+          withState(3, 'stopped'),
+          withState(4, 'stopped'),
+        ]),
+      ).toBe(true);
     });
   });
 });

--- a/packages/extension/src/domain/specifications/concurrent-session-limit-specification.ts
+++ b/packages/extension/src/domain/specifications/concurrent-session-limit-specification.ts
@@ -1,5 +1,5 @@
-import { type SessionState } from '../session/session-state.js';
-import { type SourceSession } from '../session/source-session.js';
+import { type SessionState } from '../session/session-state';
+import { type SourceSession } from '../session/source-session';
 
 /**
  * 同時セッション数仕様 (DD-270)。

--- a/packages/extension/src/domain/specifications/concurrent-session-limit-specification.ts
+++ b/packages/extension/src/domain/specifications/concurrent-session-limit-specification.ts
@@ -1,0 +1,32 @@
+import { type SessionState } from '../session/session-state.js';
+import { type SourceSession } from '../session/source-session.js';
+
+/**
+ * 同時セッション数仕様 (DD-270)。
+ *
+ * 「同時にアクティブなソースは最大 3 まで」を判定する述語群。
+ *
+ * アクティブの定義: `stopped` 以外の状態 (`error` は `acknowledge → stopped`
+ * で終了するまでリソースを保持するため稼働中として扱う)。
+ *
+ * Policy (`domain/services/session-concurrency-policy.ts`) との責務分担:
+ * Specification = 純粋述語 (`boolean` を返す)、Policy = 違反時に
+ * `DomainError` を組み立てる。Policy は本 spec を内部で利用する。
+ */
+
+export const MAX_CONCURRENT_ACTIVE_SESSIONS = 3 as const;
+
+const TERMINAL_STATES: ReadonlySet<SessionState> = new Set(['stopped']);
+
+export const isActiveSession = (session: SourceSession): boolean =>
+  !TERMINAL_STATES.has(session.state);
+
+export const countActiveSessions = (sessions: readonly SourceSession[]): number =>
+  sessions.reduce((count, session) => (isActiveSession(session) ? count + 1 : count), 0);
+
+/**
+ * 新しいアクティブセッションを追加できる余地があるかを判定する述語。
+ * 使用箇所: `StartSourceSessionUseCase` の事前条件 (use-case.md §10.1)。
+ */
+export const satisfiesConcurrentSessionLimit = (sessions: readonly SourceSession[]): boolean =>
+  countActiveSessions(sessions) < MAX_CONCURRENT_ACTIVE_SESSIONS;

--- a/packages/extension/src/domain/specifications/export-format-specification.test.ts
+++ b/packages/extension/src/domain/specifications/export-format-specification.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { isValidExportFormat } from './export-format-specification.js';
+
+describe('ExportFormatSpecification (DD-273)', () => {
+  describe('isValidExportFormat', () => {
+    it('accepts "txt"', () => {
+      expect(isValidExportFormat('txt')).toBe(true);
+    });
+
+    it('accepts "json"', () => {
+      expect(isValidExportFormat('json')).toBe(true);
+    });
+
+    it('rejects unknown string values', () => {
+      expect(isValidExportFormat('csv')).toBe(false);
+      expect(isValidExportFormat('xml')).toBe(false);
+      expect(isValidExportFormat('')).toBe(false);
+      expect(isValidExportFormat('TXT')).toBe(false); // case-sensitive
+    });
+
+    it('rejects non-string values', () => {
+      expect(isValidExportFormat(0)).toBe(false);
+      expect(isValidExportFormat(null)).toBe(false);
+      expect(isValidExportFormat(undefined)).toBe(false);
+      expect(isValidExportFormat({})).toBe(false);
+      expect(isValidExportFormat([])).toBe(false);
+    });
+
+    it('acts as a type guard that narrows unknown to ExportFormat', () => {
+      const candidate: unknown = 'txt';
+      if (isValidExportFormat(candidate)) {
+        // Within this branch, candidate is narrowed to ExportFormat ('txt' | 'json')
+        expect(candidate).toBe('txt');
+      } else {
+        throw new Error('should have been valid');
+      }
+    });
+  });
+});

--- a/packages/extension/src/domain/specifications/export-format-specification.test.ts
+++ b/packages/extension/src/domain/specifications/export-format-specification.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isValidExportFormat } from './export-format-specification.js';
+import { isValidExportFormat } from './export-format-specification';
 
 describe('ExportFormatSpecification (DD-273)', () => {
   describe('isValidExportFormat', () => {

--- a/packages/extension/src/domain/specifications/export-format-specification.ts
+++ b/packages/extension/src/domain/specifications/export-format-specification.ts
@@ -1,4 +1,4 @@
-import { EXPORT_FORMATS, type ExportFormat } from '../export/export-record.js';
+import { EXPORT_FORMATS, type ExportFormat } from '../export/export-record';
 
 /**
  * エクスポート形式仕様 (DD-273)。

--- a/packages/extension/src/domain/specifications/export-format-specification.ts
+++ b/packages/extension/src/domain/specifications/export-format-specification.ts
@@ -1,0 +1,17 @@
+import { EXPORT_FORMATS, type ExportFormat } from '../export/export-record.js';
+
+/**
+ * エクスポート形式仕様 (DD-273)。
+ *
+ * エクスポート形式は TXT / JSON のみ許可する。値オブジェクト定義
+ * (`export-record.ts` の `EXPORT_FORMATS`) に委譲し、spec は runtime 述語
+ * (type guard) を提供する。
+ *
+ * Policy との責務分担: 本 spec は `boolean` を返す純粋述語。違反時の
+ * `DomainError` 組み立ては呼び出し側 (`createExportRecord` の `validationError`
+ * 生成など) が担う。
+ */
+export const isValidExportFormat = (value: unknown): value is ExportFormat => {
+  if (typeof value !== 'string') return false;
+  return EXPORT_FORMATS.some((format) => format === value);
+};

--- a/packages/extension/src/domain/specifications/index.ts
+++ b/packages/extension/src/domain/specifications/index.ts
@@ -3,8 +3,8 @@ export {
   countActiveSessions,
   isActiveSession,
   satisfiesConcurrentSessionLimit,
-} from './concurrent-session-limit-specification.js';
-export { isValidExportFormat } from './export-format-specification.js';
+} from './concurrent-session-limit-specification';
+export { isValidExportFormat } from './export-format-specification';
 export {
   OVERLAY_MIN_LINES,
   OVERLAY_OPACITY_BOUNDS,
@@ -15,5 +15,5 @@ export {
   isValidOverlayOpacity,
   isValidOverlayPositionPreset,
   type OverlayPositionPreset,
-} from './overlay-settings-specification.js';
-export { canAttachTranslation } from './translation-attachment-specification.js';
+} from './overlay-settings-specification';
+export { canAttachTranslation } from './translation-attachment-specification';

--- a/packages/extension/src/domain/specifications/index.ts
+++ b/packages/extension/src/domain/specifications/index.ts
@@ -1,0 +1,19 @@
+export {
+  MAX_CONCURRENT_ACTIVE_SESSIONS,
+  countActiveSessions,
+  isActiveSession,
+  satisfiesConcurrentSessionLimit,
+} from './concurrent-session-limit-specification.js';
+export { isValidExportFormat } from './export-format-specification.js';
+export {
+  OVERLAY_MIN_LINES,
+  OVERLAY_OPACITY_BOUNDS,
+  OVERLAY_POSITION_PRESETS,
+  hasAtLeastOneVisibleText,
+  isValidOverlayFontScale,
+  isValidOverlayMaxLines,
+  isValidOverlayOpacity,
+  isValidOverlayPositionPreset,
+  type OverlayPositionPreset,
+} from './overlay-settings-specification.js';
+export { canAttachTranslation } from './translation-attachment-specification.js';

--- a/packages/extension/src/domain/specifications/overlay-settings-specification.test.ts
+++ b/packages/extension/src/domain/specifications/overlay-settings-specification.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { createOverlaySettings } from '../profile/overlay-settings.js';
+import {
+  OVERLAY_MIN_LINES,
+  OVERLAY_OPACITY_BOUNDS,
+  OVERLAY_POSITION_PRESETS,
+  hasAtLeastOneVisibleText,
+  isValidOverlayFontScale,
+  isValidOverlayMaxLines,
+  isValidOverlayOpacity,
+  isValidOverlayPositionPreset,
+} from './overlay-settings-specification.js';
+
+describe('OverlaySettingsSpecification (DD-272)', () => {
+  describe('isValidOverlayPositionPreset', () => {
+    it.each(OVERLAY_POSITION_PRESETS)('accepts %s', (preset) => {
+      expect(isValidOverlayPositionPreset(preset)).toBe(true);
+    });
+
+    it('rejects unknown string values', () => {
+      expect(isValidOverlayPositionPreset('center')).toBe(false);
+      expect(isValidOverlayPositionPreset('TOP')).toBe(false); // case-sensitive
+      expect(isValidOverlayPositionPreset('')).toBe(false);
+    });
+
+    it('rejects non-string values', () => {
+      expect(isValidOverlayPositionPreset(0)).toBe(false);
+      expect(isValidOverlayPositionPreset(null)).toBe(false);
+      expect(isValidOverlayPositionPreset(undefined)).toBe(false);
+    });
+  });
+
+  describe('isValidOverlayOpacity', () => {
+    it('accepts the boundary values 0 and 1', () => {
+      expect(isValidOverlayOpacity(OVERLAY_OPACITY_BOUNDS.min)).toBe(true);
+      expect(isValidOverlayOpacity(OVERLAY_OPACITY_BOUNDS.max)).toBe(true);
+    });
+
+    it('accepts mid-range values', () => {
+      expect(isValidOverlayOpacity(0.5)).toBe(true);
+      expect(isValidOverlayOpacity(0.8)).toBe(true);
+    });
+
+    it('rejects out-of-range values', () => {
+      expect(isValidOverlayOpacity(-0.0001)).toBe(false);
+      expect(isValidOverlayOpacity(1.0001)).toBe(false);
+    });
+
+    it('rejects non-finite numbers', () => {
+      expect(isValidOverlayOpacity(Number.NaN)).toBe(false);
+      expect(isValidOverlayOpacity(Number.POSITIVE_INFINITY)).toBe(false);
+      expect(isValidOverlayOpacity(Number.NEGATIVE_INFINITY)).toBe(false);
+    });
+
+    it('rejects non-number values', () => {
+      expect(isValidOverlayOpacity('0.5')).toBe(false);
+      expect(isValidOverlayOpacity(null)).toBe(false);
+    });
+  });
+
+  describe('isValidOverlayMaxLines', () => {
+    it('accepts the minimum boundary', () => {
+      expect(isValidOverlayMaxLines(OVERLAY_MIN_LINES)).toBe(true);
+    });
+
+    it('accepts larger integers', () => {
+      expect(isValidOverlayMaxLines(2)).toBe(true);
+      expect(isValidOverlayMaxLines(100)).toBe(true);
+    });
+
+    it('rejects values below the minimum', () => {
+      expect(isValidOverlayMaxLines(0)).toBe(false);
+      expect(isValidOverlayMaxLines(-1)).toBe(false);
+    });
+
+    it('rejects non-integer numbers', () => {
+      expect(isValidOverlayMaxLines(1.5)).toBe(false);
+      expect(isValidOverlayMaxLines(Number.NaN)).toBe(false);
+    });
+
+    it('rejects non-number values', () => {
+      expect(isValidOverlayMaxLines('2')).toBe(false);
+      expect(isValidOverlayMaxLines(null)).toBe(false);
+    });
+  });
+
+  describe('isValidOverlayFontScale', () => {
+    it('accepts positive finite numbers', () => {
+      expect(isValidOverlayFontScale(0.1)).toBe(true);
+      expect(isValidOverlayFontScale(1)).toBe(true);
+      expect(isValidOverlayFontScale(2.5)).toBe(true);
+    });
+
+    it('rejects zero and negative numbers', () => {
+      expect(isValidOverlayFontScale(0)).toBe(false);
+      expect(isValidOverlayFontScale(-0.1)).toBe(false);
+    });
+
+    it('rejects non-finite values', () => {
+      expect(isValidOverlayFontScale(Number.POSITIVE_INFINITY)).toBe(false);
+      expect(isValidOverlayFontScale(Number.NaN)).toBe(false);
+    });
+  });
+
+  describe('hasAtLeastOneVisibleText', () => {
+    it('returns true when at least one of the two flags is true', () => {
+      expect(hasAtLeastOneVisibleText(true, true)).toBe(true);
+      expect(hasAtLeastOneVisibleText(true, false)).toBe(true);
+      expect(hasAtLeastOneVisibleText(false, true)).toBe(true);
+    });
+
+    it('returns false when both flags are false', () => {
+      expect(hasAtLeastOneVisibleText(false, false)).toBe(false);
+    });
+  });
+
+  describe('consistency with createOverlaySettings (Zod schema as authoritative)', () => {
+    it('each individual spec boundary matches what createOverlaySettings accepts', () => {
+      // positive control: all boundary values simultaneously should be accepted
+      const result = createOverlaySettings({
+        positionPreset: OVERLAY_POSITION_PRESETS[0],
+        opacity: OVERLAY_OPACITY_BOUNDS.min,
+        maxLines: OVERLAY_MIN_LINES,
+        fontScale: 0.1,
+        showOriginalText: true,
+        showTranslatedText: false,
+      });
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('rejecting either visibility flag at both-false keeps createOverlaySettings consistent', () => {
+      const result = createOverlaySettings({
+        positionPreset: 'top',
+        opacity: 0.5,
+        maxLines: 2,
+        fontScale: 1,
+        showOriginalText: false,
+        showTranslatedText: false,
+      });
+      expect(result.isErr()).toBe(true);
+      expect(hasAtLeastOneVisibleText(false, false)).toBe(false);
+    });
+  });
+});

--- a/packages/extension/src/domain/specifications/overlay-settings-specification.test.ts
+++ b/packages/extension/src/domain/specifications/overlay-settings-specification.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createOverlaySettings } from '../profile/overlay-settings.js';
+import { createOverlaySettings } from '../profile/overlay-settings';
 import {
   OVERLAY_MIN_LINES,
   OVERLAY_OPACITY_BOUNDS,
@@ -9,7 +9,7 @@ import {
   isValidOverlayMaxLines,
   isValidOverlayOpacity,
   isValidOverlayPositionPreset,
-} from './overlay-settings-specification.js';
+} from './overlay-settings-specification';
 
 describe('OverlaySettingsSpecification (DD-272)', () => {
   describe('isValidOverlayPositionPreset', () => {

--- a/packages/extension/src/domain/specifications/overlay-settings-specification.ts
+++ b/packages/extension/src/domain/specifications/overlay-settings-specification.ts
@@ -1,0 +1,40 @@
+/**
+ * オーバーレイ表示設定仕様 (DD-272)。
+ *
+ * 「オーバーレイ表示値は UI で扱える範囲内に制限する」を個別述語として
+ * 提供する。生成時のバリデーションは
+ * `domain/profile/overlay-settings.ts` の Zod schema (`createOverlaySettings`)
+ * が権威であり、本 spec はそれと同期した intent 明確化 + UI preview 等の
+ * 軽量チェック用途。
+ *
+ * 同期は `overlay-settings-specification.test.ts` の consistency テストで
+ * 保証する。
+ */
+
+export const OVERLAY_POSITION_PRESETS = ['top', 'bottom', 'floating'] as const;
+export type OverlayPositionPreset = (typeof OVERLAY_POSITION_PRESETS)[number];
+
+export const OVERLAY_OPACITY_BOUNDS = { min: 0, max: 1 } as const;
+export const OVERLAY_MIN_LINES = 1 as const;
+
+export const isValidOverlayPositionPreset = (value: unknown): value is OverlayPositionPreset => {
+  if (typeof value !== 'string') return false;
+  return OVERLAY_POSITION_PRESETS.some((preset) => preset === value);
+};
+
+export const isValidOverlayOpacity = (value: unknown): boolean =>
+  typeof value === 'number' &&
+  Number.isFinite(value) &&
+  value >= OVERLAY_OPACITY_BOUNDS.min &&
+  value <= OVERLAY_OPACITY_BOUNDS.max;
+
+export const isValidOverlayMaxLines = (value: unknown): boolean =>
+  typeof value === 'number' && Number.isInteger(value) && value >= OVERLAY_MIN_LINES;
+
+export const isValidOverlayFontScale = (value: unknown): boolean =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0;
+
+export const hasAtLeastOneVisibleText = (
+  showOriginalText: boolean,
+  showTranslatedText: boolean,
+): boolean => showOriginalText || showTranslatedText;

--- a/packages/extension/src/domain/specifications/translation-attachment-specification.test.ts
+++ b/packages/extension/src/domain/specifications/translation-attachment-specification.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseSegmentIdentifier,
+  type SegmentIdentifier,
+} from '../transcript/segment-identifier.js';
+import { createTimestampRange } from '../transcript/timestamp-range.js';
+import {
+  appendPartialTranscriptSegment,
+  createTranscriptStream,
+  finalizeSegment,
+  type TranscriptStream,
+} from '../transcript/transcript-stream.js';
+import { canAttachTranslation } from './translation-attachment-specification.js';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+const SEGMENT_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7D2';
+const SEGMENT_ID_MISSING = '01HZX8Y1R8M7D3Q2P4T5V6W7DF';
+
+const segmentId = (raw: string): SegmentIdentifier => parseSegmentIdentifier(raw)._unsafeUnwrap();
+
+const range = (startMs: number, endMs: number) =>
+  createTimestampRange({ startMs, endMs })._unsafeUnwrap();
+
+const buildStream = (): TranscriptStream => {
+  let stream = createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+  // finalized segment 1
+  stream = appendPartialTranscriptSegment(stream, {
+    segmentIdentifier: SEGMENT_ID_1,
+    revision: 1,
+    text: 'hello',
+    timeRange: range(0, 1000),
+  })._unsafeUnwrap();
+  stream = finalizeSegment(stream, { segmentIdentifier: SEGMENT_ID_1 })._unsafeUnwrap();
+  // partial (non-final) segment 2
+  stream = appendPartialTranscriptSegment(stream, {
+    segmentIdentifier: SEGMENT_ID_2,
+    revision: 1,
+    text: 'world',
+    timeRange: range(1500, 2500),
+  })._unsafeUnwrap();
+  return stream;
+};
+
+describe('TranslationAttachmentSpecification (DD-271)', () => {
+  describe('canAttachTranslation', () => {
+    it('returns true when the segment is finalized', () => {
+      const stream = buildStream();
+      expect(canAttachTranslation(stream, segmentId(SEGMENT_ID_1))).toBe(true);
+    });
+
+    it('returns false when the segment is a partial (not yet finalized)', () => {
+      const stream = buildStream();
+      expect(canAttachTranslation(stream, segmentId(SEGMENT_ID_2))).toBe(false);
+    });
+
+    it('returns false when the segment does not exist in the stream', () => {
+      const stream = buildStream();
+      expect(canAttachTranslation(stream, segmentId(SEGMENT_ID_MISSING))).toBe(false);
+    });
+
+    it('returns false for an empty stream regardless of the segment identifier', () => {
+      const empty = createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+      expect(canAttachTranslation(empty, segmentId(SEGMENT_ID_1))).toBe(false);
+    });
+  });
+});

--- a/packages/extension/src/domain/specifications/translation-attachment-specification.test.ts
+++ b/packages/extension/src/domain/specifications/translation-attachment-specification.test.ts
@@ -1,16 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import {
-  parseSegmentIdentifier,
-  type SegmentIdentifier,
-} from '../transcript/segment-identifier.js';
-import { createTimestampRange } from '../transcript/timestamp-range.js';
+import { parseSegmentIdentifier, type SegmentIdentifier } from '../transcript/segment-identifier';
+import { createTimestampRange } from '../transcript/timestamp-range';
 import {
   appendPartialTranscriptSegment,
   createTranscriptStream,
   finalizeSegment,
   type TranscriptStream,
-} from '../transcript/transcript-stream.js';
-import { canAttachTranslation } from './translation-attachment-specification.js';
+} from '../transcript/transcript-stream';
+import { canAttachTranslation } from './translation-attachment-specification';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const SEGMENT_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';

--- a/packages/extension/src/domain/specifications/translation-attachment-specification.ts
+++ b/packages/extension/src/domain/specifications/translation-attachment-specification.ts
@@ -1,0 +1,21 @@
+import { type SegmentIdentifier } from '../transcript/segment-identifier.js';
+import { type TranscriptStream } from '../transcript/transcript-stream.js';
+
+/**
+ * 翻訳紐付け仕様 (DD-271)。
+ *
+ * 「翻訳は確定字幕にのみ紐づけ可能」を判定する述語。`TranscriptStream` 内の
+ * 指定 segment が finalized (`isFinal === true`) であるかを確認する。
+ *
+ * Policy / aggregate との責務分担: 本 spec は `boolean` を返す。
+ * 違反時の `DomainError` 組み立ては `transcript-stream.ts` の
+ * `attachTranslationToSegment` が担う (invariantViolationError 生成)。
+ */
+export const canAttachTranslation = (
+  stream: TranscriptStream,
+  segmentIdentifier: SegmentIdentifier,
+): boolean => {
+  const segment = stream.segments.get(segmentIdentifier);
+  if (segment === undefined) return false;
+  return segment.isFinal;
+};

--- a/packages/extension/src/domain/specifications/translation-attachment-specification.ts
+++ b/packages/extension/src/domain/specifications/translation-attachment-specification.ts
@@ -1,5 +1,5 @@
-import { type SegmentIdentifier } from '../transcript/segment-identifier.js';
-import { type TranscriptStream } from '../transcript/transcript-stream.js';
+import { type SegmentIdentifier } from '../transcript/segment-identifier';
+import { type TranscriptStream } from '../transcript/transcript-stream';
 
 /**
  * 翻訳紐付け仕様 (DD-271)。

--- a/packages/extension/src/domain/transcript/segment-identifier.test.ts
+++ b/packages/extension/src/domain/transcript/segment-identifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createSegmentIdentifier, parseSegmentIdentifier } from './segment-identifier.js';
+import { createSegmentIdentifier, parseSegmentIdentifier } from './segment-identifier';
 
 describe('SegmentIdentifier', () => {
   it('creates a ULID-shaped identifier', () => {

--- a/packages/extension/src/domain/transcript/segment-identifier.ts
+++ b/packages/extension/src/domain/transcript/segment-identifier.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
 import { ulid } from 'ulid';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 字幕セグメントの識別子 (CLAUDE.md §命名規則)。

--- a/packages/extension/src/domain/transcript/timestamp-range.test.ts
+++ b/packages/extension/src/domain/transcript/timestamp-range.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createTimestampRange } from './timestamp-range.js';
+import { createTimestampRange } from './timestamp-range';
 
 describe('TimestampRange', () => {
   it('accepts start < end', () => {

--- a/packages/extension/src/domain/transcript/timestamp-range.ts
+++ b/packages/extension/src/domain/transcript/timestamp-range.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 字幕セグメントのタイムスタンプ範囲 (DD-235)。

--- a/packages/extension/src/domain/transcript/transcript-segment.test.ts
+++ b/packages/extension/src/domain/transcript/transcript-segment.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { createTimestampRange } from './timestamp-range.js';
+import { createTimestampRange } from './timestamp-range';
 import {
   createPartialTranscriptSegment,
   finalizeTranscriptSegment,
   updatePartialTranscriptSegment,
-} from './transcript-segment.js';
+} from './transcript-segment';
 
 const VALID_ULID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 const timeRange = createTimestampRange({ startMs: 0, endMs: 1000 })._unsafeUnwrap();

--- a/packages/extension/src/domain/transcript/transcript-segment.ts
+++ b/packages/extension/src/domain/transcript/transcript-segment.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
-import { type DomainError, invariantViolationError, validationError } from '../shared/errors.js';
-import { parseSegmentIdentifier, type SegmentIdentifier } from './segment-identifier.js';
-import { type TimestampRange } from './timestamp-range.js';
+import { type DomainError, invariantViolationError, validationError } from '../shared/errors';
+import { parseSegmentIdentifier, type SegmentIdentifier } from './segment-identifier';
+import { type TimestampRange } from './timestamp-range';
 
 /**
  * 字幕セグメントエンティティ (DD-221)。

--- a/packages/extension/src/domain/transcript/transcript-stream.test.ts
+++ b/packages/extension/src/domain/transcript/transcript-stream.test.ts
@@ -6,8 +6,8 @@ import {
   finalizeSegment,
   getSegment,
   getTranslation,
-} from './transcript-stream.js';
-import { createTimestampRange } from './timestamp-range.js';
+} from './transcript-stream';
+import { createTimestampRange } from './timestamp-range';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 const SEGMENT_A = '01HZX8Y2R8M7D3Q2P4T5V6W7X1';

--- a/packages/extension/src/domain/transcript/transcript-stream.ts
+++ b/packages/extension/src/domain/transcript/transcript-stream.ts
@@ -1,18 +1,15 @@
 import { err, type Result } from 'neverthrow';
-import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
-import { type DomainError, invariantViolationError, notFoundError } from '../shared/errors.js';
-import { parseSegmentIdentifier } from './segment-identifier.js';
-import type { TimestampRange } from './timestamp-range.js';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier';
+import { type DomainError, invariantViolationError, notFoundError } from '../shared/errors';
+import { parseSegmentIdentifier } from './segment-identifier';
+import type { TimestampRange } from './timestamp-range';
 import {
   createPartialTranscriptSegment,
   finalizeTranscriptSegment,
   updatePartialTranscriptSegment,
   type TranscriptSegment,
-} from './transcript-segment.js';
-import {
-  createCompletedTranslationSegment,
-  type TranslationSegment,
-} from './translation-segment.js';
+} from './transcript-segment';
+import { createCompletedTranslationSegment, type TranslationSegment } from './translation-segment';
 
 /**
  * 字幕ストリーム集約ルート (DD-211)。

--- a/packages/extension/src/domain/transcript/translation-identifier.test.ts
+++ b/packages/extension/src/domain/transcript/translation-identifier.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  createTranslationIdentifier,
-  parseTranslationIdentifier,
-} from './translation-identifier.js';
+import { createTranslationIdentifier, parseTranslationIdentifier } from './translation-identifier';
 
 describe('TranslationIdentifier', () => {
   it('creates a ULID-shaped identifier', () => {

--- a/packages/extension/src/domain/transcript/translation-identifier.ts
+++ b/packages/extension/src/domain/transcript/translation-identifier.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
 import { ulid } from 'ulid';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 翻訳セグメントの識別子 (DD-222)。

--- a/packages/extension/src/domain/transcript/translation-segment.test.ts
+++ b/packages/extension/src/domain/transcript/translation-segment.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createCompletedTranslationSegment,
   createFailedTranslationSegment,
-} from './translation-segment.js';
+} from './translation-segment';
 
 const VALID_ULID_A = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 const VALID_ULID_B = '01HZX8Y1R8M7D3Q2P4T5V6W7X9';

--- a/packages/extension/src/domain/transcript/translation-segment.ts
+++ b/packages/extension/src/domain/transcript/translation-segment.ts
@@ -1,11 +1,8 @@
 import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
-import { parseSegmentIdentifier, type SegmentIdentifier } from './segment-identifier.js';
-import {
-  parseTranslationIdentifier,
-  type TranslationIdentifier,
-} from './translation-identifier.js';
+import { type DomainError, validationError } from '../shared/errors';
+import { parseSegmentIdentifier, type SegmentIdentifier } from './segment-identifier';
+import { parseTranslationIdentifier, type TranslationIdentifier } from './translation-identifier';
 
 /**
  * 翻訳セグメントエンティティ (DD-222)。

--- a/packages/extension/src/entrypoints/monitor/main.tsx
+++ b/packages/extension/src/entrypoints/monitor/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { App } from './App.js';
+import { App } from './App';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/packages/extension/src/entrypoints/popup/main.tsx
+++ b/packages/extension/src/entrypoints/popup/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { App } from './App.js';
+import { App } from './App';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/packages/extension/src/entrypoints/sidepanel/main.tsx
+++ b/packages/extension/src/entrypoints/sidepanel/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { App } from './App.js';
+import { App } from './App';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/packages/relay-api/src/presentation/http/server.ts
+++ b/packages/relay-api/src/presentation/http/server.ts
@@ -1,6 +1,6 @@
 import Fastify, { type FastifyInstance } from 'fastify';
-import { loggerOptions } from '../../infrastructure/logging/logger.js';
-import { registerHealthRoute } from './routes/health.js';
+import { loggerOptions } from '../../infrastructure/logging/logger';
+import { registerHealthRoute } from './routes/health';
 
 export function buildApp(): FastifyInstance {
   const app = Fastify({

--- a/packages/relay-api/tests/smoke.test.ts
+++ b/packages/relay-api/tests/smoke.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from 'vitest';
-import { buildApp } from '../src/presentation/http/server.js';
+import { buildApp } from '../src/presentation/http/server';
 
 const app = buildApp();
 


### PR DESCRIPTION
## Summary

Phase 1 §3.6 として 4 Specification (DD-270〜273) を純粋述語パターンで実装し、**Phase 1 ドメイン層を完成**。併せて IMPL-120 `SessionConcurrencyPolicy` を spec 利用にリファクタし、Policy と Specification の責務分担を明確化。

- **IMPL-153 `ExportFormatSpecification` (DD-273)** — `isValidExportFormat` type guard
- **IMPL-152 `OverlaySettingsSpecification` (DD-272)** — 個別述語群 + 定数。Zod schema と同期 consistency テスト付き
- **IMPL-151 `TranslationAttachmentSpecification` (DD-271)** — `canAttachTranslation(stream, segmentId): boolean`
- **IMPL-150 `ConcurrentSessionLimitSpecification` (DD-270)** — `MAX_CONCURRENT_ACTIVE_SESSIONS` / `isActiveSession` / `countActiveSessions` / `satisfiesConcurrentSessionLimit` (`SessionConcurrencyPolicy` から移動)

### SessionConcurrencyPolicy リファクタ

`session-concurrency-policy.ts` から下記を削除し、spec から import する形に変更:

- `MAX_CONCURRENT_ACTIVE_SESSIONS` / `TERMINAL_STATES` / `isActiveSession` / `countActiveSessions`

Policy 側に残るのは `validateSessionConcurrency` のみ。対応する policy test から述語テストを削除し spec test に集約。

### 責務分担の明確化

| 層 | 責務 | 戻り値 |
|---|---|---|
| Specification | 純粋述語 | `boolean` (or type guard) |
| Policy | Spec を内部利用し、違反時に `DomainError` を組み立て | `Result<void, DomainError>` |
| Value Object (Zod schema) | 生成時バリデーション権威 | `Result<VO, DomainError>` |

### 依存方向

`domain/specifications/` → `domain/session/` / `domain/transcript/` / `domain/export/` の片方向。`domain/services/` (policy) → `domain/specifications/` の依存追加。逆方向依存なし。

## Test plan

- [x] `pnpm --filter @perapera/extension test` → 304 tests pass (31 test files、既存 268 から +36 新規)
- [x] `pnpm --filter @perapera/extension test:coverage`
  - `domain/specifications/` 全 4 ファイル: **100%** (statements/branches/functions/lines)
  - 全体: 96.42% / 97.9% / 98.78% / 96.42% (Phase 1 目標 90%+ 大幅達成)
- [x] `pnpm check` (fmt:check + lint + typecheck + test) 全緑
- [ ] CI `All Green` 通過

## Phase 1 完了

本 PR の merge により Phase 1 ドメイン層 (IMPL-101〜153) が完了。次フェーズは §4 Phase 2 アプリケーション層 (UseCase, DTO, 出力ポート)。