### PR TITLE
feat(application): IMPL-220〜221 DTOs (input/output × 7 UseCases)

### DIFF
--- a/packages/extension/src/application/dto/export-session-result-dto.test.ts
+++ b/packages/extension/src/application/dto/export-session-result-dto.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseExportSessionResultInput,
+  type ExportSessionResultInput,
+  type ExportSessionResultOutput,
+} from './export-session-result-dto';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const EXPORT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7F1';
+
+describe('ExportSessionResultDTO (DD-307)', () => {
+  describe('parseExportSessionResultInput', () => {
+    it('accepts a fully populated payload with format=txt', () => {
+      const result = parseExportSessionResultInput({
+        sessionId: SESSION_ID,
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: true,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.format).toBe('txt');
+    });
+
+    it('accepts format=json', () => {
+      const result = parseExportSessionResultInput({
+        sessionId: SESSION_ID,
+        format: 'json',
+        includeOriginal: false,
+        includeTranslation: true,
+      });
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('rejects unknown format values', () => {
+      const result = parseExportSessionResultInput({
+        sessionId: SESSION_ID,
+        format: 'csv',
+        includeOriginal: true,
+        includeTranslation: true,
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('validation');
+    });
+
+    it('rejects when sessionId is empty', () => {
+      const result = parseExportSessionResultInput({
+        sessionId: '',
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: true,
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects when required include flags are missing', () => {
+      const result = parseExportSessionResultInput({
+        sessionId: SESSION_ID,
+        format: 'txt',
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects when both include flags are false (defensive at DTO layer)', () => {
+      const result = parseExportSessionResultInput({
+        sessionId: SESSION_ID,
+        format: 'txt',
+        includeOriginal: false,
+        includeTranslation: false,
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('ExportSessionResultOutput', () => {
+    it('carries exportId, format, and bytes', () => {
+      const output: ExportSessionResultOutput = {
+        exportId: EXPORT_ID,
+        format: 'json',
+        bytes: 1024,
+      };
+      expect(output.bytes).toBe(1024);
+    });
+  });
+
+  describe('ExportSessionResultInput type shape', () => {
+    it('accepts a typed literal that matches the DTO', () => {
+      const input: ExportSessionResultInput = {
+        sessionId: SESSION_ID,
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: true,
+      };
+      expect(input.includeOriginal).toBe(true);
+    });
+  });
+});

--- a/packages/extension/src/application/dto/export-session-result-dto.ts
+++ b/packages/extension/src/application/dto/export-session-result-dto.ts
@@ -1,0 +1,54 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { EXPORT_FORMATS, type ExportFormat } from '../../domain/export/export-record';
+import { type DomainError, validationError } from '../../domain/shared/errors';
+
+/**
+ * エクスポート実行入力 DTO (DTO-I-307, DD-307)。
+ * 形式は `EXPORT_FORMATS` のみ許可 (DD-273 ExportFormatSpecification 準拠)。
+ * `includeOriginal` / `includeTranslation` の両方が false の場合は
+ * 出力内容が無いため defensive に validation で拒否する。
+ */
+export type ExportSessionResultInput = {
+  sessionId: string;
+  format: ExportFormat;
+  includeOriginal: boolean;
+  includeTranslation: boolean;
+};
+
+const exportSessionResultInputSchema = z
+  .object({
+    sessionId: z.string().min(1),
+    format: z.enum(EXPORT_FORMATS),
+    includeOriginal: z.boolean(),
+    includeTranslation: z.boolean(),
+  })
+  .refine((value) => value.includeOriginal || value.includeTranslation, {
+    message: 'at least one of includeOriginal / includeTranslation must be true',
+  });
+
+export const parseExportSessionResultInput = (
+  raw: unknown,
+): Result<ExportSessionResultInput, DomainError> => {
+  const result = exportSessionResultInputSchema.safeParse(raw);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'ExportSessionResultInput',
+        message: result.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};
+
+/**
+ * エクスポート実行出力 DTO (DTO-O-307)。
+ * `ExportRecord` の `exportIdentifier` を `exportId` として primitive 化し、
+ * 生成バイト数 `bytes` を追加。
+ */
+export type ExportSessionResultOutput = Readonly<{
+  exportId: string;
+  format: ExportFormat;
+  bytes: number;
+}>;

--- a/packages/extension/src/application/dto/get-session-monitor-state-dto.test.ts
+++ b/packages/extension/src/application/dto/get-session-monitor-state-dto.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseGetSessionMonitorStateInput,
+  type GetSessionMonitorStateInput,
+  type SessionMonitorStateOutput,
+} from './get-session-monitor-state-dto';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SESSION_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+
+describe('GetSessionMonitorStateDTO (DD-302)', () => {
+  describe('parseGetSessionMonitorStateInput', () => {
+    it('accepts a minimum payload (includeOverlayState only, sessionIds omitted)', () => {
+      const result = parseGetSessionMonitorStateInput({ includeOverlayState: false });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.sessionIds).toBeUndefined();
+    });
+
+    it('accepts a payload with sessionIds filter', () => {
+      const result = parseGetSessionMonitorStateInput({
+        sessionIds: [SESSION_ID, SESSION_ID_2],
+        includeOverlayState: true,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.sessionIds).toHaveLength(2);
+        expect(result.value.includeOverlayState).toBe(true);
+      }
+    });
+
+    it('rejects an empty sessionIds array (use undefined for all-sessions query)', () => {
+      const result = parseGetSessionMonitorStateInput({
+        sessionIds: [],
+        includeOverlayState: false,
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('validation');
+    });
+
+    it('rejects when includeOverlayState is missing', () => {
+      const result = parseGetSessionMonitorStateInput({});
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects when sessionIds contains non-string values', () => {
+      const result = parseGetSessionMonitorStateInput({
+        sessionIds: [SESSION_ID, 123],
+        includeOverlayState: false,
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('SessionMonitorStateOutput type shape', () => {
+    it('carries a composite structure (sessions + latestSegments + optional overlayState)', () => {
+      const output: SessionMonitorStateOutput = {
+        sessions: [
+          {
+            sessionId: SESSION_ID,
+            displayName: 'Example tab',
+            state: 'capturing',
+            sourceType: 'tab',
+          },
+        ],
+        latestSegments: [
+          {
+            sessionId: SESSION_ID,
+            segmentId: SEGMENT_ID,
+            originalText: 'hello',
+            translatedText: 'こんにちは',
+          },
+        ],
+        overlayState: {
+          sessionId: SESSION_ID,
+          positionPreset: 'bottom',
+          opacity: 0.8,
+          maxLines: 2,
+          fontScale: 1,
+          showOriginalText: true,
+          showTranslatedText: true,
+        },
+      };
+      expect(output.sessions).toHaveLength(1);
+      expect(output.latestSegments[0]?.translatedText).toBe('こんにちは');
+      expect(output.overlayState?.positionPreset).toBe('bottom');
+    });
+
+    it('allows overlayState to be omitted when not requested', () => {
+      const output: SessionMonitorStateOutput = {
+        sessions: [],
+        latestSegments: [],
+      };
+      expect(output.overlayState).toBeUndefined();
+    });
+
+    it('allows segments with only original text (translation pending)', () => {
+      const output: SessionMonitorStateOutput = {
+        sessions: [],
+        latestSegments: [
+          {
+            sessionId: SESSION_ID,
+            segmentId: SEGMENT_ID,
+            originalText: 'hello',
+          },
+        ],
+      };
+      expect(output.latestSegments[0]?.translatedText).toBeUndefined();
+    });
+  });
+
+  describe('GetSessionMonitorStateInput type shape', () => {
+    it('accepts a typed literal', () => {
+      const input: GetSessionMonitorStateInput = { includeOverlayState: false };
+      expect(input.includeOverlayState).toBe(false);
+    });
+  });
+});

--- a/packages/extension/src/application/dto/get-session-monitor-state-dto.ts
+++ b/packages/extension/src/application/dto/get-session-monitor-state-dto.ts
@@ -1,0 +1,67 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../../domain/shared/errors';
+import { type OverlayPositionPreset } from '../../domain/specifications/overlay-settings-specification';
+
+/**
+ * セッション監視状態取得入力 DTO (DTO-I-302, DD-302)。
+ *
+ * Side Panel 等から UseCase 層へ渡される Query 入力。`sessionIds` 省略時は
+ * 全アクティブセッションを返す。空配列は意図が曖昧 (絞り込み 0 件) なため
+ * validation で拒否 (undefined を使う)。
+ */
+export type GetSessionMonitorStateInput = {
+  sessionIds?: readonly string[] | undefined;
+  includeOverlayState: boolean;
+};
+
+const getSessionMonitorStateInputSchema = z.object({
+  sessionIds: z.array(z.string().min(1)).min(1).optional(),
+  includeOverlayState: z.boolean(),
+});
+
+export const parseGetSessionMonitorStateInput = (
+  raw: unknown,
+): Result<GetSessionMonitorStateInput, DomainError> => {
+  const result = getSessionMonitorStateInputSchema.safeParse(raw);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'GetSessionMonitorStateInput',
+        message: result.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};
+
+/**
+ * セッション監視状態出力 DTO (DTO-O-302)。
+ *
+ * Side Panel / Popup UI に表示する複合構造。`SourceSession` と
+ * `TranscriptStream` から投影し primitive 化する。`overlayState` は
+ * `includeOverlayState === true` の場合のみ含まれる。
+ */
+export type SessionMonitorStateOutput = Readonly<{
+  sessions: readonly {
+    sessionId: string;
+    displayName: string;
+    state: string;
+    sourceType: string;
+  }[];
+  latestSegments: readonly {
+    sessionId: string;
+    segmentId: string;
+    originalText?: string;
+    translatedText?: string;
+  }[];
+  overlayState?: {
+    sessionId: string;
+    positionPreset: OverlayPositionPreset;
+    opacity: number;
+    maxLines: number;
+    fontScale: number;
+    showOriginalText: boolean;
+    showTranslatedText: boolean;
+  };
+}>;

--- a/packages/extension/src/application/dto/handle-transcript-final-dto.test.ts
+++ b/packages/extension/src/application/dto/handle-transcript-final-dto.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { parseSessionIdentifier } from '../../domain/session/session-identifier';
+import type { OverlayRenderModel } from '../ports/overlay-presenter';
+import {
+  parseHandleTranscriptFinalInput,
+  type HandleTranscriptFinalInput,
+  type HandleTranscriptFinalOutput,
+} from './handle-transcript-final-dto';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+
+describe('HandleTranscriptFinalDTO (DD-305)', () => {
+  describe('parseHandleTranscriptFinalInput', () => {
+    it('accepts a payload without translation', () => {
+      const result = parseHandleTranscriptFinalInput({
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        text: 'hello world',
+        timeRange: { startMs: 0, endMs: 1500 },
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.translation).toBeUndefined();
+    });
+
+    it('accepts a payload with completed translation', () => {
+      const result = parseHandleTranscriptFinalInput({
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        text: 'hello',
+        timeRange: { startMs: 0, endMs: 1000 },
+        translation: {
+          targetLanguage: 'ja-JP',
+          text: 'こんにちは',
+          status: 'completed',
+        },
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.translation?.status).toBe('completed');
+    });
+
+    it('accepts a payload with failed translation', () => {
+      const result = parseHandleTranscriptFinalInput({
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        text: 'hello',
+        timeRange: { startMs: 0, endMs: 1000 },
+        translation: {
+          targetLanguage: 'ja-JP',
+          text: '',
+          status: 'failed',
+        },
+      });
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('rejects empty text (final segment must have content)', () => {
+      const result = parseHandleTranscriptFinalInput({
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        text: '',
+        timeRange: { startMs: 0, endMs: 1000 },
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('validation');
+    });
+
+    it('rejects unknown translation.status', () => {
+      const result = parseHandleTranscriptFinalInput({
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        text: 'hello',
+        timeRange: { startMs: 0, endMs: 1000 },
+        translation: {
+          targetLanguage: 'ja-JP',
+          text: 'こんにちは',
+          status: 'pending',
+        },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects malformed target language BCP-47', () => {
+      const result = parseHandleTranscriptFinalInput({
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        text: 'hello',
+        timeRange: { startMs: 0, endMs: 1000 },
+        translation: {
+          targetLanguage: 'NOT_A_TAG',
+          text: 'こんにちは',
+          status: 'completed',
+        },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('HandleTranscriptFinalOutput type shape', () => {
+    it('supports translationStatus values: completed / failed / pending', () => {
+      const renderModel: OverlayRenderModel = {
+        sessionIdentifier: parseSessionIdentifier(SESSION_ID)._unsafeUnwrap(),
+        lines: [],
+      };
+      const completed: HandleTranscriptFinalOutput = {
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        translationStatus: 'completed',
+        renderModel,
+      };
+      const failed: HandleTranscriptFinalOutput = {
+        ...completed,
+        translationStatus: 'failed',
+      };
+      const pending: HandleTranscriptFinalOutput = {
+        ...completed,
+        translationStatus: 'pending',
+      };
+      expect(completed.translationStatus).toBe('completed');
+      expect(failed.translationStatus).toBe('failed');
+      expect(pending.translationStatus).toBe('pending');
+    });
+  });
+
+  describe('HandleTranscriptFinalInput type shape', () => {
+    it('accepts a typed literal', () => {
+      const input: HandleTranscriptFinalInput = {
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        text: 'hi',
+        timeRange: { startMs: 0, endMs: 50 },
+      };
+      expect(input.segmentId).toBe(SEGMENT_ID);
+    });
+  });
+});

--- a/packages/extension/src/application/dto/handle-transcript-final-dto.ts
+++ b/packages/extension/src/application/dto/handle-transcript-final-dto.ts
@@ -1,0 +1,84 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../../domain/shared/errors';
+import { type OverlayRenderModel } from '../ports/overlay-presenter';
+
+const bcp47Schema = z.string().regex(/^[a-z]{2,3}(?:-[A-Z]{2})?$/);
+
+const timeRangeSchema = z
+  .object({
+    startMs: z.number().int().nonnegative(),
+    endMs: z.number().int().nonnegative(),
+  })
+  .refine((value) => value.startMs <= value.endMs, {
+    message: 'startMs must be <= endMs',
+  });
+
+const translationPayloadSchema = z.object({
+  targetLanguage: bcp47Schema,
+  text: z.string(),
+  status: z.enum(['completed', 'failed']),
+});
+
+/**
+ * 確定字幕処理入力 DTO (DTO-I-305, DD-305)。
+ *
+ * `translation` はオプション — 翻訳が間に合っていない時点で UseCase が
+ * 呼ばれた場合、`translation` なしで受け取り、後続の翻訳完了時に
+ * `HandleTranslationFinalEvent` 相当の別経路で反映する (設計書 §6.2 結果整合性)。
+ *
+ * `translation.status === 'failed'` 時は `text` が空文字でも許容 (実装側では
+ * `TranslationSegment.failed` として扱う)。
+ */
+export type HandleTranscriptFinalInput = {
+  sessionId: string;
+  segmentId: string;
+  text: string;
+  timeRange: {
+    startMs: number;
+    endMs: number;
+  };
+  translation?:
+    | {
+        targetLanguage: string;
+        text: string;
+        status: 'completed' | 'failed';
+      }
+    | undefined;
+};
+
+const handleTranscriptFinalInputSchema = z.object({
+  sessionId: z.string().min(1),
+  segmentId: z.string().min(1),
+  text: z.string().min(1),
+  timeRange: timeRangeSchema,
+  translation: translationPayloadSchema.optional(),
+});
+
+export const parseHandleTranscriptFinalInput = (
+  raw: unknown,
+): Result<HandleTranscriptFinalInput, DomainError> => {
+  const result = handleTranscriptFinalInputSchema.safeParse(raw);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'HandleTranscriptFinalInput',
+        message: result.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};
+
+/**
+ * 確定字幕処理出力 DTO (DTO-O-305)。
+ *
+ * `translationStatus` に `'pending'` を含めることで、翻訳がまだ到着していない
+ * 確定字幕の表示モデルを UI 層が区別できる (結果整合性、§6.2)。
+ */
+export type HandleTranscriptFinalOutput = Readonly<{
+  sessionId: string;
+  segmentId: string;
+  translationStatus: 'completed' | 'failed' | 'pending';
+  renderModel: OverlayRenderModel;
+}>;

--- a/packages/extension/src/application/dto/handle-transcript-partial-dto.test.ts
+++ b/packages/extension/src/application/dto/handle-transcript-partial-dto.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { parseSessionIdentifier } from '../../domain/session/session-identifier';
+import type { OverlayRenderModel } from '../ports/overlay-presenter';
+import {
+  parseHandleTranscriptPartialInput,
+  type HandleTranscriptPartialInput,
+  type HandleTranscriptPartialOutput,
+} from './handle-transcript-partial-dto';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+
+describe('HandleTranscriptPartialDTO (DD-304)', () => {
+  describe('parseHandleTranscriptPartialInput', () => {
+    it('accepts a valid payload', () => {
+      const result = parseHandleTranscriptPartialInput({
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        revision: 1,
+        text: 'hello world',
+        timeRange: { startMs: 0, endMs: 1500 },
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.revision).toBe(1);
+    });
+
+    it('rejects revision < 1', () => {
+      const result = parseHandleTranscriptPartialInput({
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        revision: 0,
+        text: 'hello',
+        timeRange: { startMs: 0, endMs: 100 },
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('validation');
+    });
+
+    it('rejects non-integer revision', () => {
+      const result = parseHandleTranscriptPartialInput({
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        revision: 1.5,
+        text: 'hello',
+        timeRange: { startMs: 0, endMs: 100 },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects empty text', () => {
+      const result = parseHandleTranscriptPartialInput({
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        revision: 1,
+        text: '',
+        timeRange: { startMs: 0, endMs: 100 },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects timeRange where startMs > endMs', () => {
+      const result = parseHandleTranscriptPartialInput({
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        revision: 1,
+        text: 'hello',
+        timeRange: { startMs: 200, endMs: 100 },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects negative timestamp offsets', () => {
+      const result = parseHandleTranscriptPartialInput({
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        revision: 1,
+        text: 'hello',
+        timeRange: { startMs: -1, endMs: 100 },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('HandleTranscriptPartialOutput type shape', () => {
+    it('carries renderModel from OverlayPresenter port', () => {
+      const renderModel: OverlayRenderModel = {
+        sessionIdentifier: parseSessionIdentifier(SESSION_ID)._unsafeUnwrap(),
+        lines: [],
+      };
+      const output: HandleTranscriptPartialOutput = {
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        revision: 1,
+        renderModel,
+      };
+      expect(output.revision).toBe(1);
+    });
+  });
+
+  describe('HandleTranscriptPartialInput type shape', () => {
+    it('accepts a typed literal', () => {
+      const input: HandleTranscriptPartialInput = {
+        sessionId: SESSION_ID,
+        segmentId: SEGMENT_ID,
+        revision: 1,
+        text: 'hi',
+        timeRange: { startMs: 0, endMs: 50 },
+      };
+      expect(input.segmentId).toBe(SEGMENT_ID);
+    });
+  });
+});

--- a/packages/extension/src/application/dto/handle-transcript-partial-dto.ts
+++ b/packages/extension/src/application/dto/handle-transcript-partial-dto.ts
@@ -1,0 +1,69 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../../domain/shared/errors';
+import { type OverlayRenderModel } from '../ports/overlay-presenter';
+
+/**
+ * 部分字幕処理入力 DTO (DTO-I-304, DD-304)。
+ *
+ * Relay イベント `transcript.partial` 受信時に UseCase 層が受け取る境界型。
+ * `revision >= 1` (整数)、`text.length >= 1`、`timeRange.startMs <= endMs`
+ * を検証。文字列上限はドメイン側の TranscriptSegment バリデーションで再確認
+ * される。
+ */
+export type HandleTranscriptPartialInput = {
+  sessionId: string;
+  segmentId: string;
+  revision: number;
+  text: string;
+  timeRange: {
+    startMs: number;
+    endMs: number;
+  };
+};
+
+const timeRangeSchema = z
+  .object({
+    startMs: z.number().int().nonnegative(),
+    endMs: z.number().int().nonnegative(),
+  })
+  .refine((value) => value.startMs <= value.endMs, {
+    message: 'startMs must be <= endMs',
+  });
+
+const handleTranscriptPartialInputSchema = z.object({
+  sessionId: z.string().min(1),
+  segmentId: z.string().min(1),
+  revision: z.number().int().min(1),
+  text: z.string().min(1),
+  timeRange: timeRangeSchema,
+});
+
+export const parseHandleTranscriptPartialInput = (
+  raw: unknown,
+): Result<HandleTranscriptPartialInput, DomainError> => {
+  const result = handleTranscriptPartialInputSchema.safeParse(raw);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'HandleTranscriptPartialInput',
+        message: result.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};
+
+/**
+ * 部分字幕処理出力 DTO (DTO-O-304)。
+ *
+ * `TranscriptSegment` の要約と、`OverlayPresenter` へプッシュする
+ * `OverlayRenderModel` を含む。UseCase 層内で `OverlayRenderModel` を
+ * 構築し本 DTO に含める。
+ */
+export type HandleTranscriptPartialOutput = Readonly<{
+  sessionId: string;
+  segmentId: string;
+  revision: number;
+  renderModel: OverlayRenderModel;
+}>;

--- a/packages/extension/src/application/dto/index.ts
+++ b/packages/extension/src/application/dto/index.ts
@@ -1,0 +1,35 @@
+export {
+  parseExportSessionResultInput,
+  type ExportSessionResultInput,
+  type ExportSessionResultOutput,
+} from './export-session-result-dto';
+export {
+  parseGetSessionMonitorStateInput,
+  type GetSessionMonitorStateInput,
+  type SessionMonitorStateOutput,
+} from './get-session-monitor-state-dto';
+export {
+  parseHandleTranscriptFinalInput,
+  type HandleTranscriptFinalInput,
+  type HandleTranscriptFinalOutput,
+} from './handle-transcript-final-dto';
+export {
+  parseHandleTranscriptPartialInput,
+  type HandleTranscriptPartialInput,
+  type HandleTranscriptPartialOutput,
+} from './handle-transcript-partial-dto';
+export {
+  parseStartSourceSessionInput,
+  type StartSourceSessionInput,
+  type StartSourceSessionOutput,
+} from './start-source-session-dto';
+export {
+  parseStopSourceSessionInput,
+  type StopSourceSessionInput,
+  type StopSourceSessionOutput,
+} from './stop-source-session-dto';
+export {
+  parseUpdateSourceSettingsInput,
+  type UpdateSourceSettingsInput,
+  type UpdateSourceSettingsOutput,
+} from './update-source-settings-dto';

--- a/packages/extension/src/application/dto/start-source-session-dto.test.ts
+++ b/packages/extension/src/application/dto/start-source-session-dto.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseStartSourceSessionInput,
+  type StartSourceSessionInput,
+  type StartSourceSessionOutput,
+} from './start-source-session-dto';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+
+describe('StartSourceSessionDTO (DD-301)', () => {
+  describe('parseStartSourceSessionInput', () => {
+    it('accepts a tab source with overlayTarget=tab', () => {
+      const result = parseStartSourceSessionInput({
+        sourceType: 'tab',
+        displayName: 'Example tab',
+        sourceLanguage: 'en-US',
+        autoDetectLanguage: false,
+        targetLanguage: 'ja-JP',
+        overlayTarget: { kind: 'tab', tabId: 42 },
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.sourceType).toBe('tab');
+        expect(result.value.overlayTarget.kind).toBe('tab');
+      }
+    });
+
+    it('accepts a microphone source with extension-monitor overlay', () => {
+      const result = parseStartSourceSessionInput({
+        sourceType: 'microphone',
+        displayName: 'Built-in mic',
+        sourceLanguage: null,
+        autoDetectLanguage: true,
+        targetLanguage: 'ja-JP',
+        overlayTarget: { kind: 'extension-monitor', pageId: 'monitor-1' },
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.sourceLanguage).toBeNull();
+        expect(result.value.autoDetectLanguage).toBe(true);
+      }
+    });
+
+    it('accepts a desktop source with minimal overlayTarget', () => {
+      const result = parseStartSourceSessionInput({
+        sourceType: 'desktop',
+        displayName: 'Screen share',
+        autoDetectLanguage: false,
+        targetLanguage: 'ja-JP',
+        overlayTarget: { kind: 'extension-monitor' },
+      });
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('rejects unknown sourceType', () => {
+      const result = parseStartSourceSessionInput({
+        sourceType: 'webcam',
+        displayName: 'bad',
+        autoDetectLanguage: false,
+        targetLanguage: 'ja-JP',
+        overlayTarget: { kind: 'tab' },
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('validation');
+    });
+
+    it('rejects empty displayName', () => {
+      const result = parseStartSourceSessionInput({
+        sourceType: 'tab',
+        displayName: '',
+        autoDetectLanguage: false,
+        targetLanguage: 'ja-JP',
+        overlayTarget: { kind: 'tab' },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects malformed BCP-47 target language', () => {
+      const result = parseStartSourceSessionInput({
+        sourceType: 'tab',
+        displayName: 'tab',
+        autoDetectLanguage: false,
+        targetLanguage: 'NOT_A_TAG',
+        overlayTarget: { kind: 'tab' },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects unknown overlayTarget.kind', () => {
+      const result = parseStartSourceSessionInput({
+        sourceType: 'tab',
+        displayName: 'tab',
+        autoDetectLanguage: false,
+        targetLanguage: 'ja-JP',
+        overlayTarget: { kind: 'sidebar' },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('StartSourceSessionOutput type shape', () => {
+    it('carries sessionId, state, and startedAt', () => {
+      const output: StartSourceSessionOutput = {
+        sessionId: SESSION_ID,
+        state: 'requesting_permission',
+        startedAt: '2026-04-21T00:00:00.000Z',
+      };
+      expect(output.state).toBe('requesting_permission');
+    });
+  });
+
+  describe('StartSourceSessionInput type shape', () => {
+    it('accepts a typed literal', () => {
+      const input: StartSourceSessionInput = {
+        sourceType: 'tab',
+        displayName: 'Tab',
+        autoDetectLanguage: false,
+        targetLanguage: 'ja-JP',
+        overlayTarget: { kind: 'tab' },
+      };
+      expect(input.sourceType).toBe('tab');
+    });
+  });
+});

--- a/packages/extension/src/application/dto/start-source-session-dto.ts
+++ b/packages/extension/src/application/dto/start-source-session-dto.ts
@@ -1,0 +1,67 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { SOURCE_TYPES } from '../../domain/session/source-type';
+import { type DomainError, validationError } from '../../domain/shared/errors';
+
+const bcp47Schema = z.string().regex(/^[a-z]{2,3}(?:-[A-Z]{2})?$/);
+
+const overlayTargetSchema = z.object({
+  kind: z.enum(['tab', 'extension-monitor']),
+  tabId: z.number().int().nonnegative().optional(),
+  pageId: z.string().min(1).optional(),
+});
+
+/**
+ * セッション開始入力 DTO (DTO-I-301, DD-301)。
+ *
+ * Popup / Side Panel の「ソース追加」操作から UseCase 層に渡される境界型。
+ * `sourceType` は `SOURCE_TYPES` と同期。`sourceLanguage` は `null` で
+ * 自動判定をリセット、`autoDetectLanguage` は別フラグで ON/OFF を管理する。
+ * `overlayTarget` は overlay の表示先 (タブ or 拡張 monitor ページ) を指定。
+ */
+export type StartSourceSessionInput = {
+  sourceType: (typeof SOURCE_TYPES)[number];
+  displayName: string;
+  sourceLanguage?: string | null | undefined;
+  autoDetectLanguage: boolean;
+  targetLanguage: string;
+  overlayTarget: {
+    kind: 'tab' | 'extension-monitor';
+    tabId?: number | undefined;
+    pageId?: string | undefined;
+  };
+};
+
+const startSourceSessionInputSchema = z.object({
+  sourceType: z.enum(SOURCE_TYPES),
+  displayName: z.string().min(1),
+  sourceLanguage: bcp47Schema.nullable().optional(),
+  autoDetectLanguage: z.boolean(),
+  targetLanguage: bcp47Schema,
+  overlayTarget: overlayTargetSchema,
+});
+
+export const parseStartSourceSessionInput = (
+  raw: unknown,
+): Result<StartSourceSessionInput, DomainError> => {
+  const result = startSourceSessionInputSchema.safeParse(raw);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'StartSourceSessionInput',
+        message: result.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};
+
+/**
+ * セッション開始出力 DTO (DTO-O-301)。
+ * `SourceSession` から `sessionId` / `state` / `startedAt` を primitive 化。
+ */
+export type StartSourceSessionOutput = Readonly<{
+  sessionId: string;
+  state: string;
+  startedAt: string;
+}>;

--- a/packages/extension/src/application/dto/stop-source-session-dto.test.ts
+++ b/packages/extension/src/application/dto/stop-source-session-dto.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseStopSourceSessionInput,
+  type StopSourceSessionInput,
+  type StopSourceSessionOutput,
+} from './stop-source-session-dto';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+
+describe('StopSourceSessionDTO (DD-306)', () => {
+  describe('parseStopSourceSessionInput', () => {
+    it('accepts the minimum payload (sessionId only)', () => {
+      const result = parseStopSourceSessionInput({ sessionId: SESSION_ID });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.sessionId).toBe(SESSION_ID);
+        expect(result.value.reason).toBeUndefined();
+      }
+    });
+
+    it('accepts a payload with optional reason', () => {
+      const result = parseStopSourceSessionInput({
+        sessionId: SESSION_ID,
+        reason: 'user_requested',
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.reason).toBe('user_requested');
+    });
+
+    it('rejects when sessionId is missing', () => {
+      const result = parseStopSourceSessionInput({});
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('validation');
+    });
+
+    it('rejects when sessionId is not a string', () => {
+      const result = parseStopSourceSessionInput({ sessionId: 123 });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects when sessionId is an empty string', () => {
+      const result = parseStopSourceSessionInput({ sessionId: '' });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects a non-object payload', () => {
+      expect(parseStopSourceSessionInput(null).isErr()).toBe(true);
+      expect(parseStopSourceSessionInput('bad').isErr()).toBe(true);
+    });
+  });
+
+  describe('StopSourceSessionOutput type shape', () => {
+    it('carries sessionId, state, and stoppedAt', () => {
+      const output: StopSourceSessionOutput = {
+        sessionId: SESSION_ID,
+        state: 'stopped',
+        stoppedAt: '2026-04-21T00:10:00.000Z',
+      };
+      expect(output.state).toBe('stopped');
+    });
+  });
+
+  describe('StopSourceSessionInput type narrowing', () => {
+    it('permits reason omission in the type definition', () => {
+      const minimal: StopSourceSessionInput = { sessionId: SESSION_ID };
+      expect(minimal.reason).toBeUndefined();
+    });
+  });
+});

--- a/packages/extension/src/application/dto/stop-source-session-dto.ts
+++ b/packages/extension/src/application/dto/stop-source-session-dto.ts
@@ -1,0 +1,43 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../../domain/shared/errors';
+
+/**
+ * セッション停止入力 DTO (DTO-I-306, DD-306)。
+ * Popup / Side Panel UI から UseCase 層へ渡される境界型。Zod で runtime 検証。
+ */
+export type StopSourceSessionInput = {
+  sessionId: string;
+  reason?: string | undefined;
+};
+
+const stopSourceSessionInputSchema = z.object({
+  sessionId: z.string().min(1),
+  reason: z.string().optional(),
+});
+
+export const parseStopSourceSessionInput = (
+  raw: unknown,
+): Result<StopSourceSessionInput, DomainError> => {
+  const result = stopSourceSessionInputSchema.safeParse(raw);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'StopSourceSessionInput',
+        message: result.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};
+
+/**
+ * セッション停止出力 DTO (DTO-O-306)。
+ * UseCase 層から UI 層へ返される投影型。`SourceSession` から `sessionId` /
+ * `state` / `stoppedAt` を抽出。
+ */
+export type StopSourceSessionOutput = Readonly<{
+  sessionId: string;
+  state: string;
+  stoppedAt: string;
+}>;

--- a/packages/extension/src/application/dto/update-source-settings-dto.test.ts
+++ b/packages/extension/src/application/dto/update-source-settings-dto.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseUpdateSourceSettingsInput,
+  type UpdateSourceSettingsInput,
+  type UpdateSourceSettingsOutput,
+} from './update-source-settings-dto';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+
+describe('UpdateSourceSettingsDTO (DD-303)', () => {
+  describe('parseUpdateSourceSettingsInput', () => {
+    it('accepts the minimum payload (sessionId only, all optional fields omitted)', () => {
+      const result = parseUpdateSourceSettingsInput({ sessionId: SESSION_ID });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.sessionId).toBe(SESSION_ID);
+    });
+
+    it('accepts language pair updates', () => {
+      const result = parseUpdateSourceSettingsInput({
+        sessionId: SESSION_ID,
+        sourceLanguage: 'en-US',
+        targetLanguage: 'ja-JP',
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.sourceLanguage).toBe('en-US');
+        expect(result.value.targetLanguage).toBe('ja-JP');
+      }
+    });
+
+    it('accepts sourceLanguage=null (auto-detect reset)', () => {
+      const result = parseUpdateSourceSettingsInput({
+        sessionId: SESSION_ID,
+        sourceLanguage: null,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value.sourceLanguage).toBeNull();
+    });
+
+    it('accepts a valid overlaySettings object', () => {
+      const result = parseUpdateSourceSettingsInput({
+        sessionId: SESSION_ID,
+        overlaySettings: {
+          positionPreset: 'bottom',
+          opacity: 0.8,
+          maxLines: 2,
+          fontScale: 1,
+          showOriginalText: true,
+          showTranslatedText: false,
+        },
+      });
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('rejects out-of-range opacity', () => {
+      const result = parseUpdateSourceSettingsInput({
+        sessionId: SESSION_ID,
+        overlaySettings: {
+          positionPreset: 'bottom',
+          opacity: 1.5,
+          maxLines: 2,
+          fontScale: 1,
+          showOriginalText: true,
+          showTranslatedText: true,
+        },
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('validation');
+    });
+
+    it('rejects non-integer maxLines', () => {
+      const result = parseUpdateSourceSettingsInput({
+        sessionId: SESSION_ID,
+        overlaySettings: {
+          positionPreset: 'top',
+          opacity: 0.5,
+          maxLines: 1.5,
+          fontScale: 1,
+          showOriginalText: true,
+          showTranslatedText: true,
+        },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects zero or negative fontScale', () => {
+      const result = parseUpdateSourceSettingsInput({
+        sessionId: SESSION_ID,
+        overlaySettings: {
+          positionPreset: 'top',
+          opacity: 0.5,
+          maxLines: 2,
+          fontScale: 0,
+          showOriginalText: true,
+          showTranslatedText: true,
+        },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects unknown positionPreset', () => {
+      const result = parseUpdateSourceSettingsInput({
+        sessionId: SESSION_ID,
+        overlaySettings: {
+          positionPreset: 'center',
+          opacity: 0.5,
+          maxLines: 2,
+          fontScale: 1,
+          showOriginalText: true,
+          showTranslatedText: true,
+        },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects malformed BCP-47 source language', () => {
+      const result = parseUpdateSourceSettingsInput({
+        sessionId: SESSION_ID,
+        sourceLanguage: 'NOT_A_TAG',
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects missing sessionId', () => {
+      const result = parseUpdateSourceSettingsInput({
+        sourceLanguage: 'en-US',
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('UpdateSourceSettingsOutput', () => {
+    it('carries sessionId and appliedAt', () => {
+      const output: UpdateSourceSettingsOutput = {
+        sessionId: SESSION_ID,
+        appliedAt: '2026-04-21T00:05:00.000Z',
+      };
+      expect(output.appliedAt).toBe('2026-04-21T00:05:00.000Z');
+    });
+  });
+
+  describe('UpdateSourceSettingsInput type shape', () => {
+    it('accepts a typed literal', () => {
+      const input: UpdateSourceSettingsInput = {
+        sessionId: SESSION_ID,
+        targetLanguage: 'ja-JP',
+      };
+      expect(input.targetLanguage).toBe('ja-JP');
+    });
+  });
+});

--- a/packages/extension/src/application/dto/update-source-settings-dto.ts
+++ b/packages/extension/src/application/dto/update-source-settings-dto.ts
@@ -1,0 +1,75 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../../domain/shared/errors';
+import {
+  OVERLAY_MIN_LINES,
+  OVERLAY_OPACITY_BOUNDS,
+  OVERLAY_POSITION_PRESETS,
+} from '../../domain/specifications/overlay-settings-specification';
+
+/**
+ * BCP-47 簡易 regex (domain/session/language-pair.ts と同期)。
+ */
+const bcp47Schema = z.string().regex(/^[a-z]{2,3}(?:-[A-Z]{2})?$/);
+
+const overlaySettingsPayloadSchema = z.object({
+  positionPreset: z.enum(OVERLAY_POSITION_PRESETS),
+  opacity: z.number().min(OVERLAY_OPACITY_BOUNDS.min).max(OVERLAY_OPACITY_BOUNDS.max),
+  maxLines: z.number().int().min(OVERLAY_MIN_LINES),
+  fontScale: z.number().positive(),
+  showOriginalText: z.boolean(),
+  showTranslatedText: z.boolean(),
+});
+
+/**
+ * オーバーレイ設定更新入力 DTO (DTO-I-303, DD-303)。
+ *
+ * いずれのオプションも省略可能だが、何らかのフィールドが指定されない場合は
+ * 更新対象なしとして UseCase 層で no-op 扱いされる。値域は
+ * `domain/specifications/overlay-settings-specification.ts` の定数と同期。
+ */
+export type UpdateSourceSettingsInput = {
+  sessionId: string;
+  sourceLanguage?: string | null | undefined;
+  targetLanguage?: string | undefined;
+  overlaySettings?:
+    | {
+        positionPreset: (typeof OVERLAY_POSITION_PRESETS)[number];
+        opacity: number;
+        maxLines: number;
+        fontScale: number;
+        showOriginalText: boolean;
+        showTranslatedText: boolean;
+      }
+    | undefined;
+};
+
+const updateSourceSettingsInputSchema = z.object({
+  sessionId: z.string().min(1),
+  sourceLanguage: bcp47Schema.nullable().optional(),
+  targetLanguage: bcp47Schema.optional(),
+  overlaySettings: overlaySettingsPayloadSchema.optional(),
+});
+
+export const parseUpdateSourceSettingsInput = (
+  raw: unknown,
+): Result<UpdateSourceSettingsInput, DomainError> => {
+  const result = updateSourceSettingsInputSchema.safeParse(raw);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'UpdateSourceSettingsInput',
+        message: result.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};
+
+/**
+ * オーバーレイ設定更新出力 DTO (DTO-O-303)。
+ */
+export type UpdateSourceSettingsOutput = Readonly<{
+  sessionId: string;
+  appliedAt: string;
+}>;

--- a/packages/extension/src/application/ports/audio-preprocessor.test.ts
+++ b/packages/extension/src/application/ports/audio-preprocessor.test.ts
@@ -1,0 +1,92 @@
+import { okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import {
+  type AudioFrameChannel,
+  type AudioFrameEnvelope,
+  type AudioPreprocessor,
+} from './audio-preprocessor';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const emptyChannel = (): AudioFrameChannel => ({
+  frames: {
+    [Symbol.asyncIterator]: () => ({
+      next: () => Promise.resolve({ done: true, value: undefined }),
+    }),
+  },
+  close: () => {
+    /* noop */
+  },
+});
+
+const frameEnvelope = (sequenceNumber: number): AudioFrameEnvelope => ({
+  sessionIdentifier,
+  sequenceNumber,
+  sampleRate: 16000,
+  channels: 1,
+  pcm16Base64: 'AA==',
+  capturedAt: '2026-04-21T00:00:00.000Z',
+  durationMs: 100,
+});
+
+describe('AudioPreprocessor (DD-104)', () => {
+  describe('type contract', () => {
+    it('accepts an object literal that implements attach and detach', () => {
+      const mock: AudioPreprocessor = {
+        attach: () => okAsync(emptyChannel()),
+        detach: () => okAsync(undefined),
+      };
+      expect(typeof mock.attach).toBe('function');
+      expect(typeof mock.detach).toBe('function');
+    });
+  });
+
+  describe('AudioFrameEnvelope shape', () => {
+    it('conforms to the expected PCM 16kHz mono 100ms payload contract', () => {
+      const envelope = frameEnvelope(1);
+      expect(envelope.sampleRate).toBe(16000);
+      expect(envelope.channels).toBe(1);
+      expect(envelope.durationMs).toBe(100);
+      expect(typeof envelope.pcm16Base64).toBe('string');
+      expect(envelope.sequenceNumber).toBe(1);
+    });
+  });
+
+  describe('AudioFrameChannel', () => {
+    it('frames is an AsyncIterable and yields AudioFrameEnvelope values', async () => {
+      const channel: AudioFrameChannel = {
+        frames: (async function* () {
+          await Promise.resolve();
+          yield frameEnvelope(1);
+          yield frameEnvelope(2);
+        })(),
+        close: () => {
+          /* noop */
+        },
+      };
+      const collected: AudioFrameEnvelope[] = [];
+      for await (const frame of channel.frames) {
+        collected.push(frame);
+      }
+      expect(collected).toHaveLength(2);
+      expect(collected[0]?.sequenceNumber).toBe(1);
+      expect(collected[1]?.sequenceNumber).toBe(2);
+    });
+  });
+
+  describe('detach', () => {
+    it('resolves to ok(void) on the success path', async () => {
+      const mock: AudioPreprocessor = {
+        attach: () => okAsync(emptyChannel()),
+        detach: () => okAsync(undefined),
+      };
+      const result = await mock.detach(sessionIdentifier);
+      expect(result.isOk()).toBe(true);
+    });
+  });
+});

--- a/packages/extension/src/application/ports/audio-preprocessor.ts
+++ b/packages/extension/src/application/ports/audio-preprocessor.ts
@@ -1,0 +1,51 @@
+import { type ResultAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * 音声フレームエンベロープ (DD-104)。
+ *
+ * AudioWorklet で前処理した PCM16 モノラル 16kHz 100ms フレームの搬送形式。
+ * Relay API (DD-401) へ audio.frame メッセージとして送信される。
+ */
+export type AudioFrameEnvelope = Readonly<{
+  sessionIdentifier: SessionIdentifier;
+  sequenceNumber: number;
+  sampleRate: 16000;
+  channels: 1;
+  pcm16Base64: string;
+  capturedAt: string;
+  durationMs: number;
+}>;
+
+/**
+ * PCM フレーム配信チャネル。
+ * `frames` は AsyncIterable で毎 100ms に新しいフレームを yield する。
+ * `close` は購読者がチャネルを明示的に終了する際に呼ぶ (AudioContext の
+ * クリーンアップをトリガ)。
+ */
+export type AudioFrameChannel = Readonly<{
+  frames: AsyncIterable<AudioFrameEnvelope>;
+  close: () => void;
+}>;
+
+/**
+ * 音声前処理ポート (DD-104)。
+ *
+ * `MediaStream` を受け取り AudioWorklet でモノラル化 / 16kHz リサンプリング /
+ * 100ms PCM16 フレーム化を行い、`AudioFrameChannel` として配信する。
+ *
+ * ホットパス最重要 (infrastructure.md §10.1): 音声フレーム化は 100ms 以内に
+ * 完了することが性能要件。
+ *
+ * エラー:
+ * - `attach`: AudioContext 取得失敗 / AudioWorklet ロード失敗時は
+ *   `invariantViolationError({ invariant: 'audio-context-unavailable' })` を想定
+ */
+export type AudioPreprocessor = Readonly<{
+  attach: (
+    stream: MediaStream,
+    sessionIdentifier: SessionIdentifier,
+  ) => ResultAsync<AudioFrameChannel, DomainError>;
+  detach: (sessionIdentifier: SessionIdentifier) => ResultAsync<void, DomainError>;
+}>;

--- a/packages/extension/src/application/ports/index.ts
+++ b/packages/extension/src/application/ports/index.ts
@@ -1,0 +1,11 @@
+export type {
+  AudioFrameChannel,
+  AudioFrameEnvelope,
+  AudioPreprocessor,
+} from './audio-preprocessor';
+export type { OverlayLine, OverlayPresenter, OverlayRenderModel } from './overlay-presenter';
+export type { PermissionCoordinator, PermissionGrant } from './permission-coordinator';
+export type { RelayEvent, RelayEventListener, RelayGateway, Unsubscribe } from './relay-gateway';
+export type { ExportBundle, SessionStore } from './session-store';
+export type { SettingsStore } from './settings-store';
+export type { SourceAdapter, SourceAdapterFactory, StartSourceCommand } from './source-adapter';

--- a/packages/extension/src/application/ports/overlay-presenter.test.ts
+++ b/packages/extension/src/application/ports/overlay-presenter.test.ts
@@ -1,0 +1,118 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { createOverlaySettings } from '../../domain/profile/overlay-settings';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import {
+  parseSegmentIdentifier,
+  type SegmentIdentifier,
+} from '../../domain/transcript/segment-identifier';
+import {
+  type OverlayLine,
+  type OverlayPresenter,
+  type OverlayRenderModel,
+} from './overlay-presenter';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+const segmentIdentifier: SegmentIdentifier = parseSegmentIdentifier(SEGMENT_ID)._unsafeUnwrap();
+
+const overlaySettings = createOverlaySettings({
+  positionPreset: 'bottom',
+  opacity: 0.8,
+  maxLines: 2,
+  fontScale: 1,
+  showOriginalText: true,
+  showTranslatedText: true,
+})._unsafeUnwrap();
+
+const sampleLine: OverlayLine = {
+  segmentIdentifier,
+  originalText: 'hello',
+  translatedText: 'こんにちは',
+  targetLanguage: 'ja-JP',
+  isFinal: true,
+};
+
+const sampleModel: OverlayRenderModel = {
+  sessionIdentifier,
+  lines: [sampleLine],
+};
+
+const okMock: OverlayPresenter = {
+  mount: () => okAsync(undefined),
+  render: () => okAsync(undefined),
+  updateSettings: () => okAsync(undefined),
+  unmount: () => okAsync(undefined),
+};
+
+describe('OverlayPresenter (DD-108)', () => {
+  describe('type contract', () => {
+    it('accepts an object literal implementing all four methods', () => {
+      expect(typeof okMock.mount).toBe('function');
+      expect(typeof okMock.render).toBe('function');
+      expect(typeof okMock.updateSettings).toBe('function');
+      expect(typeof okMock.unmount).toBe('function');
+    });
+  });
+
+  describe('OverlayRenderModel', () => {
+    it('carries sessionIdentifier and an ordered list of lines', () => {
+      expect(sampleModel.sessionIdentifier).toBe(SESSION_ID);
+      expect(sampleModel.lines).toHaveLength(1);
+      expect(sampleModel.lines[0]?.segmentIdentifier).toBe(SEGMENT_ID);
+    });
+
+    it('OverlayLine allows original-only, translation-only, or both to be present', () => {
+      const originalOnly: OverlayLine = {
+        segmentIdentifier,
+        originalText: 'hello',
+        translatedText: null,
+        targetLanguage: null,
+        isFinal: false,
+      };
+      const translationOnly: OverlayLine = {
+        segmentIdentifier,
+        originalText: null,
+        translatedText: 'こんにちは',
+        targetLanguage: 'ja-JP',
+        isFinal: true,
+      };
+      expect(originalOnly.translatedText).toBeNull();
+      expect(translationOnly.originalText).toBeNull();
+    });
+  });
+
+  describe('mount / render / updateSettings / unmount', () => {
+    it('all resolve to ok(void) on the success path', async () => {
+      const m = await okMock.mount(sessionIdentifier);
+      const r = await okMock.render(sampleModel);
+      const u = await okMock.updateSettings(sessionIdentifier, overlaySettings);
+      const un = await okMock.unmount(sessionIdentifier);
+      expect(m.isOk()).toBe(true);
+      expect(r.isOk()).toBe(true);
+      expect(u.isOk()).toBe(true);
+      expect(un.isOk()).toBe(true);
+    });
+
+    it('mount can return invariantViolationError when DOM target is unavailable', async () => {
+      const mock: OverlayPresenter = {
+        ...okMock,
+        mount: () =>
+          errAsync<void, DomainError>(
+            invariantViolationError({
+              invariant: 'overlay-mount-failed',
+              details: 'Shadow DOM host not found',
+            }),
+          ),
+      };
+      const result = await mock.mount(sessionIdentifier);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    });
+  });
+});

--- a/packages/extension/src/application/ports/overlay-presenter.ts
+++ b/packages/extension/src/application/ports/overlay-presenter.ts
@@ -1,0 +1,57 @@
+import { type ResultAsync } from 'neverthrow';
+import { type OverlaySettings } from '../../domain/profile/overlay-settings';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type DomainError } from '../../domain/shared/errors';
+import { type SegmentIdentifier } from '../../domain/transcript/segment-identifier';
+
+/**
+ * オーバーレイの 1 行分の表示モデル。
+ *
+ * `originalText` / `translatedText` はそれぞれ `null` を許容し、
+ * `OverlaySettings.showOriginalText` / `showTranslatedText` 設定に応じて
+ * アプリケーション層で事前フィルタされる。
+ */
+export type OverlayLine = Readonly<{
+  segmentIdentifier: SegmentIdentifier;
+  originalText: string | null;
+  translatedText: string | null;
+  targetLanguage: string | null;
+  isFinal: boolean;
+}>;
+
+/**
+ * オーバーレイへの描画モデル。特定セッションの最新字幕集合を渡す。
+ */
+export type OverlayRenderModel = Readonly<{
+  sessionIdentifier: SessionIdentifier;
+  lines: readonly OverlayLine[];
+}>;
+
+/**
+ * オーバーレイ描画ポート (DD-108)。
+ *
+ * Content Script + Shadow DOM で対象ページに翻訳オーバーレイを表示する
+ * 抽象 interface。ページ CSS 競合を避けるため Shadow DOM が前提。
+ *
+ * ライフサイクル:
+ * - `mount`: セッション開始時に Shadow host を対象ページへ注入
+ * - `render`: `transcript.partial` / `final` / `translation.final` 受信ごとに
+ *   最新字幕モデルをプッシュ (ホットパス上)
+ * - `updateSettings`: 利用者がオーバーレイ設定を変更した際に反映
+ * - `unmount`: セッション停止時にリソースを解放
+ *
+ * エラー:
+ * - `mount`: Shadow DOM ホスト作成失敗時
+ *   `invariantViolationError({ invariant: 'overlay-mount-failed' })` を想定
+ * - `render` 失敗はアプリケーション層で WARN ログに留める
+ *   (UI 描画失敗がホットパスを止めないように)
+ */
+export type OverlayPresenter = Readonly<{
+  mount: (sessionIdentifier: SessionIdentifier) => ResultAsync<void, DomainError>;
+  render: (model: OverlayRenderModel) => ResultAsync<void, DomainError>;
+  updateSettings: (
+    sessionIdentifier: SessionIdentifier,
+    settings: OverlaySettings,
+  ) => ResultAsync<void, DomainError>;
+  unmount: (sessionIdentifier: SessionIdentifier) => ResultAsync<void, DomainError>;
+}>;

--- a/packages/extension/src/application/ports/permission-coordinator.test.ts
+++ b/packages/extension/src/application/ports/permission-coordinator.test.ts
@@ -1,0 +1,66 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { type PermissionCoordinator, type PermissionGrant } from './permission-coordinator';
+
+describe('PermissionCoordinator (DD-001)', () => {
+  describe('type contract', () => {
+    it('accepts an object literal that implements requestFor', () => {
+      const mock: PermissionCoordinator = {
+        requestFor: () => okAsync({ status: 'granted', sourceType: 'tab' }),
+      };
+      expect(typeof mock.requestFor).toBe('function');
+    });
+  });
+
+  describe('requestFor', () => {
+    it('returns a granted PermissionGrant when the user allows capture', async () => {
+      const mock: PermissionCoordinator = {
+        requestFor: (sourceType) => okAsync({ status: 'granted', sourceType }),
+      };
+      const result = await mock.requestFor('microphone');
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.status).toBe('granted');
+        if (result.value.status === 'granted') {
+          expect(result.value.sourceType).toBe('microphone');
+        }
+      }
+    });
+
+    it('returns a denied PermissionGrant with an optional reason when the user rejects', async () => {
+      const mock: PermissionCoordinator = {
+        requestFor: (sourceType) =>
+          okAsync({
+            status: 'denied',
+            sourceType,
+            reason: 'user-dismissed-prompt',
+          }),
+      };
+      const result = await mock.requestFor('desktop');
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.status).toBe('denied');
+        if (result.value.status === 'denied') {
+          expect(result.value.sourceType).toBe('desktop');
+          expect(result.value.reason).toBe('user-dismissed-prompt');
+        }
+      }
+    });
+
+    it('returns a DomainError only when the permissions API itself is inoperable', async () => {
+      const mock: PermissionCoordinator = {
+        requestFor: () =>
+          errAsync<PermissionGrant, DomainError>(
+            invariantViolationError({
+              invariant: 'permission-api-unavailable',
+              details: 'chrome.permissions API is not accessible',
+            }),
+          ),
+      };
+      const result = await mock.requestFor('tab');
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    });
+  });
+});

--- a/packages/extension/src/application/ports/permission-coordinator.ts
+++ b/packages/extension/src/application/ports/permission-coordinator.ts
@@ -1,0 +1,25 @@
+import { type ResultAsync } from 'neverthrow';
+import { type SourceType } from '../../domain/session/source-type';
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * 権限要求の結果 (DD-001)。
+ *
+ * 拒否 (`denied`) は**ビジネス的に有効な結果**であり DomainError で Err
+ * として返さない。DomainError を返すのは chrome.permissions API 自体が
+ * 動作不能な system-level エラーのみ。
+ */
+export type PermissionGrant =
+  | Readonly<{ status: 'granted'; sourceType: SourceType }>
+  | Readonly<{ status: 'denied'; sourceType: SourceType; reason?: string }>;
+
+/**
+ * 権限調整ポート (DD-001)。
+ *
+ * SourceType に応じた Chrome 拡張権限要求 (activeTab / microphone /
+ * desktopCapture) を抽象化する。詳細設計書 §3.1 DD-001 の音声ソース開始
+ * シーケンスで呼ばれる。
+ */
+export type PermissionCoordinator = Readonly<{
+  requestFor: (sourceType: SourceType) => ResultAsync<PermissionGrant, DomainError>;
+}>;

--- a/packages/extension/src/application/ports/relay-gateway.test.ts
+++ b/packages/extension/src/application/ports/relay-gateway.test.ts
@@ -1,0 +1,158 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { createSourceSession, type SourceSession } from '../../domain/session/source-session';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { type AudioFrameEnvelope } from './audio-preprocessor';
+import { type RelayEvent, type RelayGateway } from './relay-gateway';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const buildSession = (): SourceSession =>
+  createSourceSession({
+    sessionIdentifier: SESSION_ID,
+    sourceIdentifier: SOURCE_ID,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt: '2026-04-21T00:00:00.000Z',
+  })._unsafeUnwrap();
+
+const buildFrame = (sequenceNumber: number): AudioFrameEnvelope => ({
+  sessionIdentifier,
+  sequenceNumber,
+  sampleRate: 16000,
+  channels: 1,
+  pcm16Base64: 'AA==',
+  capturedAt: '2026-04-21T00:00:00.000Z',
+  durationMs: 100,
+});
+
+const okMock: RelayGateway = {
+  openSession: () => okAsync(undefined),
+  sendAudioFrame: () => okAsync(undefined),
+  closeSession: () => okAsync(undefined),
+  subscribe: () => () => {
+    /* unsubscribe noop */
+  },
+};
+
+describe('RelayGateway (DD-401)', () => {
+  describe('type contract', () => {
+    it('accepts an object literal implementing the full interface', () => {
+      expect(typeof okMock.openSession).toBe('function');
+      expect(typeof okMock.sendAudioFrame).toBe('function');
+      expect(typeof okMock.closeSession).toBe('function');
+      expect(typeof okMock.subscribe).toBe('function');
+    });
+  });
+
+  describe('openSession / sendAudioFrame / closeSession', () => {
+    it('all resolve to ok(void) on the success path', async () => {
+      const o = await okMock.openSession(buildSession());
+      const s = await okMock.sendAudioFrame(buildFrame(1));
+      const c = await okMock.closeSession(sessionIdentifier);
+      expect(o.isOk()).toBe(true);
+      expect(s.isOk()).toBe(true);
+      expect(c.isOk()).toBe(true);
+    });
+
+    it('openSession can return invariantViolationError when Relay WebSocket handshake fails', async () => {
+      const mock: RelayGateway = {
+        ...okMock,
+        openSession: () =>
+          errAsync<void, DomainError>(
+            invariantViolationError({
+              invariant: 'relay-handshake-failed',
+              details: 'stream token rejected',
+            }),
+          ),
+      };
+      const result = await mock.openSession(buildSession());
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    });
+  });
+
+  describe('subscribe', () => {
+    it('invokes the listener with published RelayEvent instances', () => {
+      const listener = vi.fn<(event: RelayEvent) => void>();
+      let broadcast: ((event: RelayEvent) => void) | undefined;
+      const mock: RelayGateway = {
+        ...okMock,
+        subscribe: (_, cb) => {
+          broadcast = cb;
+          return () => {
+            broadcast = undefined;
+          };
+        },
+      };
+      const unsubscribe = mock.subscribe(sessionIdentifier, listener);
+      broadcast?.({
+        type: 'session.ready',
+        sessionIdentifier,
+        streamToken: 'token-xxx',
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+      unsubscribe();
+      broadcast?.({
+        type: 'session.ready',
+        sessionIdentifier,
+        streamToken: 'token-yyy',
+      });
+      // After unsubscribe, the mock clears broadcast so further events should not invoke listener.
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('RelayEvent discriminated union', () => {
+    it('narrows payload via the type discriminator', () => {
+      const events: RelayEvent[] = [
+        { type: 'session.ready', sessionIdentifier, streamToken: 'tkn' },
+        {
+          type: 'transcript.partial',
+          sessionIdentifier,
+          segmentIdentifier: 'seg-1',
+          revision: 1,
+          text: 'hello',
+        },
+        {
+          type: 'transcript.final',
+          sessionIdentifier,
+          segmentIdentifier: 'seg-1',
+          text: 'hello',
+          finalizedAt: '2026-04-21T00:00:05.000Z',
+        },
+        {
+          type: 'translation.final',
+          sessionIdentifier,
+          segmentIdentifier: 'seg-1',
+          translationIdentifier: 'tr-1',
+          targetLanguage: 'ja-JP',
+          text: 'こんにちは',
+        },
+        {
+          type: 'session.error',
+          sessionIdentifier,
+          code: 'TRANSLATION_TIMEOUT',
+          message: 'translation timed out',
+          retryable: true,
+          fatal: false,
+        },
+      ];
+      for (const event of events) {
+        if (event.type === 'transcript.partial') {
+          expect(event.revision).toBe(1);
+        } else if (event.type === 'session.error') {
+          expect(event.retryable).toBe(true);
+          expect(event.fatal).toBe(false);
+        }
+      }
+    });
+  });
+});

--- a/packages/extension/src/application/ports/relay-gateway.ts
+++ b/packages/extension/src/application/ports/relay-gateway.ts
@@ -1,0 +1,83 @@
+import { type ResultAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type SessionState } from '../../domain/session/session-state';
+import { type SourceSession } from '../../domain/session/source-session';
+import { type DomainError } from '../../domain/shared/errors';
+import { type AudioFrameEnvelope } from './audio-preprocessor';
+
+/**
+ * Relay API から受信するサーバーイベント (DD-401 / api-specification.md §6.3)。
+ *
+ * 全イベントに `sessionIdentifier` を含めて subscribe 側で絞り込み可能に
+ * する。`session.error` は `retryable` / `fatal` フラグで取り扱いを分岐。
+ */
+export type RelayEvent =
+  | Readonly<{
+      type: 'session.ready';
+      sessionIdentifier: SessionIdentifier;
+      streamToken: string;
+    }>
+  | Readonly<{
+      type: 'transcript.partial';
+      sessionIdentifier: SessionIdentifier;
+      segmentIdentifier: string;
+      revision: number;
+      text: string;
+    }>
+  | Readonly<{
+      type: 'transcript.final';
+      sessionIdentifier: SessionIdentifier;
+      segmentIdentifier: string;
+      text: string;
+      finalizedAt: string;
+    }>
+  | Readonly<{
+      type: 'translation.final';
+      sessionIdentifier: SessionIdentifier;
+      segmentIdentifier: string;
+      translationIdentifier: string;
+      targetLanguage: string;
+      text: string;
+    }>
+  | Readonly<{
+      type: 'session.state.changed';
+      sessionIdentifier: SessionIdentifier;
+      state: SessionState;
+    }>
+  | Readonly<{
+      type: 'session.error';
+      sessionIdentifier: SessionIdentifier;
+      code: string;
+      message: string;
+      retryable: boolean;
+      fatal: boolean;
+    }>;
+
+export type RelayEventListener = (event: RelayEvent) => void;
+export type Unsubscribe = () => void;
+
+/**
+ * Relay WebSocket ゲートウェイポート (DD-401)。
+ *
+ * `packages/relay-api` への制御メッセージ送信とサーバーイベント購読を抽象化
+ * する。WebSocket の接続確立は `openSession` 内で実行し、`subscribe` で
+ * 購読者に配信する。ホットパス最重要 (audio.frame 送信 ≤50ms、infrastructure.md
+ * §10.1)。
+ *
+ * エラー:
+ * - `openSession`: ハンドシェイク失敗 / stream token 拒否時
+ *   `invariantViolationError({ invariant: 'relay-handshake-failed' })` を想定
+ * - `sendAudioFrame`: WebSocket 切断時は即座に Err (再接続は呼び出し側が
+ *   `openSession` 再試行で対応)
+ * - `closeSession`: 正常クローズ。失敗しても ok(void) で済ませる
+ *
+ * 購読:
+ * - `subscribe` は同期的に listener を登録し、`Unsubscribe` 関数を返す。
+ *   呼び出し側は session lifecycle の終了時に必ず unsubscribe する
+ */
+export type RelayGateway = Readonly<{
+  openSession: (session: SourceSession) => ResultAsync<void, DomainError>;
+  sendAudioFrame: (frame: AudioFrameEnvelope) => ResultAsync<void, DomainError>;
+  closeSession: (sessionIdentifier: SessionIdentifier) => ResultAsync<void, DomainError>;
+  subscribe: (sessionIdentifier: SessionIdentifier, listener: RelayEventListener) => Unsubscribe;
+}>;

--- a/packages/extension/src/application/ports/session-store.test.ts
+++ b/packages/extension/src/application/ports/session-store.test.ts
@@ -1,0 +1,135 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { createSourceSession, type SourceSession } from '../../domain/session/source-session';
+import {
+  invariantViolationError,
+  notFoundError,
+  type DomainError,
+} from '../../domain/shared/errors';
+import { createTimestampRange } from '../../domain/transcript/timestamp-range';
+import {
+  createPartialTranscriptSegment,
+  type TranscriptSegment,
+} from '../../domain/transcript/transcript-segment';
+import { createTranscriptStream } from '../../domain/transcript/transcript-stream';
+import {
+  createCompletedTranslationSegment,
+  type TranslationSegment,
+} from '../../domain/transcript/translation-segment';
+import { type ExportBundle, type SessionStore } from './session-store';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+const TRANSLATION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7E1';
+
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const buildSession = (): SourceSession =>
+  createSourceSession({
+    sessionIdentifier: SESSION_ID,
+    sourceIdentifier: SOURCE_ID,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt: '2026-04-21T00:00:00.000Z',
+  })._unsafeUnwrap();
+
+const buildSegment = (): TranscriptSegment =>
+  createPartialTranscriptSegment({
+    segmentIdentifier: SEGMENT_ID,
+    revision: 1,
+    text: 'hello',
+    timeRange: createTimestampRange({ startMs: 0, endMs: 1500 })._unsafeUnwrap(),
+  })._unsafeUnwrap();
+
+const buildTranslation = (): TranslationSegment =>
+  createCompletedTranslationSegment({
+    translationIdentifier: TRANSLATION_ID,
+    segmentIdentifier: SEGMENT_ID,
+    targetLanguage: 'ja-JP',
+    text: 'こんにちは',
+  })._unsafeUnwrap();
+
+const buildBundle = (): ExportBundle => ({
+  session: buildSession(),
+  stream: createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap(),
+});
+
+const okMock: SessionStore = {
+  saveSession: () => okAsync(undefined),
+  appendTranscript: () => okAsync(undefined),
+  appendTranslation: () => okAsync(undefined),
+  loadExportBundle: () => okAsync(buildBundle()),
+};
+
+describe('SessionStore (DD-106)', () => {
+  describe('type contract', () => {
+    it('accepts an object literal that implements all four required methods', () => {
+      expect(typeof okMock.saveSession).toBe('function');
+      expect(typeof okMock.appendTranscript).toBe('function');
+      expect(typeof okMock.appendTranslation).toBe('function');
+      expect(typeof okMock.loadExportBundle).toBe('function');
+    });
+  });
+
+  describe('saveSession', () => {
+    it('resolves to ok(void) on success', async () => {
+      const result = await okMock.saveSession(buildSession());
+      expect(result.isOk()).toBe(true);
+    });
+  });
+
+  describe('appendTranscript and appendTranslation', () => {
+    it('both resolve to ok(void) on success (append-only semantics)', async () => {
+      const t = await okMock.appendTranscript(sessionIdentifier, buildSegment());
+      const tr = await okMock.appendTranslation(sessionIdentifier, buildTranslation());
+      expect(t.isOk()).toBe(true);
+      expect(tr.isOk()).toBe(true);
+    });
+
+    it('can return invariantViolationError when storage fails (hot-path continues regardless)', async () => {
+      const mock: SessionStore = {
+        ...okMock,
+        appendTranscript: () =>
+          errAsync<void, DomainError>(
+            invariantViolationError({
+              invariant: 'session-persistence',
+              details: 'IndexedDB quota exceeded',
+            }),
+          ),
+      };
+      const result = await mock.appendTranscript(sessionIdentifier, buildSegment());
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    });
+  });
+
+  describe('loadExportBundle', () => {
+    it('returns session and stream as an ExportBundle', async () => {
+      const result = await okMock.loadExportBundle(sessionIdentifier);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.session.sessionIdentifier).toBe(SESSION_ID);
+        expect(result.value.stream.sessionIdentifier).toBe(SESSION_ID);
+      }
+    });
+
+    it('returns notFoundError when session does not exist', async () => {
+      const mock: SessionStore = {
+        ...okMock,
+        loadExportBundle: (id) =>
+          errAsync<ExportBundle, DomainError>(
+            notFoundError({ resourceType: 'SourceSession', identifier: id }),
+          ),
+      };
+      const result = await mock.loadExportBundle(sessionIdentifier);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('not-found');
+    });
+  });
+});

--- a/packages/extension/src/application/ports/session-store.ts
+++ b/packages/extension/src/application/ports/session-store.ts
@@ -1,0 +1,41 @@
+import { type ResultAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type SourceSession } from '../../domain/session/source-session';
+import { type DomainError } from '../../domain/shared/errors';
+import { type TranscriptSegment } from '../../domain/transcript/transcript-segment';
+import { type TranscriptStream } from '../../domain/transcript/transcript-stream';
+import { type TranslationSegment } from '../../domain/transcript/translation-segment';
+
+/**
+ * セッションストアポート (DD-106)。
+ *
+ * IndexedDB に字幕・翻訳を非同期 append-only で永続化する抽象 interface
+ * (DB-001〜004)。ホットパス外で実行され、失敗時も UI 表示・翻訳フローは
+ * 継続する結果整合設計 (CLAUDE.md §ホットパス最優先原則)。
+ *
+ * エラー:
+ * - `saveSession` / `appendTranscript` / `appendTranslation`: storage 書き込み
+ *   失敗時 `invariantViolationError({ invariant: 'session-persistence' })`
+ *   を想定。呼び出し側は WARN ログに留め、ホットパスを落とさない
+ * - `loadExportBundle`: 指定セッションが存在しない場合
+ *   `notFoundError({ resourceType: 'SourceSession', identifier })` を Err
+ */
+export type ExportBundle = Readonly<{
+  session: SourceSession;
+  stream: TranscriptStream;
+}>;
+
+export type SessionStore = Readonly<{
+  saveSession: (session: SourceSession) => ResultAsync<void, DomainError>;
+  appendTranscript: (
+    sessionIdentifier: SessionIdentifier,
+    segment: TranscriptSegment,
+  ) => ResultAsync<void, DomainError>;
+  appendTranslation: (
+    sessionIdentifier: SessionIdentifier,
+    translation: TranslationSegment,
+  ) => ResultAsync<void, DomainError>;
+  loadExportBundle: (
+    sessionIdentifier: SessionIdentifier,
+  ) => ResultAsync<ExportBundle, DomainError>;
+}>;

--- a/packages/extension/src/application/ports/settings-store.test.ts
+++ b/packages/extension/src/application/ports/settings-store.test.ts
@@ -1,0 +1,79 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { createOverlaySettings, type OverlaySettings } from '../../domain/profile/overlay-settings';
+import { createLanguagePair, type LanguagePair } from '../../domain/session/language-pair';
+import { notFoundError, type DomainError } from '../../domain/shared/errors';
+import { type SettingsStore } from './settings-store';
+
+const buildLanguagePair = (): LanguagePair =>
+  createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap();
+
+const buildOverlaySettings = (): OverlaySettings =>
+  createOverlaySettings({
+    positionPreset: 'bottom',
+    opacity: 0.8,
+    maxLines: 2,
+    fontScale: 1,
+    showOriginalText: true,
+    showTranslatedText: true,
+  })._unsafeUnwrap();
+
+describe('SettingsStore (DD-107)', () => {
+  describe('type contract', () => {
+    it('accepts an object literal that implements all four required methods', () => {
+      const mock: SettingsStore = {
+        getDefaultLanguagePair: () => okAsync(buildLanguagePair()),
+        saveDefaultLanguagePair: () => okAsync(undefined),
+        getDefaultOverlaySettings: () => okAsync(buildOverlaySettings()),
+        saveDefaultOverlaySettings: () => okAsync(undefined),
+      };
+      expect(typeof mock.getDefaultLanguagePair).toBe('function');
+      expect(typeof mock.saveDefaultLanguagePair).toBe('function');
+      expect(typeof mock.getDefaultOverlaySettings).toBe('function');
+      expect(typeof mock.saveDefaultOverlaySettings).toBe('function');
+    });
+  });
+
+  describe('getDefaultLanguagePair', () => {
+    it('returns stored LanguagePair on success', async () => {
+      const pair = buildLanguagePair();
+      const mock: SettingsStore = {
+        getDefaultLanguagePair: () => okAsync(pair),
+        saveDefaultLanguagePair: () => okAsync(undefined),
+        getDefaultOverlaySettings: () => okAsync(buildOverlaySettings()),
+        saveDefaultOverlaySettings: () => okAsync(undefined),
+      };
+      const result = await mock.getDefaultLanguagePair();
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) expect(result.value).toBe(pair);
+    });
+
+    it('returns notFoundError when uninitialized', async () => {
+      const mock: SettingsStore = {
+        getDefaultLanguagePair: () =>
+          errAsync<LanguagePair, DomainError>(
+            notFoundError({ resourceType: 'LanguagePair', identifier: 'default' }),
+          ),
+        saveDefaultLanguagePair: () => okAsync(undefined),
+        getDefaultOverlaySettings: () => okAsync(buildOverlaySettings()),
+        saveDefaultOverlaySettings: () => okAsync(undefined),
+      };
+      const result = await mock.getDefaultLanguagePair();
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('not-found');
+    });
+  });
+
+  describe('saveDefaultOverlaySettings', () => {
+    it('resolves to ok(void) on success (upsert semantics)', async () => {
+      const mock: SettingsStore = {
+        getDefaultLanguagePair: () => okAsync(buildLanguagePair()),
+        saveDefaultLanguagePair: () => okAsync(undefined),
+        getDefaultOverlaySettings: () => okAsync(buildOverlaySettings()),
+        saveDefaultOverlaySettings: () => okAsync(undefined),
+      };
+      const result = await mock.saveDefaultOverlaySettings(buildOverlaySettings());
+      expect(result.isOk()).toBe(true);
+    });
+  });
+});

--- a/packages/extension/src/application/ports/settings-store.ts
+++ b/packages/extension/src/application/ports/settings-store.ts
@@ -1,0 +1,26 @@
+import { type ResultAsync } from 'neverthrow';
+import { type OverlaySettings } from '../../domain/profile/overlay-settings';
+import { type LanguagePair } from '../../domain/session/language-pair';
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * 設定ストアポート (DD-107)。
+ *
+ * 拡張の既定値 (言語ペア / オーバーレイ設定) を `chrome.storage.local` 等の
+ * 軽量ストレージに保存する抽象 interface。起動時即時復元用途 (DB-005)。
+ *
+ * キーは値オブジェクト単位に型特化し、キー文字列は infrastructure 実装の
+ * 詳細として扱う (呼び出し側は keyed generic API を意識しない)。
+ *
+ * エラー:
+ * - `getDefault*`: 未初期化時
+ *   `notFoundError({ resourceType, identifier: 'default' })` を Err で返す
+ * - `saveDefault*`: storage 書き込み失敗時
+ *   `invariantViolationError` を想定
+ */
+export type SettingsStore = Readonly<{
+  getDefaultLanguagePair: () => ResultAsync<LanguagePair, DomainError>;
+  saveDefaultLanguagePair: (pair: LanguagePair) => ResultAsync<void, DomainError>;
+  getDefaultOverlaySettings: () => ResultAsync<OverlaySettings, DomainError>;
+  saveDefaultOverlaySettings: (settings: OverlaySettings) => ResultAsync<void, DomainError>;
+}>;

--- a/packages/extension/src/application/ports/source-adapter.test.ts
+++ b/packages/extension/src/application/ports/source-adapter.test.ts
@@ -1,0 +1,108 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import {
+  type SourceAdapter,
+  type SourceAdapterFactory,
+  type StartSourceCommand,
+} from './source-adapter';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const tabCommand: StartSourceCommand = {
+  sourceType: 'tab',
+  sessionIdentifier,
+  tabId: 42,
+};
+
+const microphoneCommand: StartSourceCommand = {
+  sourceType: 'microphone',
+  sessionIdentifier,
+  deviceId: 'default',
+};
+
+const desktopCommand: StartSourceCommand = {
+  sourceType: 'desktop',
+  sessionIdentifier,
+};
+
+const erroringAdapter: SourceAdapter = {
+  open: () =>
+    errAsync<MediaStream, DomainError>(
+      invariantViolationError({
+        invariant: 'source-open-failed',
+        details: 'capture permission denied',
+      }),
+    ),
+  close: () => okAsync(undefined),
+};
+
+describe('SourceAdapter (DD-101〜103)', () => {
+  describe('type contract', () => {
+    it('accepts an object literal that implements open and close', () => {
+      expect(typeof erroringAdapter.open).toBe('function');
+      expect(typeof erroringAdapter.close).toBe('function');
+    });
+  });
+
+  describe('StartSourceCommand discriminated union', () => {
+    it('accepts tab variant with optional tabId', () => {
+      expect(tabCommand.sourceType).toBe('tab');
+      if (tabCommand.sourceType === 'tab') {
+        expect(tabCommand.tabId).toBe(42);
+      }
+    });
+
+    it('accepts microphone variant with optional deviceId', () => {
+      expect(microphoneCommand.sourceType).toBe('microphone');
+      if (microphoneCommand.sourceType === 'microphone') {
+        expect(microphoneCommand.deviceId).toBe('default');
+      }
+    });
+
+    it('accepts desktop variant without additional fields', () => {
+      expect(desktopCommand.sourceType).toBe('desktop');
+    });
+  });
+
+  describe('open error path', () => {
+    it('returns invariantViolationError when capture fails', async () => {
+      const result = await erroringAdapter.open(tabCommand);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe('invariant-violation');
+        if (result.error.kind === 'invariant-violation') {
+          expect(result.error.invariant).toBe('source-open-failed');
+        }
+      }
+    });
+  });
+
+  describe('close', () => {
+    it('resolves to ok(void) on the success path', async () => {
+      const result = await erroringAdapter.close(sessionIdentifier);
+      expect(result.isOk()).toBe(true);
+    });
+  });
+});
+
+describe('SourceAdapterFactory', () => {
+  const factoryMock: SourceAdapterFactory = {
+    create: () => erroringAdapter,
+  };
+
+  it('accepts an object literal implementing create', () => {
+    expect(typeof factoryMock.create).toBe('function');
+  });
+
+  it('returns a SourceAdapter instance for a given sourceType', () => {
+    const adapter = factoryMock.create('tab');
+    expect(typeof adapter.open).toBe('function');
+    expect(typeof adapter.close).toBe('function');
+  });
+});

--- a/packages/extension/src/application/ports/source-adapter.ts
+++ b/packages/extension/src/application/ports/source-adapter.ts
@@ -1,0 +1,54 @@
+import { type ResultAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type SourceType } from '../../domain/session/source-type';
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * 音声ソース開始コマンド (DD-101〜103)。
+ *
+ * SourceType ごとに固有パラメータを持つ discriminated union。
+ */
+export type StartSourceCommand =
+  | Readonly<{
+      sourceType: 'tab';
+      sessionIdentifier: SessionIdentifier;
+      tabId?: number;
+    }>
+  | Readonly<{
+      sourceType: 'microphone';
+      sessionIdentifier: SessionIdentifier;
+      deviceId?: string;
+    }>
+  | Readonly<{
+      sourceType: 'desktop';
+      sessionIdentifier: SessionIdentifier;
+    }>;
+
+/**
+ * 音声ソースアダプタポート (DD-101〜103)。
+ *
+ * Chrome 拡張の 3 種類の音声取得 API (`chrome.tabCapture` /
+ * `navigator.mediaDevices.getUserMedia` / `chrome.desktopCapture` +
+ * `getDisplayMedia`) を統一した interface で抽象化する。
+ *
+ * エラー:
+ * - `open`: 権限拒否 / ストリーム取得失敗時
+ *   `invariantViolationError({ invariant: 'source-open-failed', ... })` を想定。
+ *   権限拒否は `PermissionCoordinator` (IMPL-206) で事前に処理されるため、
+ *   ここでは system-level の失敗 (API 不利用可能、タブ消失等) を主に扱う
+ * - `close`: リソース解放失敗は警告レベル。基本的に ok(void) を返す
+ */
+export type SourceAdapter = Readonly<{
+  open: (command: StartSourceCommand) => ResultAsync<MediaStream, DomainError>;
+  close: (sessionIdentifier: SessionIdentifier) => ResultAsync<void, DomainError>;
+}>;
+
+/**
+ * ソースアダプタファクトリ (DD-101〜103)。
+ *
+ * SourceType に応じた具体アダプタ (Tab / Microphone / Desktop) を返す純粋関数
+ * ファクトリ。SessionCommandService がコマンド処理時に呼び出す。
+ */
+export type SourceAdapterFactory = Readonly<{
+  create: (sourceType: SourceType) => SourceAdapter;
+}>;

--- a/packages/extension/src/domain/events/domain-events.test.ts
+++ b/packages/extension/src/domain/events/domain-events.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from '../session/language-pair.js';
-import { createSourceSession } from '../session/source-session.js';
-import { createPartialTranscriptSegment } from '../transcript/transcript-segment.js';
-import { createTimestampRange } from '../transcript/timestamp-range.js';
-import { createCompletedTranslationSegment } from '../transcript/translation-segment.js';
+import { createLanguagePair } from '../session/language-pair';
+import { createSourceSession } from '../session/source-session';
+import { createPartialTranscriptSegment } from '../transcript/transcript-segment';
+import { createTimestampRange } from '../transcript/timestamp-range';
+import { createCompletedTranslationSegment } from '../transcript/translation-segment';
 import {
   sourceSessionDegraded,
   sourceSessionStarted,
@@ -12,7 +12,7 @@ import {
   transcriptPartialUpdated,
   translationCompleted,
   type DomainEvent,
-} from './domain-events.js';
+} from './domain-events';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';

--- a/packages/extension/src/domain/events/domain-events.ts
+++ b/packages/extension/src/domain/events/domain-events.ts
@@ -1,11 +1,11 @@
-import { type SessionIdentifier } from '../session/session-identifier.js';
-import { type SourceIdentifier } from '../session/source-identifier.js';
-import { type SourceSession } from '../session/source-session.js';
-import { type SourceType } from '../session/source-type.js';
-import { type SegmentIdentifier } from '../transcript/segment-identifier.js';
-import { type TranscriptSegment } from '../transcript/transcript-segment.js';
-import { type TranslationIdentifier } from '../transcript/translation-identifier.js';
-import { type TranslationSegment } from '../transcript/translation-segment.js';
+import { type SessionIdentifier } from '../session/session-identifier';
+import { type SourceIdentifier } from '../session/source-identifier';
+import { type SourceSession } from '../session/source-session';
+import { type SourceType } from '../session/source-type';
+import { type SegmentIdentifier } from '../transcript/segment-identifier';
+import { type TranscriptSegment } from '../transcript/transcript-segment';
+import { type TranslationIdentifier } from '../transcript/translation-identifier';
+import { type TranslationSegment } from '../transcript/translation-segment';
 
 /**
  * ドメインイベント (DD-250〜DD-255)。

--- a/packages/extension/src/domain/export/export-identifier.test.ts
+++ b/packages/extension/src/domain/export/export-identifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createExportIdentifier, parseExportIdentifier } from './export-identifier.js';
+import { createExportIdentifier, parseExportIdentifier } from './export-identifier';
 
 describe('ExportIdentifier', () => {
   it('creates a ULID-shaped identifier', () => {

--- a/packages/extension/src/domain/export/export-identifier.ts
+++ b/packages/extension/src/domain/export/export-identifier.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
 import { ulid } from 'ulid';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * エクスポートレコード (`ExportRecord`, DD-223) の識別子。

--- a/packages/extension/src/domain/export/export-record.test.ts
+++ b/packages/extension/src/domain/export/export-record.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createExportRecord, EXPORT_FORMATS } from './export-record.js';
+import { createExportRecord, EXPORT_FORMATS } from './export-record';
 
 const VALID_EXPORT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 const VALID_SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X9';

--- a/packages/extension/src/domain/export/export-record.ts
+++ b/packages/extension/src/domain/export/export-record.ts
@@ -1,8 +1,8 @@
 import { err, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
-import { type DomainError, validationError } from '../shared/errors.js';
-import { parseExportIdentifier, type ExportIdentifier } from './export-identifier.js';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier';
+import { type DomainError, validationError } from '../shared/errors';
+import { parseExportIdentifier, type ExportIdentifier } from './export-identifier';
 
 /**
  * エクスポート形式の列挙 (DD-273 ExportFormatSpecification)。

--- a/packages/extension/src/domain/profile/extension-profile.test.ts
+++ b/packages/extension/src/domain/profile/extension-profile.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from '../session/language-pair.js';
+import { createLanguagePair } from '../session/language-pair';
 import {
   createExtensionProfile,
   updateDefaultLanguagePair,
   updateDefaultOverlaySettings,
   toggleAutoDetect,
-} from './extension-profile.js';
-import { createOverlaySettings } from './overlay-settings.js';
+} from './extension-profile';
+import { createOverlaySettings } from './overlay-settings';
 
 const PROFILE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 const defaultLanguagePair = createLanguagePair({

--- a/packages/extension/src/domain/profile/extension-profile.ts
+++ b/packages/extension/src/domain/profile/extension-profile.ts
@@ -1,8 +1,8 @@
 import { ok, type Result } from 'neverthrow';
-import { type LanguagePair } from '../session/language-pair.js';
-import { type DomainError } from '../shared/errors.js';
-import { type OverlaySettings } from './overlay-settings.js';
-import { parseProfileIdentifier, type ProfileIdentifier } from './profile-identifier.js';
+import { type LanguagePair } from '../session/language-pair';
+import { type DomainError } from '../shared/errors';
+import { type OverlaySettings } from './overlay-settings';
+import { parseProfileIdentifier, type ProfileIdentifier } from './profile-identifier';
 
 /**
  * 拡張プロファイル集約ルート (DD-212)。

--- a/packages/extension/src/domain/profile/overlay-settings.test.ts
+++ b/packages/extension/src/domain/profile/overlay-settings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createOverlaySettings } from './overlay-settings.js';
+import { createOverlaySettings } from './overlay-settings';
 
 const baseValid = {
   positionPreset: 'bottom' as const,

--- a/packages/extension/src/domain/profile/overlay-settings.ts
+++ b/packages/extension/src/domain/profile/overlay-settings.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 翻訳オーバーレイの表示設定 (DD-234)。

--- a/packages/extension/src/domain/profile/profile-identifier.ts
+++ b/packages/extension/src/domain/profile/profile-identifier.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
 import { ulid } from 'ulid';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 拡張プロファイル集約 (`ExtensionProfile`, DD-212) の識別子。

--- a/packages/extension/src/domain/repositories/export-record-repository.test.ts
+++ b/packages/extension/src/domain/repositories/export-record-repository.test.ts
@@ -1,9 +1,9 @@
 import { errAsync, okAsync } from 'neverthrow';
 import { describe, expect, it } from 'vitest';
-import { createExportRecord, type ExportRecord } from '../export/export-record.js';
-import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
-import { invariantViolationError, type DomainError } from '../shared/errors.js';
-import { type ExportRecordRepository } from './export-record-repository.js';
+import { createExportRecord, type ExportRecord } from '../export/export-record';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier';
+import { invariantViolationError, type DomainError } from '../shared/errors';
+import { type ExportRecordRepository } from './export-record-repository';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const EXPORT_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7F1';

--- a/packages/extension/src/domain/repositories/export-record-repository.ts
+++ b/packages/extension/src/domain/repositories/export-record-repository.ts
@@ -1,7 +1,7 @@
 import { type ResultAsync } from 'neverthrow';
-import { type ExportRecord } from '../export/export-record.js';
-import { type SessionIdentifier } from '../session/session-identifier.js';
-import { type DomainError } from '../shared/errors.js';
+import { type ExportRecord } from '../export/export-record';
+import { type SessionIdentifier } from '../session/session-identifier';
+import { type DomainError } from '../shared/errors';
 
 /**
  * エクスポート履歴リポジトリ (DD-263)。

--- a/packages/extension/src/domain/repositories/extension-profile-repository.test.ts
+++ b/packages/extension/src/domain/repositories/extension-profile-repository.test.ts
@@ -1,10 +1,10 @@
 import { errAsync, okAsync } from 'neverthrow';
 import { describe, expect, it } from 'vitest';
-import { createExtensionProfile, type ExtensionProfile } from '../profile/extension-profile.js';
-import { createOverlaySettings } from '../profile/overlay-settings.js';
-import { createLanguagePair } from '../session/language-pair.js';
-import { notFoundError, type DomainError } from '../shared/errors.js';
-import { type ExtensionProfileRepository } from './extension-profile-repository.js';
+import { createExtensionProfile, type ExtensionProfile } from '../profile/extension-profile';
+import { createOverlaySettings } from '../profile/overlay-settings';
+import { createLanguagePair } from '../session/language-pair';
+import { notFoundError, type DomainError } from '../shared/errors';
+import { type ExtensionProfileRepository } from './extension-profile-repository';
 
 const PROFILE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
 

--- a/packages/extension/src/domain/repositories/extension-profile-repository.ts
+++ b/packages/extension/src/domain/repositories/extension-profile-repository.ts
@@ -1,6 +1,6 @@
 import { type ResultAsync } from 'neverthrow';
-import { type ExtensionProfile } from '../profile/extension-profile.js';
-import { type DomainError } from '../shared/errors.js';
+import { type ExtensionProfile } from '../profile/extension-profile';
+import { type DomainError } from '../shared/errors';
 
 /**
  * 拡張プロファイルリポジトリ (DD-262)。

--- a/packages/extension/src/domain/repositories/index.ts
+++ b/packages/extension/src/domain/repositories/index.ts
@@ -1,4 +1,4 @@
-export type { ExtensionProfileRepository } from './extension-profile-repository.js';
-export type { ExportRecordRepository } from './export-record-repository.js';
-export type { SourceSessionRepository } from './source-session-repository.js';
-export type { TranscriptStreamRepository } from './transcript-stream-repository.js';
+export type { ExtensionProfileRepository } from './extension-profile-repository';
+export type { ExportRecordRepository } from './export-record-repository';
+export type { SourceSessionRepository } from './source-session-repository';
+export type { TranscriptStreamRepository } from './transcript-stream-repository';

--- a/packages/extension/src/domain/repositories/source-session-repository.test.ts
+++ b/packages/extension/src/domain/repositories/source-session-repository.test.ts
@@ -1,10 +1,10 @@
 import { errAsync, okAsync } from 'neverthrow';
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from '../session/language-pair.js';
-import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
-import { createSourceSession, type SourceSession } from '../session/source-session.js';
-import { notFoundError, type DomainError } from '../shared/errors.js';
-import { type SourceSessionRepository } from './source-session-repository.js';
+import { createLanguagePair } from '../session/language-pair';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier';
+import { createSourceSession, type SourceSession } from '../session/source-session';
+import { notFoundError, type DomainError } from '../shared/errors';
+import { type SourceSessionRepository } from './source-session-repository';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const SESSION_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';

--- a/packages/extension/src/domain/repositories/source-session-repository.ts
+++ b/packages/extension/src/domain/repositories/source-session-repository.ts
@@ -1,7 +1,7 @@
 import { type ResultAsync } from 'neverthrow';
-import { type SessionIdentifier } from '../session/session-identifier.js';
-import { type SourceSession } from '../session/source-session.js';
-import { type DomainError } from '../shared/errors.js';
+import { type SessionIdentifier } from '../session/session-identifier';
+import { type SourceSession } from '../session/source-session';
+import { type DomainError } from '../shared/errors';
 
 /**
  * ソースセッションリポジトリ (DD-260)。

--- a/packages/extension/src/domain/repositories/transcript-stream-repository.test.ts
+++ b/packages/extension/src/domain/repositories/transcript-stream-repository.test.ts
@@ -1,19 +1,19 @@
 import { errAsync, okAsync } from 'neverthrow';
 import { describe, expect, it } from 'vitest';
-import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
-import { invariantViolationError, notFoundError, type DomainError } from '../shared/errors.js';
-import { createTimestampRange } from '../transcript/timestamp-range.js';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier';
+import { invariantViolationError, notFoundError, type DomainError } from '../shared/errors';
+import { createTimestampRange } from '../transcript/timestamp-range';
 import {
   createPartialTranscriptSegment,
   finalizeTranscriptSegment,
   type TranscriptSegment,
-} from '../transcript/transcript-segment.js';
-import { createTranscriptStream, type TranscriptStream } from '../transcript/transcript-stream.js';
+} from '../transcript/transcript-segment';
+import { createTranscriptStream, type TranscriptStream } from '../transcript/transcript-stream';
 import {
   createCompletedTranslationSegment,
   type TranslationSegment,
-} from '../transcript/translation-segment.js';
-import { type TranscriptStreamRepository } from './transcript-stream-repository.js';
+} from '../transcript/translation-segment';
+import { type TranscriptStreamRepository } from './transcript-stream-repository';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';

--- a/packages/extension/src/domain/repositories/transcript-stream-repository.ts
+++ b/packages/extension/src/domain/repositories/transcript-stream-repository.ts
@@ -1,9 +1,9 @@
 import { type ResultAsync } from 'neverthrow';
-import { type SessionIdentifier } from '../session/session-identifier.js';
-import { type DomainError } from '../shared/errors.js';
-import { type TranscriptSegment } from '../transcript/transcript-segment.js';
-import { type TranscriptStream } from '../transcript/transcript-stream.js';
-import { type TranslationSegment } from '../transcript/translation-segment.js';
+import { type SessionIdentifier } from '../session/session-identifier';
+import { type DomainError } from '../shared/errors';
+import { type TranscriptSegment } from '../transcript/transcript-segment';
+import { type TranscriptStream } from '../transcript/transcript-stream';
+import { type TranslationSegment } from '../transcript/translation-segment';
 
 /**
  * 字幕ストリームリポジトリ (DD-261)。

--- a/packages/extension/src/domain/services/export-assembly-service.test.ts
+++ b/packages/extension/src/domain/services/export-assembly-service.test.ts
@@ -5,13 +5,13 @@ import {
   createTranscriptStream,
   finalizeSegment,
   type TranscriptStream,
-} from '../transcript/transcript-stream.js';
+} from '../transcript/transcript-stream';
 import {
   createFailedTranslationSegment,
   type TranslationSegment,
-} from '../transcript/translation-segment.js';
-import { createTimestampRange, type TimestampRange } from '../transcript/timestamp-range.js';
-import { assembleExport } from './export-assembly-service.js';
+} from '../transcript/translation-segment';
+import { createTimestampRange, type TimestampRange } from '../transcript/timestamp-range';
+import { assembleExport } from './export-assembly-service';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
 const SEGMENT_IDS = [

--- a/packages/extension/src/domain/services/export-assembly-service.ts
+++ b/packages/extension/src/domain/services/export-assembly-service.ts
@@ -1,9 +1,9 @@
 import { err, ok, type Result } from 'neverthrow';
-import { type ExportFormat } from '../export/export-record.js';
-import { type TranscriptSegment } from '../transcript/transcript-segment.js';
-import { type TranscriptStream } from '../transcript/transcript-stream.js';
-import { type TranslationSegment } from '../transcript/translation-segment.js';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type ExportFormat } from '../export/export-record';
+import { type TranscriptSegment } from '../transcript/transcript-segment';
+import { type TranscriptStream } from '../transcript/transcript-stream';
+import { type TranslationSegment } from '../transcript/translation-segment';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * エクスポート整形サービス (DD-242)。

--- a/packages/extension/src/domain/services/language-routing-policy.test.ts
+++ b/packages/extension/src/domain/services/language-routing-policy.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { createExtensionProfile, type ExtensionProfile } from '../profile/extension-profile.js';
-import { createOverlaySettings } from '../profile/overlay-settings.js';
-import { createLanguagePair, type LanguagePair } from '../session/language-pair.js';
-import { resolveEffectiveLanguagePair } from './language-routing-policy.js';
+import { createExtensionProfile, type ExtensionProfile } from '../profile/extension-profile';
+import { createOverlaySettings } from '../profile/overlay-settings';
+import { createLanguagePair, type LanguagePair } from '../session/language-pair';
+import { resolveEffectiveLanguagePair } from './language-routing-policy';
 
 const PROFILE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
 

--- a/packages/extension/src/domain/services/language-routing-policy.ts
+++ b/packages/extension/src/domain/services/language-routing-policy.ts
@@ -1,7 +1,7 @@
 import { ok, type Result } from 'neverthrow';
-import { type ExtensionProfile } from '../profile/extension-profile.js';
-import { createLanguagePair, type LanguagePair } from '../session/language-pair.js';
-import { type DomainError } from '../shared/errors.js';
+import { type ExtensionProfile } from '../profile/extension-profile';
+import { createLanguagePair, type LanguagePair } from '../session/language-pair';
+import { type DomainError } from '../shared/errors';
 
 /**
  * 言語ルーティングポリシー (DD-243)。

--- a/packages/extension/src/domain/services/session-concurrency-policy.test.ts
+++ b/packages/extension/src/domain/services/session-concurrency-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from '../session/language-pair.js';
+import { createLanguagePair } from '../session/language-pair';
 import {
   createSourceSession,
   markSourceSessionDegraded,
@@ -8,9 +8,9 @@ import {
   stopSourceSession,
   transitionSourceSessionState,
   type SourceSession,
-} from '../session/source-session.js';
-import { type SessionState } from '../session/session-state.js';
-import { validateSessionConcurrency } from './session-concurrency-policy.js';
+} from '../session/source-session';
+import { type SessionState } from '../session/session-state';
+import { validateSessionConcurrency } from './session-concurrency-policy';
 
 const SESSION_IDS = [
   '01HZX8Y1R8M7D3Q2P4T5V6W7A1',

--- a/packages/extension/src/domain/services/session-concurrency-policy.ts
+++ b/packages/extension/src/domain/services/session-concurrency-policy.ts
@@ -1,47 +1,36 @@
 import { err, ok, type Result } from 'neverthrow';
 import { type SourceSession } from '../session/source-session.js';
-import { type SessionState } from '../session/session-state.js';
 import { type DomainError, invariantViolationError } from '../shared/errors.js';
+import {
+  MAX_CONCURRENT_ACTIVE_SESSIONS,
+  countActiveSessions,
+  satisfiesConcurrentSessionLimit,
+} from '../specifications/concurrent-session-limit-specification.js';
 
 /**
  * セッション並行度ポリシー (DD-240)。
  *
- * 設計文書: domain.md DD-240, DD-270 (ConcurrentSessionLimitSpecification)。
- * `SourceSession` が同時にアクティブに保持できる数の上限 (3) を保証する。
+ * Specification (DD-270, `domain/specifications/concurrent-session-limit-specification.ts`)
+ * を利用して不変条件を検証し、違反時に `DomainError` を組み立てる責務を持つ。
  *
- * アクティブ = `stopped` 以外の状態。`error` も「acknowledge() → stopped」で
- * 終了させるまではリソースを保持しているため稼働中として扱う。
+ * 使用箇所: `StartSourceSessionUseCase` の事前条件チェック
+ * (use-case.md §10.1 `Policy.validate()`)。
  *
- * IMPL-150 `ConcurrentSessionLimitSpecification` 実装時に、`isActiveSession` /
- * `countActiveSessions` を述語 spec へ移動し、本ポリシーはそれを利用する形に
- * リファクタされる予定。
- */
-export const MAX_CONCURRENT_ACTIVE_SESSIONS = 3 as const;
-
-const TERMINAL_STATES: ReadonlySet<SessionState> = new Set(['stopped']);
-
-export const isActiveSession = (session: SourceSession): boolean =>
-  !TERMINAL_STATES.has(session.state);
-
-export const countActiveSessions = (sessions: readonly SourceSession[]): number =>
-  sessions.reduce((count, session) => (isActiveSession(session) ? count + 1 : count), 0);
-
-/**
- * セッション追加前の事前条件チェック。既存アクティブ数が上限未満なら OK。
- * use-case.md §10.1 `StartSourceSessionUseCase` のシーケンスで
- * `Policy.validate()` として呼ばれる想定。
+ * 責務分担:
+ * - Specification = 純粋述語 (`satisfiesConcurrentSessionLimit` 等)
+ * - Policy = 違反時に `invariantViolationError` を組み立てる本モジュール
  */
 export const validateSessionConcurrency = (
   existingSessions: readonly SourceSession[],
 ): Result<void, DomainError> => {
-  const activeCount = countActiveSessions(existingSessions);
-  if (activeCount >= MAX_CONCURRENT_ACTIVE_SESSIONS) {
-    return err(
-      invariantViolationError({
-        invariant: 'concurrent-session-limit',
-        details: `active session count ${String(activeCount)} would exceed limit ${String(MAX_CONCURRENT_ACTIVE_SESSIONS)}`,
-      }),
-    );
+  if (satisfiesConcurrentSessionLimit(existingSessions)) {
+    return ok(undefined);
   }
-  return ok(undefined);
+  const activeCount = countActiveSessions(existingSessions);
+  return err(
+    invariantViolationError({
+      invariant: 'concurrent-session-limit',
+      details: `active session count ${String(activeCount)} would exceed limit ${String(MAX_CONCURRENT_ACTIVE_SESSIONS)}`,
+    }),
+  );
 };

--- a/packages/extension/src/domain/services/session-concurrency-policy.ts
+++ b/packages/extension/src/domain/services/session-concurrency-policy.ts
@@ -1,11 +1,11 @@
 import { err, ok, type Result } from 'neverthrow';
-import { type SourceSession } from '../session/source-session.js';
-import { type DomainError, invariantViolationError } from '../shared/errors.js';
+import { type SourceSession } from '../session/source-session';
+import { type DomainError, invariantViolationError } from '../shared/errors';
 import {
   MAX_CONCURRENT_ACTIVE_SESSIONS,
   countActiveSessions,
   satisfiesConcurrentSessionLimit,
-} from '../specifications/concurrent-session-limit-specification.js';
+} from '../specifications/concurrent-session-limit-specification';
 
 /**
  * セッション並行度ポリシー (DD-240)。

--- a/packages/extension/src/domain/services/session-state-transition-policy.test.ts
+++ b/packages/extension/src/domain/services/session-state-transition-policy.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { SESSION_STATES, type SessionState } from '../session/session-state.js';
+import { SESSION_STATES, type SessionState } from '../session/session-state';
 import {
   ALLOWED_TRANSITIONS,
   canTransitionSessionState,
   validateSessionStateTransition,
-} from './session-state-transition-policy.js';
+} from './session-state-transition-policy';
 
 /**
  * 状態遷移表 (detailed-design.md §7.2) を網羅的に検証する。

--- a/packages/extension/src/domain/services/session-state-transition-policy.ts
+++ b/packages/extension/src/domain/services/session-state-transition-policy.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from 'neverthrow';
-import { type SessionState } from '../session/session-state.js';
-import { type DomainError, sessionStateTransitionError } from '../shared/errors.js';
+import { type SessionState } from '../session/session-state';
+import { type DomainError, sessionStateTransitionError } from '../shared/errors';
 
 /**
  * ソースセッション状態遷移ポリシー (DD-241)。

--- a/packages/extension/src/domain/session/language-pair.test.ts
+++ b/packages/extension/src/domain/session/language-pair.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from './language-pair.js';
+import { createLanguagePair } from './language-pair';
 
 describe('LanguagePair', () => {
   it('accepts a valid pair (en-US -> ja-JP)', () => {

--- a/packages/extension/src/domain/session/language-pair.ts
+++ b/packages/extension/src/domain/session/language-pair.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * BCP-47 言語タグの簡易検証。言語コード (2-3 文字小文字) + 任意の地域コード

--- a/packages/extension/src/domain/session/session-identifier.test.ts
+++ b/packages/extension/src/domain/session/session-identifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createSessionIdentifier, parseSessionIdentifier } from './session-identifier.js';
+import { createSessionIdentifier, parseSessionIdentifier } from './session-identifier';
 
 const VALID_ULID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 

--- a/packages/extension/src/domain/session/session-identifier.ts
+++ b/packages/extension/src/domain/session/session-identifier.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
 import { ulid } from 'ulid';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * ソースセッション集約 (DD-210) の自己識別子 (DD-230)。

--- a/packages/extension/src/domain/session/session-state.test.ts
+++ b/packages/extension/src/domain/session/session-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { SESSION_STATES, parseSessionState } from './session-state.js';
+import { SESSION_STATES, parseSessionState } from './session-state';
 
 describe('SessionState', () => {
   it('enumerates exactly 11 states (DD-233)', () => {

--- a/packages/extension/src/domain/session/session-state.ts
+++ b/packages/extension/src/domain/session/session-state.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * `SourceSession` 集約の状態値 (DD-233 / DD-210)。

--- a/packages/extension/src/domain/session/source-identifier.test.ts
+++ b/packages/extension/src/domain/session/source-identifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createSourceIdentifier, parseSourceIdentifier } from './source-identifier.js';
+import { createSourceIdentifier, parseSourceIdentifier } from './source-identifier';
 
 const VALID_ULID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 

--- a/packages/extension/src/domain/session/source-identifier.ts
+++ b/packages/extension/src/domain/session/source-identifier.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
 import { ulid } from 'ulid';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 音声ソース (`AudioSource`) の識別子 (DD-231)。

--- a/packages/extension/src/domain/session/source-session.test.ts
+++ b/packages/extension/src/domain/session/source-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from './language-pair.js';
+import { createLanguagePair } from './language-pair';
 import {
   createSourceSession,
   markSourceSessionDegraded,
@@ -9,7 +9,7 @@ import {
   startSourceSession,
   stopSourceSession,
   transitionSourceSessionState,
-} from './source-session.js';
+} from './source-session';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X9';

--- a/packages/extension/src/domain/session/source-session.ts
+++ b/packages/extension/src/domain/session/source-session.ts
@@ -3,17 +3,13 @@ import { z } from 'zod';
 import {
   canTransitionSessionState,
   validateSessionStateTransition,
-} from '../services/session-state-transition-policy.js';
-import {
-  type DomainError,
-  sessionStateTransitionError,
-  validationError,
-} from '../shared/errors.js';
-import { type LanguagePair } from './language-pair.js';
-import { parseSessionIdentifier, type SessionIdentifier } from './session-identifier.js';
-import { type SessionState } from './session-state.js';
-import { parseSourceIdentifier, type SourceIdentifier } from './source-identifier.js';
-import { parseSourceType, type SourceType } from './source-type.js';
+} from '../services/session-state-transition-policy';
+import { type DomainError, sessionStateTransitionError, validationError } from '../shared/errors';
+import { type LanguagePair } from './language-pair';
+import { parseSessionIdentifier, type SessionIdentifier } from './session-identifier';
+import { type SessionState } from './session-state';
+import { parseSourceIdentifier, type SourceIdentifier } from './source-identifier';
+import { parseSourceType, type SourceType } from './source-type';
 
 /**
  * ソースセッション集約ルート (DD-210 / DD-220)。

--- a/packages/extension/src/domain/session/source-type.test.ts
+++ b/packages/extension/src/domain/session/source-type.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { SOURCE_TYPES, parseSourceType } from './source-type.js';
+import { SOURCE_TYPES, parseSourceType } from './source-type';
 
 describe('SourceType', () => {
   it('accepts "tab"', () => {

--- a/packages/extension/src/domain/session/source-type.ts
+++ b/packages/extension/src/domain/session/source-type.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 音声ソース種別 (DD-210 ソースセッション集約)。

--- a/packages/extension/src/domain/shared/errors.test.ts
+++ b/packages/extension/src/domain/shared/errors.test.ts
@@ -6,7 +6,7 @@ import {
   sessionStateTransitionError,
   validationError,
   type DomainError,
-} from './errors.js';
+} from './errors';
 
 describe('DomainError factories', () => {
   it('creates a session-state-transition error', () => {

--- a/packages/extension/src/domain/specifications/concurrent-session-limit-specification.test.ts
+++ b/packages/extension/src/domain/specifications/concurrent-session-limit-specification.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createLanguagePair } from '../session/language-pair.js';
+import { createLanguagePair } from '../session/language-pair';
 import {
   createSourceSession,
   markSourceSessionDegraded,
@@ -8,14 +8,14 @@ import {
   stopSourceSession,
   transitionSourceSessionState,
   type SourceSession,
-} from '../session/source-session.js';
-import { SESSION_STATES, type SessionState } from '../session/session-state.js';
+} from '../session/source-session';
+import { SESSION_STATES, type SessionState } from '../session/session-state';
 import {
   MAX_CONCURRENT_ACTIVE_SESSIONS,
   countActiveSessions,
   isActiveSession,
   satisfiesConcurrentSessionLimit,
-} from './concurrent-session-limit-specification.js';
+} from './concurrent-session-limit-specification';
 
 const SESSION_IDS = [
   '01HZX8Y1R8M7D3Q2P4T5V6W7A1',

--- a/packages/extension/src/domain/specifications/concurrent-session-limit-specification.test.ts
+++ b/packages/extension/src/domain/specifications/concurrent-session-limit-specification.test.ts
@@ -9,8 +9,13 @@ import {
   transitionSourceSessionState,
   type SourceSession,
 } from '../session/source-session.js';
-import { type SessionState } from '../session/session-state.js';
-import { validateSessionConcurrency } from './session-concurrency-policy.js';
+import { SESSION_STATES, type SessionState } from '../session/session-state.js';
+import {
+  MAX_CONCURRENT_ACTIVE_SESSIONS,
+  countActiveSessions,
+  isActiveSession,
+  satisfiesConcurrentSessionLimit,
+} from './concurrent-session-limit-specification.js';
 
 const SESSION_IDS = [
   '01HZX8Y1R8M7D3Q2P4T5V6W7A1',
@@ -91,61 +96,104 @@ const withState = (index: number, targetState: SessionState): SourceSession => {
   }
 };
 
-describe('SessionConcurrencyPolicy (DD-240)', () => {
-  describe('validateSessionConcurrency', () => {
-    it('returns ok for empty active session list', () => {
-      const result = validateSessionConcurrency([]);
-      expect(result.isOk()).toBe(true);
+describe('ConcurrentSessionLimitSpecification (DD-270)', () => {
+  it('exposes MAX_CONCURRENT_ACTIVE_SESSIONS = 3', () => {
+    expect(MAX_CONCURRENT_ACTIVE_SESSIONS).toBe(3);
+  });
+
+  describe('isActiveSession', () => {
+    const ACTIVE: readonly SessionState[] = [
+      'idle',
+      'requesting_permission',
+      'connecting',
+      'capturing',
+      'transcribing',
+      'translating',
+      'paused',
+      'reconnecting',
+      'degraded',
+      'error',
+    ];
+    const TERMINAL: readonly SessionState[] = ['stopped'];
+
+    it.each(ACTIVE)('treats %s as active', (state) => {
+      expect(isActiveSession(withState(0, state))).toBe(true);
     });
 
-    it('returns ok when active count is 1', () => {
-      const result = validateSessionConcurrency([withState(0, 'capturing')]);
-      expect(result.isOk()).toBe(true);
+    it.each(TERMINAL)('treats %s as non-active (terminal)', (state) => {
+      expect(isActiveSession(withState(0, state))).toBe(false);
     });
 
-    it('returns ok when active count is 2 (below limit)', () => {
-      const result = validateSessionConcurrency([
-        withState(0, 'capturing'),
-        withState(1, 'transcribing'),
-      ]);
-      expect(result.isOk()).toBe(true);
-    });
-
-    it('returns err with invariant-violation when active count reaches the limit', () => {
-      const result = validateSessionConcurrency([
-        withState(0, 'capturing'),
-        withState(1, 'transcribing'),
-        withState(2, 'translating'),
-      ]);
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect(result.error.kind).toBe('invariant-violation');
-        if (result.error.kind === 'invariant-violation') {
-          expect(result.error.invariant).toBe('concurrent-session-limit');
-          expect(result.error.details).toContain('3');
-        }
+    it('covers all 11 SessionState variants in the categorization', () => {
+      const covered = new Set<SessionState>([...ACTIVE, ...TERMINAL]);
+      for (const state of SESSION_STATES) {
+        expect(covered.has(state)).toBe(true);
       }
     });
+  });
 
-    it('returns err when active count exceeds the limit', () => {
-      const result = validateSessionConcurrency([
-        withState(0, 'capturing'),
-        withState(1, 'transcribing'),
-        withState(2, 'translating'),
-        withState(3, 'paused'),
-      ]);
-      expect(result.isErr()).toBe(true);
+  describe('countActiveSessions', () => {
+    it('returns 0 for an empty input', () => {
+      expect(countActiveSessions([])).toBe(0);
     });
 
-    it('ignores stopped sessions when evaluating the limit (2 active + 10 stopped → ok)', () => {
-      const result = validateSessionConcurrency([
+    it('counts only active sessions, ignoring stopped ones', () => {
+      const sessions: readonly SourceSession[] = [
         withState(0, 'capturing'),
-        withState(1, 'transcribing'),
-        withState(2, 'stopped'),
-        withState(3, 'stopped'),
-        withState(4, 'stopped'),
-      ]);
-      expect(result.isOk()).toBe(true);
+        withState(1, 'stopped'),
+        withState(2, 'transcribing'),
+      ];
+      expect(countActiveSessions(sessions)).toBe(2);
+    });
+
+    it('returns 0 when all sessions are stopped', () => {
+      const sessions: readonly SourceSession[] = [withState(0, 'stopped'), withState(1, 'stopped')];
+      expect(countActiveSessions(sessions)).toBe(0);
+    });
+  });
+
+  describe('satisfiesConcurrentSessionLimit', () => {
+    it('returns true for an empty session list', () => {
+      expect(satisfiesConcurrentSessionLimit([])).toBe(true);
+    });
+
+    it('returns true when active count is below the limit', () => {
+      expect(
+        satisfiesConcurrentSessionLimit([withState(0, 'capturing'), withState(1, 'transcribing')]),
+      ).toBe(true);
+    });
+
+    it('returns false when active count equals the limit (adding one more would exceed)', () => {
+      expect(
+        satisfiesConcurrentSessionLimit([
+          withState(0, 'capturing'),
+          withState(1, 'transcribing'),
+          withState(2, 'translating'),
+        ]),
+      ).toBe(false);
+    });
+
+    it('returns false when active count exceeds the limit', () => {
+      expect(
+        satisfiesConcurrentSessionLimit([
+          withState(0, 'capturing'),
+          withState(1, 'transcribing'),
+          withState(2, 'translating'),
+          withState(3, 'paused'),
+        ]),
+      ).toBe(false);
+    });
+
+    it('ignores stopped sessions when counting', () => {
+      expect(
+        satisfiesConcurrentSessionLimit([
+          withState(0, 'capturing'),
+          withState(1, 'transcribing'),
+          withState(2, 'stopped'),
+          withState(3, 'stopped'),
+          withState(4, 'stopped'),
+        ]),
+      ).toBe(true);
     });
   });
 });

--- a/packages/extension/src/domain/specifications/concurrent-session-limit-specification.ts
+++ b/packages/extension/src/domain/specifications/concurrent-session-limit-specification.ts
@@ -1,5 +1,5 @@
-import { type SessionState } from '../session/session-state.js';
-import { type SourceSession } from '../session/source-session.js';
+import { type SessionState } from '../session/session-state';
+import { type SourceSession } from '../session/source-session';
 
 /**
  * 同時セッション数仕様 (DD-270)。

--- a/packages/extension/src/domain/specifications/concurrent-session-limit-specification.ts
+++ b/packages/extension/src/domain/specifications/concurrent-session-limit-specification.ts
@@ -1,0 +1,32 @@
+import { type SessionState } from '../session/session-state.js';
+import { type SourceSession } from '../session/source-session.js';
+
+/**
+ * 同時セッション数仕様 (DD-270)。
+ *
+ * 「同時にアクティブなソースは最大 3 まで」を判定する述語群。
+ *
+ * アクティブの定義: `stopped` 以外の状態 (`error` は `acknowledge → stopped`
+ * で終了するまでリソースを保持するため稼働中として扱う)。
+ *
+ * Policy (`domain/services/session-concurrency-policy.ts`) との責務分担:
+ * Specification = 純粋述語 (`boolean` を返す)、Policy = 違反時に
+ * `DomainError` を組み立てる。Policy は本 spec を内部で利用する。
+ */
+
+export const MAX_CONCURRENT_ACTIVE_SESSIONS = 3 as const;
+
+const TERMINAL_STATES: ReadonlySet<SessionState> = new Set(['stopped']);
+
+export const isActiveSession = (session: SourceSession): boolean =>
+  !TERMINAL_STATES.has(session.state);
+
+export const countActiveSessions = (sessions: readonly SourceSession[]): number =>
+  sessions.reduce((count, session) => (isActiveSession(session) ? count + 1 : count), 0);
+
+/**
+ * 新しいアクティブセッションを追加できる余地があるかを判定する述語。
+ * 使用箇所: `StartSourceSessionUseCase` の事前条件 (use-case.md §10.1)。
+ */
+export const satisfiesConcurrentSessionLimit = (sessions: readonly SourceSession[]): boolean =>
+  countActiveSessions(sessions) < MAX_CONCURRENT_ACTIVE_SESSIONS;

--- a/packages/extension/src/domain/specifications/export-format-specification.test.ts
+++ b/packages/extension/src/domain/specifications/export-format-specification.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { isValidExportFormat } from './export-format-specification.js';
+
+describe('ExportFormatSpecification (DD-273)', () => {
+  describe('isValidExportFormat', () => {
+    it('accepts "txt"', () => {
+      expect(isValidExportFormat('txt')).toBe(true);
+    });
+
+    it('accepts "json"', () => {
+      expect(isValidExportFormat('json')).toBe(true);
+    });
+
+    it('rejects unknown string values', () => {
+      expect(isValidExportFormat('csv')).toBe(false);
+      expect(isValidExportFormat('xml')).toBe(false);
+      expect(isValidExportFormat('')).toBe(false);
+      expect(isValidExportFormat('TXT')).toBe(false); // case-sensitive
+    });
+
+    it('rejects non-string values', () => {
+      expect(isValidExportFormat(0)).toBe(false);
+      expect(isValidExportFormat(null)).toBe(false);
+      expect(isValidExportFormat(undefined)).toBe(false);
+      expect(isValidExportFormat({})).toBe(false);
+      expect(isValidExportFormat([])).toBe(false);
+    });
+
+    it('acts as a type guard that narrows unknown to ExportFormat', () => {
+      const candidate: unknown = 'txt';
+      if (isValidExportFormat(candidate)) {
+        // Within this branch, candidate is narrowed to ExportFormat ('txt' | 'json')
+        expect(candidate).toBe('txt');
+      } else {
+        throw new Error('should have been valid');
+      }
+    });
+  });
+});

--- a/packages/extension/src/domain/specifications/export-format-specification.test.ts
+++ b/packages/extension/src/domain/specifications/export-format-specification.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isValidExportFormat } from './export-format-specification.js';
+import { isValidExportFormat } from './export-format-specification';
 
 describe('ExportFormatSpecification (DD-273)', () => {
   describe('isValidExportFormat', () => {

--- a/packages/extension/src/domain/specifications/export-format-specification.ts
+++ b/packages/extension/src/domain/specifications/export-format-specification.ts
@@ -1,4 +1,4 @@
-import { EXPORT_FORMATS, type ExportFormat } from '../export/export-record.js';
+import { EXPORT_FORMATS, type ExportFormat } from '../export/export-record';
 
 /**
  * エクスポート形式仕様 (DD-273)。

--- a/packages/extension/src/domain/specifications/export-format-specification.ts
+++ b/packages/extension/src/domain/specifications/export-format-specification.ts
@@ -1,0 +1,17 @@
+import { EXPORT_FORMATS, type ExportFormat } from '../export/export-record.js';
+
+/**
+ * エクスポート形式仕様 (DD-273)。
+ *
+ * エクスポート形式は TXT / JSON のみ許可する。値オブジェクト定義
+ * (`export-record.ts` の `EXPORT_FORMATS`) に委譲し、spec は runtime 述語
+ * (type guard) を提供する。
+ *
+ * Policy との責務分担: 本 spec は `boolean` を返す純粋述語。違反時の
+ * `DomainError` 組み立ては呼び出し側 (`createExportRecord` の `validationError`
+ * 生成など) が担う。
+ */
+export const isValidExportFormat = (value: unknown): value is ExportFormat => {
+  if (typeof value !== 'string') return false;
+  return EXPORT_FORMATS.some((format) => format === value);
+};

--- a/packages/extension/src/domain/specifications/index.ts
+++ b/packages/extension/src/domain/specifications/index.ts
@@ -3,8 +3,8 @@ export {
   countActiveSessions,
   isActiveSession,
   satisfiesConcurrentSessionLimit,
-} from './concurrent-session-limit-specification.js';
-export { isValidExportFormat } from './export-format-specification.js';
+} from './concurrent-session-limit-specification';
+export { isValidExportFormat } from './export-format-specification';
 export {
   OVERLAY_MIN_LINES,
   OVERLAY_OPACITY_BOUNDS,
@@ -15,5 +15,5 @@ export {
   isValidOverlayOpacity,
   isValidOverlayPositionPreset,
   type OverlayPositionPreset,
-} from './overlay-settings-specification.js';
-export { canAttachTranslation } from './translation-attachment-specification.js';
+} from './overlay-settings-specification';
+export { canAttachTranslation } from './translation-attachment-specification';

--- a/packages/extension/src/domain/specifications/index.ts
+++ b/packages/extension/src/domain/specifications/index.ts
@@ -1,0 +1,19 @@
+export {
+  MAX_CONCURRENT_ACTIVE_SESSIONS,
+  countActiveSessions,
+  isActiveSession,
+  satisfiesConcurrentSessionLimit,
+} from './concurrent-session-limit-specification.js';
+export { isValidExportFormat } from './export-format-specification.js';
+export {
+  OVERLAY_MIN_LINES,
+  OVERLAY_OPACITY_BOUNDS,
+  OVERLAY_POSITION_PRESETS,
+  hasAtLeastOneVisibleText,
+  isValidOverlayFontScale,
+  isValidOverlayMaxLines,
+  isValidOverlayOpacity,
+  isValidOverlayPositionPreset,
+  type OverlayPositionPreset,
+} from './overlay-settings-specification.js';
+export { canAttachTranslation } from './translation-attachment-specification.js';

--- a/packages/extension/src/domain/specifications/overlay-settings-specification.test.ts
+++ b/packages/extension/src/domain/specifications/overlay-settings-specification.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { createOverlaySettings } from '../profile/overlay-settings.js';
+import {
+  OVERLAY_MIN_LINES,
+  OVERLAY_OPACITY_BOUNDS,
+  OVERLAY_POSITION_PRESETS,
+  hasAtLeastOneVisibleText,
+  isValidOverlayFontScale,
+  isValidOverlayMaxLines,
+  isValidOverlayOpacity,
+  isValidOverlayPositionPreset,
+} from './overlay-settings-specification.js';
+
+describe('OverlaySettingsSpecification (DD-272)', () => {
+  describe('isValidOverlayPositionPreset', () => {
+    it.each(OVERLAY_POSITION_PRESETS)('accepts %s', (preset) => {
+      expect(isValidOverlayPositionPreset(preset)).toBe(true);
+    });
+
+    it('rejects unknown string values', () => {
+      expect(isValidOverlayPositionPreset('center')).toBe(false);
+      expect(isValidOverlayPositionPreset('TOP')).toBe(false); // case-sensitive
+      expect(isValidOverlayPositionPreset('')).toBe(false);
+    });
+
+    it('rejects non-string values', () => {
+      expect(isValidOverlayPositionPreset(0)).toBe(false);
+      expect(isValidOverlayPositionPreset(null)).toBe(false);
+      expect(isValidOverlayPositionPreset(undefined)).toBe(false);
+    });
+  });
+
+  describe('isValidOverlayOpacity', () => {
+    it('accepts the boundary values 0 and 1', () => {
+      expect(isValidOverlayOpacity(OVERLAY_OPACITY_BOUNDS.min)).toBe(true);
+      expect(isValidOverlayOpacity(OVERLAY_OPACITY_BOUNDS.max)).toBe(true);
+    });
+
+    it('accepts mid-range values', () => {
+      expect(isValidOverlayOpacity(0.5)).toBe(true);
+      expect(isValidOverlayOpacity(0.8)).toBe(true);
+    });
+
+    it('rejects out-of-range values', () => {
+      expect(isValidOverlayOpacity(-0.0001)).toBe(false);
+      expect(isValidOverlayOpacity(1.0001)).toBe(false);
+    });
+
+    it('rejects non-finite numbers', () => {
+      expect(isValidOverlayOpacity(Number.NaN)).toBe(false);
+      expect(isValidOverlayOpacity(Number.POSITIVE_INFINITY)).toBe(false);
+      expect(isValidOverlayOpacity(Number.NEGATIVE_INFINITY)).toBe(false);
+    });
+
+    it('rejects non-number values', () => {
+      expect(isValidOverlayOpacity('0.5')).toBe(false);
+      expect(isValidOverlayOpacity(null)).toBe(false);
+    });
+  });
+
+  describe('isValidOverlayMaxLines', () => {
+    it('accepts the minimum boundary', () => {
+      expect(isValidOverlayMaxLines(OVERLAY_MIN_LINES)).toBe(true);
+    });
+
+    it('accepts larger integers', () => {
+      expect(isValidOverlayMaxLines(2)).toBe(true);
+      expect(isValidOverlayMaxLines(100)).toBe(true);
+    });
+
+    it('rejects values below the minimum', () => {
+      expect(isValidOverlayMaxLines(0)).toBe(false);
+      expect(isValidOverlayMaxLines(-1)).toBe(false);
+    });
+
+    it('rejects non-integer numbers', () => {
+      expect(isValidOverlayMaxLines(1.5)).toBe(false);
+      expect(isValidOverlayMaxLines(Number.NaN)).toBe(false);
+    });
+
+    it('rejects non-number values', () => {
+      expect(isValidOverlayMaxLines('2')).toBe(false);
+      expect(isValidOverlayMaxLines(null)).toBe(false);
+    });
+  });
+
+  describe('isValidOverlayFontScale', () => {
+    it('accepts positive finite numbers', () => {
+      expect(isValidOverlayFontScale(0.1)).toBe(true);
+      expect(isValidOverlayFontScale(1)).toBe(true);
+      expect(isValidOverlayFontScale(2.5)).toBe(true);
+    });
+
+    it('rejects zero and negative numbers', () => {
+      expect(isValidOverlayFontScale(0)).toBe(false);
+      expect(isValidOverlayFontScale(-0.1)).toBe(false);
+    });
+
+    it('rejects non-finite values', () => {
+      expect(isValidOverlayFontScale(Number.POSITIVE_INFINITY)).toBe(false);
+      expect(isValidOverlayFontScale(Number.NaN)).toBe(false);
+    });
+  });
+
+  describe('hasAtLeastOneVisibleText', () => {
+    it('returns true when at least one of the two flags is true', () => {
+      expect(hasAtLeastOneVisibleText(true, true)).toBe(true);
+      expect(hasAtLeastOneVisibleText(true, false)).toBe(true);
+      expect(hasAtLeastOneVisibleText(false, true)).toBe(true);
+    });
+
+    it('returns false when both flags are false', () => {
+      expect(hasAtLeastOneVisibleText(false, false)).toBe(false);
+    });
+  });
+
+  describe('consistency with createOverlaySettings (Zod schema as authoritative)', () => {
+    it('each individual spec boundary matches what createOverlaySettings accepts', () => {
+      // positive control: all boundary values simultaneously should be accepted
+      const result = createOverlaySettings({
+        positionPreset: OVERLAY_POSITION_PRESETS[0],
+        opacity: OVERLAY_OPACITY_BOUNDS.min,
+        maxLines: OVERLAY_MIN_LINES,
+        fontScale: 0.1,
+        showOriginalText: true,
+        showTranslatedText: false,
+      });
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('rejecting either visibility flag at both-false keeps createOverlaySettings consistent', () => {
+      const result = createOverlaySettings({
+        positionPreset: 'top',
+        opacity: 0.5,
+        maxLines: 2,
+        fontScale: 1,
+        showOriginalText: false,
+        showTranslatedText: false,
+      });
+      expect(result.isErr()).toBe(true);
+      expect(hasAtLeastOneVisibleText(false, false)).toBe(false);
+    });
+  });
+});

--- a/packages/extension/src/domain/specifications/overlay-settings-specification.test.ts
+++ b/packages/extension/src/domain/specifications/overlay-settings-specification.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createOverlaySettings } from '../profile/overlay-settings.js';
+import { createOverlaySettings } from '../profile/overlay-settings';
 import {
   OVERLAY_MIN_LINES,
   OVERLAY_OPACITY_BOUNDS,
@@ -9,7 +9,7 @@ import {
   isValidOverlayMaxLines,
   isValidOverlayOpacity,
   isValidOverlayPositionPreset,
-} from './overlay-settings-specification.js';
+} from './overlay-settings-specification';
 
 describe('OverlaySettingsSpecification (DD-272)', () => {
   describe('isValidOverlayPositionPreset', () => {

--- a/packages/extension/src/domain/specifications/overlay-settings-specification.ts
+++ b/packages/extension/src/domain/specifications/overlay-settings-specification.ts
@@ -1,0 +1,40 @@
+/**
+ * オーバーレイ表示設定仕様 (DD-272)。
+ *
+ * 「オーバーレイ表示値は UI で扱える範囲内に制限する」を個別述語として
+ * 提供する。生成時のバリデーションは
+ * `domain/profile/overlay-settings.ts` の Zod schema (`createOverlaySettings`)
+ * が権威であり、本 spec はそれと同期した intent 明確化 + UI preview 等の
+ * 軽量チェック用途。
+ *
+ * 同期は `overlay-settings-specification.test.ts` の consistency テストで
+ * 保証する。
+ */
+
+export const OVERLAY_POSITION_PRESETS = ['top', 'bottom', 'floating'] as const;
+export type OverlayPositionPreset = (typeof OVERLAY_POSITION_PRESETS)[number];
+
+export const OVERLAY_OPACITY_BOUNDS = { min: 0, max: 1 } as const;
+export const OVERLAY_MIN_LINES = 1 as const;
+
+export const isValidOverlayPositionPreset = (value: unknown): value is OverlayPositionPreset => {
+  if (typeof value !== 'string') return false;
+  return OVERLAY_POSITION_PRESETS.some((preset) => preset === value);
+};
+
+export const isValidOverlayOpacity = (value: unknown): boolean =>
+  typeof value === 'number' &&
+  Number.isFinite(value) &&
+  value >= OVERLAY_OPACITY_BOUNDS.min &&
+  value <= OVERLAY_OPACITY_BOUNDS.max;
+
+export const isValidOverlayMaxLines = (value: unknown): boolean =>
+  typeof value === 'number' && Number.isInteger(value) && value >= OVERLAY_MIN_LINES;
+
+export const isValidOverlayFontScale = (value: unknown): boolean =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0;
+
+export const hasAtLeastOneVisibleText = (
+  showOriginalText: boolean,
+  showTranslatedText: boolean,
+): boolean => showOriginalText || showTranslatedText;

--- a/packages/extension/src/domain/specifications/translation-attachment-specification.test.ts
+++ b/packages/extension/src/domain/specifications/translation-attachment-specification.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseSegmentIdentifier,
+  type SegmentIdentifier,
+} from '../transcript/segment-identifier.js';
+import { createTimestampRange } from '../transcript/timestamp-range.js';
+import {
+  appendPartialTranscriptSegment,
+  createTranscriptStream,
+  finalizeSegment,
+  type TranscriptStream,
+} from '../transcript/transcript-stream.js';
+import { canAttachTranslation } from './translation-attachment-specification.js';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+const SEGMENT_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7D2';
+const SEGMENT_ID_MISSING = '01HZX8Y1R8M7D3Q2P4T5V6W7DF';
+
+const segmentId = (raw: string): SegmentIdentifier => parseSegmentIdentifier(raw)._unsafeUnwrap();
+
+const range = (startMs: number, endMs: number) =>
+  createTimestampRange({ startMs, endMs })._unsafeUnwrap();
+
+const buildStream = (): TranscriptStream => {
+  let stream = createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+  // finalized segment 1
+  stream = appendPartialTranscriptSegment(stream, {
+    segmentIdentifier: SEGMENT_ID_1,
+    revision: 1,
+    text: 'hello',
+    timeRange: range(0, 1000),
+  })._unsafeUnwrap();
+  stream = finalizeSegment(stream, { segmentIdentifier: SEGMENT_ID_1 })._unsafeUnwrap();
+  // partial (non-final) segment 2
+  stream = appendPartialTranscriptSegment(stream, {
+    segmentIdentifier: SEGMENT_ID_2,
+    revision: 1,
+    text: 'world',
+    timeRange: range(1500, 2500),
+  })._unsafeUnwrap();
+  return stream;
+};
+
+describe('TranslationAttachmentSpecification (DD-271)', () => {
+  describe('canAttachTranslation', () => {
+    it('returns true when the segment is finalized', () => {
+      const stream = buildStream();
+      expect(canAttachTranslation(stream, segmentId(SEGMENT_ID_1))).toBe(true);
+    });
+
+    it('returns false when the segment is a partial (not yet finalized)', () => {
+      const stream = buildStream();
+      expect(canAttachTranslation(stream, segmentId(SEGMENT_ID_2))).toBe(false);
+    });
+
+    it('returns false when the segment does not exist in the stream', () => {
+      const stream = buildStream();
+      expect(canAttachTranslation(stream, segmentId(SEGMENT_ID_MISSING))).toBe(false);
+    });
+
+    it('returns false for an empty stream regardless of the segment identifier', () => {
+      const empty = createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+      expect(canAttachTranslation(empty, segmentId(SEGMENT_ID_1))).toBe(false);
+    });
+  });
+});

--- a/packages/extension/src/domain/specifications/translation-attachment-specification.test.ts
+++ b/packages/extension/src/domain/specifications/translation-attachment-specification.test.ts
@@ -1,16 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import {
-  parseSegmentIdentifier,
-  type SegmentIdentifier,
-} from '../transcript/segment-identifier.js';
-import { createTimestampRange } from '../transcript/timestamp-range.js';
+import { parseSegmentIdentifier, type SegmentIdentifier } from '../transcript/segment-identifier';
+import { createTimestampRange } from '../transcript/timestamp-range';
 import {
   appendPartialTranscriptSegment,
   createTranscriptStream,
   finalizeSegment,
   type TranscriptStream,
-} from '../transcript/transcript-stream.js';
-import { canAttachTranslation } from './translation-attachment-specification.js';
+} from '../transcript/transcript-stream';
+import { canAttachTranslation } from './translation-attachment-specification';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const SEGMENT_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';

--- a/packages/extension/src/domain/specifications/translation-attachment-specification.ts
+++ b/packages/extension/src/domain/specifications/translation-attachment-specification.ts
@@ -1,0 +1,21 @@
+import { type SegmentIdentifier } from '../transcript/segment-identifier.js';
+import { type TranscriptStream } from '../transcript/transcript-stream.js';
+
+/**
+ * 翻訳紐付け仕様 (DD-271)。
+ *
+ * 「翻訳は確定字幕にのみ紐づけ可能」を判定する述語。`TranscriptStream` 内の
+ * 指定 segment が finalized (`isFinal === true`) であるかを確認する。
+ *
+ * Policy / aggregate との責務分担: 本 spec は `boolean` を返す。
+ * 違反時の `DomainError` 組み立ては `transcript-stream.ts` の
+ * `attachTranslationToSegment` が担う (invariantViolationError 生成)。
+ */
+export const canAttachTranslation = (
+  stream: TranscriptStream,
+  segmentIdentifier: SegmentIdentifier,
+): boolean => {
+  const segment = stream.segments.get(segmentIdentifier);
+  if (segment === undefined) return false;
+  return segment.isFinal;
+};

--- a/packages/extension/src/domain/specifications/translation-attachment-specification.ts
+++ b/packages/extension/src/domain/specifications/translation-attachment-specification.ts
@@ -1,5 +1,5 @@
-import { type SegmentIdentifier } from '../transcript/segment-identifier.js';
-import { type TranscriptStream } from '../transcript/transcript-stream.js';
+import { type SegmentIdentifier } from '../transcript/segment-identifier';
+import { type TranscriptStream } from '../transcript/transcript-stream';
 
 /**
  * 翻訳紐付け仕様 (DD-271)。

--- a/packages/extension/src/domain/transcript/segment-identifier.test.ts
+++ b/packages/extension/src/domain/transcript/segment-identifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createSegmentIdentifier, parseSegmentIdentifier } from './segment-identifier.js';
+import { createSegmentIdentifier, parseSegmentIdentifier } from './segment-identifier';
 
 describe('SegmentIdentifier', () => {
   it('creates a ULID-shaped identifier', () => {

--- a/packages/extension/src/domain/transcript/segment-identifier.ts
+++ b/packages/extension/src/domain/transcript/segment-identifier.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
 import { ulid } from 'ulid';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 字幕セグメントの識別子 (CLAUDE.md §命名規則)。

--- a/packages/extension/src/domain/transcript/timestamp-range.test.ts
+++ b/packages/extension/src/domain/transcript/timestamp-range.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createTimestampRange } from './timestamp-range.js';
+import { createTimestampRange } from './timestamp-range';
 
 describe('TimestampRange', () => {
   it('accepts start < end', () => {

--- a/packages/extension/src/domain/transcript/timestamp-range.ts
+++ b/packages/extension/src/domain/transcript/timestamp-range.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 字幕セグメントのタイムスタンプ範囲 (DD-235)。

--- a/packages/extension/src/domain/transcript/transcript-segment.test.ts
+++ b/packages/extension/src/domain/transcript/transcript-segment.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { createTimestampRange } from './timestamp-range.js';
+import { createTimestampRange } from './timestamp-range';
 import {
   createPartialTranscriptSegment,
   finalizeTranscriptSegment,
   updatePartialTranscriptSegment,
-} from './transcript-segment.js';
+} from './transcript-segment';
 
 const VALID_ULID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 const timeRange = createTimestampRange({ startMs: 0, endMs: 1000 })._unsafeUnwrap();

--- a/packages/extension/src/domain/transcript/transcript-segment.ts
+++ b/packages/extension/src/domain/transcript/transcript-segment.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
-import { type DomainError, invariantViolationError, validationError } from '../shared/errors.js';
-import { parseSegmentIdentifier, type SegmentIdentifier } from './segment-identifier.js';
-import { type TimestampRange } from './timestamp-range.js';
+import { type DomainError, invariantViolationError, validationError } from '../shared/errors';
+import { parseSegmentIdentifier, type SegmentIdentifier } from './segment-identifier';
+import { type TimestampRange } from './timestamp-range';
 
 /**
  * 字幕セグメントエンティティ (DD-221)。

--- a/packages/extension/src/domain/transcript/transcript-stream.test.ts
+++ b/packages/extension/src/domain/transcript/transcript-stream.test.ts
@@ -6,8 +6,8 @@ import {
   finalizeSegment,
   getSegment,
   getTranslation,
-} from './transcript-stream.js';
-import { createTimestampRange } from './timestamp-range.js';
+} from './transcript-stream';
+import { createTimestampRange } from './timestamp-range';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 const SEGMENT_A = '01HZX8Y2R8M7D3Q2P4T5V6W7X1';

--- a/packages/extension/src/domain/transcript/transcript-stream.ts
+++ b/packages/extension/src/domain/transcript/transcript-stream.ts
@@ -1,18 +1,15 @@
 import { err, type Result } from 'neverthrow';
-import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier.js';
-import { type DomainError, invariantViolationError, notFoundError } from '../shared/errors.js';
-import { parseSegmentIdentifier } from './segment-identifier.js';
-import type { TimestampRange } from './timestamp-range.js';
+import { parseSessionIdentifier, type SessionIdentifier } from '../session/session-identifier';
+import { type DomainError, invariantViolationError, notFoundError } from '../shared/errors';
+import { parseSegmentIdentifier } from './segment-identifier';
+import type { TimestampRange } from './timestamp-range';
 import {
   createPartialTranscriptSegment,
   finalizeTranscriptSegment,
   updatePartialTranscriptSegment,
   type TranscriptSegment,
-} from './transcript-segment.js';
-import {
-  createCompletedTranslationSegment,
-  type TranslationSegment,
-} from './translation-segment.js';
+} from './transcript-segment';
+import { createCompletedTranslationSegment, type TranslationSegment } from './translation-segment';
 
 /**
  * 字幕ストリーム集約ルート (DD-211)。

--- a/packages/extension/src/domain/transcript/translation-identifier.test.ts
+++ b/packages/extension/src/domain/transcript/translation-identifier.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  createTranslationIdentifier,
-  parseTranslationIdentifier,
-} from './translation-identifier.js';
+import { createTranslationIdentifier, parseTranslationIdentifier } from './translation-identifier';
 
 describe('TranslationIdentifier', () => {
   it('creates a ULID-shaped identifier', () => {

--- a/packages/extension/src/domain/transcript/translation-identifier.ts
+++ b/packages/extension/src/domain/transcript/translation-identifier.ts
@@ -1,7 +1,7 @@
 import { err, ok, type Result } from 'neverthrow';
 import { ulid } from 'ulid';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
+import { type DomainError, validationError } from '../shared/errors';
 
 /**
  * 翻訳セグメントの識別子 (DD-222)。

--- a/packages/extension/src/domain/transcript/translation-segment.test.ts
+++ b/packages/extension/src/domain/transcript/translation-segment.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createCompletedTranslationSegment,
   createFailedTranslationSegment,
-} from './translation-segment.js';
+} from './translation-segment';
 
 const VALID_ULID_A = '01HZX8Y1R8M7D3Q2P4T5V6W7X8';
 const VALID_ULID_B = '01HZX8Y1R8M7D3Q2P4T5V6W7X9';

--- a/packages/extension/src/domain/transcript/translation-segment.ts
+++ b/packages/extension/src/domain/transcript/translation-segment.ts
@@ -1,11 +1,8 @@
 import { err, ok, type Result } from 'neverthrow';
 import { z } from 'zod';
-import { type DomainError, validationError } from '../shared/errors.js';
-import { parseSegmentIdentifier, type SegmentIdentifier } from './segment-identifier.js';
-import {
-  parseTranslationIdentifier,
-  type TranslationIdentifier,
-} from './translation-identifier.js';
+import { type DomainError, validationError } from '../shared/errors';
+import { parseSegmentIdentifier, type SegmentIdentifier } from './segment-identifier';
+import { parseTranslationIdentifier, type TranslationIdentifier } from './translation-identifier';
 
 /**
  * 翻訳セグメントエンティティ (DD-222)。

--- a/packages/extension/src/entrypoints/monitor/main.tsx
+++ b/packages/extension/src/entrypoints/monitor/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { App } from './App.js';
+import { App } from './App';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/packages/extension/src/entrypoints/popup/main.tsx
+++ b/packages/extension/src/entrypoints/popup/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { App } from './App.js';
+import { App } from './App';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/packages/extension/src/entrypoints/sidepanel/main.tsx
+++ b/packages/extension/src/entrypoints/sidepanel/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { App } from './App.js';
+import { App } from './App';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/packages/relay-api/src/presentation/http/server.ts
+++ b/packages/relay-api/src/presentation/http/server.ts
@@ -1,6 +1,6 @@
 import Fastify, { type FastifyInstance } from 'fastify';
-import { loggerOptions } from '../../infrastructure/logging/logger.js';
-import { registerHealthRoute } from './routes/health.js';
+import { loggerOptions } from '../../infrastructure/logging/logger';
+import { registerHealthRoute } from './routes/health';
 
 export function buildApp(): FastifyInstance {
   const app = Fastify({

--- a/packages/relay-api/tests/smoke.test.ts
+++ b/packages/relay-api/tests/smoke.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from 'vitest';
-import { buildApp } from '../src/presentation/http/server.js';
+import { buildApp } from '../src/presentation/http/server';
 
 const app = buildApp();
 


### PR DESCRIPTION
## Summary

Phase 2 §4.3 として 14 DTO (入力 7 / 出力 7) を実装。Popup / Side Panel / Relay イベント境界から UseCase 層へ受け渡すデータ契約を Zod で runtime 検証する。出力 DTO はドメインモデルを primitive 化した UI 向け投影型。

### 入力 DTO (IMPL-220)

- **DTO-I-306 `StopSourceSessionInput`** — sessionId + reason?
- **DTO-I-307 `ExportSessionResultInput`** — sessionId + format (EXPORT_FORMATS) + includeOriginal/Translation (両 false 拒否)
- **DTO-I-303 `UpdateSourceSettingsInput`** — sessionId + optional 言語ペア / overlaySettings (BCP-47 / 値域は spec 定数と同期)
- **DTO-I-304 `HandleTranscriptPartialInput`** — sessionId/segmentId/revision>=1/text>=1/timeRange
- **DTO-I-305 `HandleTranscriptFinalInput`** — 上記 + optional translation (completed/failed)
- **DTO-I-301 `StartSourceSessionInput`** — sourceType/displayName/言語/overlayTarget (tab|extension-monitor)
- **DTO-I-302 `GetSessionMonitorStateInput`** — sessionIds?(空配列禁止) + includeOverlayState

各 parser は `parseXxxInput(raw: unknown): Result<XxxInput, DomainError>` でドメイン層の `createXxx` factory と同じパターン。

### 出力 DTO (IMPL-221)

- **DTO-O-306/307/303/304/305/301** — `Readonly<{...}>` で immutable、ドメインモデルからの投影属性
- **DTO-O-305** の `translationStatus` に `'pending'` 追加 — 結果整合性下で翻訳未到着を表現 (use-case.md §6.2)
- **DTO-O-302 `SessionMonitorStateOutput`** — composite (sessions[] + latestSegments[] + overlayState?)

### 設計上の判断

- 配置: `packages/extension/src/application/dto/`。UseCase ごとに 1 ファイル で入出力ペア + parser を co-locate
- 入力 DTO は primitive 型で受け取り (branded type は持たない)、UseCase 層で `createXxx` factory に渡してドメインモデルへ昇格
- `exactOptionalPropertyTypes: true` 対応のため、全 optional プロパティに `| undefined` を明示
- BCP-47 / OverlaySettings 値域は既存 spec 定数を import して同期 (DRY)
- barrel export `index.ts` で 7 UseCase 分の DTO + parser を集約公開

### 依存方向

`application/dto/` → `domain/` + `application/ports/` (OverlayRenderModel のみ参照)。逆依存なし。

### base branch について

現時点で PR #13 (Phase 1) / PR #14 (output ports) が未マージ。本 PR はそれらに stacked しており、順次マージ後に diff がクリーン化される。

## Test plan

- [x] `pnpm --filter @perapera/extension test` → 402 tests pass (45 test files、既存 340 から +62 新規)
- [x] `pnpm --filter @perapera/extension test:coverage`
  - `application/dto/` 全 7 ファイル: **100%** (statements/branches/functions/lines)
  - 全体: 97.13% / 98.25% / 98.91% / 97.13%
- [x] `pnpm check` (fmt/lint/typecheck/test) 全緑
- [ ] CI `All Green` 通過