### PR TITLE
feat(application): IMPL-230 ApplicationError + DomainError mapper

### DIFF
--- a/packages/extension/src/application/errors/application-errors.test.ts
+++ b/packages/extension/src/application/errors/application-errors.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import {
+  invariantViolationError,
+  notFoundError,
+  sessionStateTransitionError,
+  validationError,
+} from '../../domain/shared/errors';
+import {
+  conflictAppError,
+  internalAppError,
+  permissionRequiredAppError,
+  sessionNotFoundAppError,
+  toApplicationError,
+  validationAppError,
+  type ApplicationError,
+} from './application-errors';
+
+describe('ApplicationError factories', () => {
+  describe('permissionRequiredAppError', () => {
+    it('builds a permission-required variant with fixed code', () => {
+      const error = permissionRequiredAppError({
+        sourceType: 'microphone',
+        message: 'Microphone permission required',
+      });
+      expect(error.type).toBe('permission-required');
+      expect(error.code).toBe('CAPTURE-PERMISSION-DENIED');
+      expect(error.sourceType).toBe('microphone');
+      expect(error.message).toBe('Microphone permission required');
+    });
+  });
+
+  describe('sessionNotFoundAppError', () => {
+    it('builds a session-not-found variant carrying the identifier', () => {
+      const error = sessionNotFoundAppError({
+        identifier: 'session-123',
+        message: 'Session not found',
+      });
+      expect(error.type).toBe('session-not-found');
+      expect(error.code).toBe('SESSION_NOT_FOUND');
+      expect(error.identifier).toBe('session-123');
+    });
+  });
+
+  describe('validationAppError', () => {
+    it('builds a validation variant with optional field and code override', () => {
+      const error = validationAppError({
+        field: 'LanguagePair',
+        message: 'source and target must differ',
+        code: 'UNSUPPORTED_LANGUAGE_PAIR',
+      });
+      expect(error.type).toBe('validation');
+      expect(error.code).toBe('UNSUPPORTED_LANGUAGE_PAIR');
+      expect(error.field).toBe('LanguagePair');
+    });
+
+    it('defaults to VALIDATION_FAILED when no code is supplied', () => {
+      const error = validationAppError({ message: 'invalid payload' });
+      expect(error.code).toBe('VALIDATION_FAILED');
+    });
+  });
+
+  describe('conflictAppError', () => {
+    it('builds a conflict variant with INVALID_STATE_TRANSITION by default', () => {
+      const error = conflictAppError({
+        message: 'cannot stop from idle',
+        details: 'idle -> stopped',
+      });
+      expect(error.type).toBe('conflict');
+      expect(error.code).toBe('INVALID_STATE_TRANSITION');
+      expect(error.details).toBe('idle -> stopped');
+    });
+  });
+
+  describe('internalAppError', () => {
+    it('builds an internal variant with INTERNAL_ERROR code', () => {
+      const error = internalAppError({ message: 'unexpected' });
+      expect(error.type).toBe('internal');
+      expect(error.code).toBe('INTERNAL_ERROR');
+    });
+  });
+});
+
+describe('toApplicationError (DD-230 — use-case.md §9.2 mapping)', () => {
+  it('maps not-found domain error to SessionNotFoundAppError', () => {
+    const app = toApplicationError(
+      notFoundError({ resourceType: 'SourceSession', identifier: 'session-123' }),
+    );
+    expect(app.type).toBe('session-not-found');
+    expect(app.code).toBe('SESSION_NOT_FOUND');
+    if (app.type === 'session-not-found') {
+      expect(app.identifier).toBe('session-123');
+    }
+  });
+
+  it('maps validation domain error to ValidationAppError', () => {
+    const app = toApplicationError(
+      validationError({ field: 'LanguagePair', message: 'source and target must differ' }),
+    );
+    expect(app.type).toBe('validation');
+    expect(app.code).toBe('VALIDATION_FAILED');
+    if (app.type === 'validation') {
+      expect(app.field).toBe('LanguagePair');
+    }
+  });
+
+  it('maps session-state-transition domain error to ConflictAppError', () => {
+    const app = toApplicationError(
+      sessionStateTransitionError({
+        from: 'idle',
+        to: 'capturing',
+        reason: 'illegal shortcut',
+      }),
+    );
+    expect(app.type).toBe('conflict');
+    expect(app.code).toBe('INVALID_STATE_TRANSITION');
+    if (app.type === 'conflict') {
+      expect(app.details).toContain('idle');
+      expect(app.details).toContain('capturing');
+    }
+  });
+
+  it('maps invariant-violation domain error to ConflictAppError', () => {
+    const app = toApplicationError(
+      invariantViolationError({
+        invariant: 'concurrent-session-limit',
+        details: 'active count 3 would exceed limit 3',
+      }),
+    );
+    expect(app.type).toBe('conflict');
+    expect(app.code).toBe('INVALID_STATE_TRANSITION');
+    if (app.type === 'conflict') {
+      expect(app.details).toContain('concurrent-session-limit');
+    }
+  });
+
+  it('covers all four DomainError kinds (no default branch needed for defined kinds)', () => {
+    const app1 = toApplicationError(notFoundError({ resourceType: 'X', identifier: 'y' }));
+    const app2 = toApplicationError(validationError({ field: 'x', message: 'y' }));
+    const app3 = toApplicationError(
+      sessionStateTransitionError({ from: 'idle', to: 'stopped', reason: 'x' }),
+    );
+    const app4 = toApplicationError(invariantViolationError({ invariant: 'x', details: 'y' }));
+    const mapped: ApplicationError[] = [app1, app2, app3, app4];
+    expect(mapped.every((e) => e.type !== 'internal')).toBe(true);
+  });
+});

--- a/packages/extension/src/application/errors/application-errors.ts
+++ b/packages/extension/src/application/errors/application-errors.ts
@@ -1,0 +1,136 @@
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * アプリケーション層エラー (DD-230 / use-case.md §9.2)。
+ *
+ * ドメイン層の `DomainError` を UI 層が扱いやすい形に変換した
+ * discriminated union。`code` は UI のエラーメッセージ辞書やログ分析で
+ * 参照される固定文字列 (use-case.md §9.2 テーブル)。
+ *
+ * 責務分担:
+ * - DomainError: ドメイン不変条件違反を表す内部表現
+ * - ApplicationError: UI に返す「状態遷移情報のみ」(内部実装詳細を隠蔽)
+ *
+ * use-case.md §9.2 のマッピング:
+ * - `PermissionDeniedError` → `permission-required` (DomainError 側は
+ *   `PermissionGrant.denied` で Ok として扱い、UseCase 層で直接構築)
+ * - `SessionNotFoundError` → `session-not-found`
+ * - `UnsupportedLanguagePairError` → `validation` (code override 可)
+ * - `InvalidStateTransitionError` → `conflict`
+ * - 予期しない例外 → `internal`
+ */
+export type ApplicationError =
+  | Readonly<{
+      type: 'permission-required';
+      code: 'CAPTURE-PERMISSION-DENIED';
+      sourceType: string;
+      message: string;
+    }>
+  | Readonly<{
+      type: 'session-not-found';
+      code: 'SESSION_NOT_FOUND';
+      identifier: string;
+      message: string;
+    }>
+  | Readonly<{
+      type: 'validation';
+      code: 'VALIDATION_FAILED' | 'UNSUPPORTED_LANGUAGE_PAIR';
+      field: string | null;
+      message: string;
+    }>
+  | Readonly<{
+      type: 'conflict';
+      code: 'INVALID_STATE_TRANSITION';
+      details: string;
+      message: string;
+    }>
+  | Readonly<{
+      type: 'internal';
+      code: 'INTERNAL_ERROR';
+      message: string;
+    }>;
+
+export type PermissionRequiredAppError = Extract<ApplicationError, { type: 'permission-required' }>;
+export type SessionNotFoundAppError = Extract<ApplicationError, { type: 'session-not-found' }>;
+export type ValidationAppError = Extract<ApplicationError, { type: 'validation' }>;
+export type ConflictAppError = Extract<ApplicationError, { type: 'conflict' }>;
+export type InternalAppError = Extract<ApplicationError, { type: 'internal' }>;
+
+export const permissionRequiredAppError = (params: {
+  sourceType: string;
+  message: string;
+}): PermissionRequiredAppError => ({
+  type: 'permission-required',
+  code: 'CAPTURE-PERMISSION-DENIED',
+  sourceType: params.sourceType,
+  message: params.message,
+});
+
+export const sessionNotFoundAppError = (params: {
+  identifier: string;
+  message: string;
+}): SessionNotFoundAppError => ({
+  type: 'session-not-found',
+  code: 'SESSION_NOT_FOUND',
+  identifier: params.identifier,
+  message: params.message,
+});
+
+export const validationAppError = (params: {
+  field?: string;
+  message: string;
+  code?: 'VALIDATION_FAILED' | 'UNSUPPORTED_LANGUAGE_PAIR';
+}): ValidationAppError => ({
+  type: 'validation',
+  code: params.code ?? 'VALIDATION_FAILED',
+  field: params.field ?? null,
+  message: params.message,
+});
+
+export const conflictAppError = (params: {
+  details: string;
+  message: string;
+}): ConflictAppError => ({
+  type: 'conflict',
+  code: 'INVALID_STATE_TRANSITION',
+  details: params.details,
+  message: params.message,
+});
+
+export const internalAppError = (params: { message: string }): InternalAppError => ({
+  type: 'internal',
+  code: 'INTERNAL_ERROR',
+  message: params.message,
+});
+
+/**
+ * DomainError → ApplicationError マッパー (use-case.md §9.2 準拠)。
+ *
+ * ドメイン層から UseCase 層へ propagate してきた Err を UI 層向けに変換する。
+ * 内部実装詳細 (invariant 名、remove 詳細等) は message / details に集約して
+ * 流し、discriminator + code による分岐のみを UI に露出する。
+ */
+export const toApplicationError = (error: DomainError): ApplicationError => {
+  switch (error.kind) {
+    case 'not-found':
+      return sessionNotFoundAppError({
+        identifier: error.identifier,
+        message: `${error.resourceType} not found: ${error.identifier}`,
+      });
+    case 'validation':
+      return validationAppError({
+        field: error.field,
+        message: error.message,
+      });
+    case 'session-state-transition':
+      return conflictAppError({
+        details: `${error.from} -> ${error.to}: ${error.reason}`,
+        message: `invalid state transition from ${error.from} to ${error.to}`,
+      });
+    case 'invariant-violation':
+      return conflictAppError({
+        details: `${error.invariant}: ${error.details}`,
+        message: `domain invariant violated: ${error.invariant}`,
+      });
+  }
+};


### PR DESCRIPTION
## Summary

Phase 2 §4.4 として、ドメイン例外をアプリケーション例外へ変換する層を実装。use-case.md §9.2 の対応表に準拠し、UI 層が扱いやすい discriminated union として ApplicationError を定義、`toApplicationError(DomainError)` マッパーで切り替える。

### 実装内容

- **`ApplicationError` discriminated union** (5 variants):
  - `permission-required` (code: `CAPTURE-PERMISSION-DENIED`)
  - `session-not-found` (code: `SESSION_NOT_FOUND`)
  - `validation` (code: `VALIDATION_FAILED` | `UNSUPPORTED_LANGUAGE_PAIR`)
  - `conflict` (code: `INVALID_STATE_TRANSITION`)
  - `internal` (code: `INTERNAL_ERROR`)
- **factory 関数 5 種** — 各 variant を `Extract<ApplicationError, {type: ...}>` で narrow 返却、呼び出し側で type-guard 不要
- **`toApplicationError(error: DomainError): ApplicationError`** マッパー — exhaustive switch で全 DomainError kind を網羅

### マッピング (use-case.md §9.2 準拠)

| DomainError.kind | ApplicationError | code |
|---|---|---|
| `not-found` | session-not-found | `SESSION_NOT_FOUND` |
| `validation` | validation | `VALIDATION_FAILED` |
| `session-state-transition` | conflict | `INVALID_STATE_TRANSITION` |
| `invariant-violation` | conflict | `INVALID_STATE_TRANSITION` |

`PermissionCoordinator.requestFor` の denied は DomainError ではなく `PermissionGrant.denied` で Ok 扱いのため、UseCase 層で直接 `permissionRequiredAppError` を構築する (マッパー対象外)。

## Test plan

- [x] `pnpm --filter @perapera/extension test` → 413 tests pass (46 test files、既存 402 から +11 新規)
- [x] `pnpm check` (fmt/lint/typecheck/test) 全緑
- [ ] CI `All Green` 通過 → auto merge