### PR TITLE
feat(application): IMPL-215 StopSourceSessionUseCase + overlay-render-projector

### DIFF
--- a/packages/extension/src/application/errors/application-errors.test.ts
+++ b/packages/extension/src/application/errors/application-errors.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import {
+  invariantViolationError,
+  notFoundError,
+  sessionStateTransitionError,
+  validationError,
+} from '../../domain/shared/errors';
+import {
+  conflictAppError,
+  internalAppError,
+  permissionRequiredAppError,
+  sessionNotFoundAppError,
+  toApplicationError,
+  validationAppError,
+  type ApplicationError,
+} from './application-errors';
+
+describe('ApplicationError factories', () => {
+  describe('permissionRequiredAppError', () => {
+    it('builds a permission-required variant with fixed code', () => {
+      const error = permissionRequiredAppError({
+        sourceType: 'microphone',
+        message: 'Microphone permission required',
+      });
+      expect(error.type).toBe('permission-required');
+      expect(error.code).toBe('CAPTURE-PERMISSION-DENIED');
+      expect(error.sourceType).toBe('microphone');
+      expect(error.message).toBe('Microphone permission required');
+    });
+  });
+
+  describe('sessionNotFoundAppError', () => {
+    it('builds a session-not-found variant carrying the identifier', () => {
+      const error = sessionNotFoundAppError({
+        identifier: 'session-123',
+        message: 'Session not found',
+      });
+      expect(error.type).toBe('session-not-found');
+      expect(error.code).toBe('SESSION_NOT_FOUND');
+      expect(error.identifier).toBe('session-123');
+    });
+  });
+
+  describe('validationAppError', () => {
+    it('builds a validation variant with optional field and code override', () => {
+      const error = validationAppError({
+        field: 'LanguagePair',
+        message: 'source and target must differ',
+        code: 'UNSUPPORTED_LANGUAGE_PAIR',
+      });
+      expect(error.type).toBe('validation');
+      expect(error.code).toBe('UNSUPPORTED_LANGUAGE_PAIR');
+      expect(error.field).toBe('LanguagePair');
+    });
+
+    it('defaults to VALIDATION_FAILED when no code is supplied', () => {
+      const error = validationAppError({ message: 'invalid payload' });
+      expect(error.code).toBe('VALIDATION_FAILED');
+    });
+  });
+
+  describe('conflictAppError', () => {
+    it('builds a conflict variant with INVALID_STATE_TRANSITION by default', () => {
+      const error = conflictAppError({
+        message: 'cannot stop from idle',
+        details: 'idle -> stopped',
+      });
+      expect(error.type).toBe('conflict');
+      expect(error.code).toBe('INVALID_STATE_TRANSITION');
+      expect(error.details).toBe('idle -> stopped');
+    });
+  });
+
+  describe('internalAppError', () => {
+    it('builds an internal variant with INTERNAL_ERROR code', () => {
+      const error = internalAppError({ message: 'unexpected' });
+      expect(error.type).toBe('internal');
+      expect(error.code).toBe('INTERNAL_ERROR');
+    });
+  });
+});
+
+describe('toApplicationError (DD-230 — use-case.md §9.2 mapping)', () => {
+  it('maps not-found domain error to SessionNotFoundAppError', () => {
+    const app = toApplicationError(
+      notFoundError({ resourceType: 'SourceSession', identifier: 'session-123' }),
+    );
+    expect(app.type).toBe('session-not-found');
+    expect(app.code).toBe('SESSION_NOT_FOUND');
+    if (app.type === 'session-not-found') {
+      expect(app.identifier).toBe('session-123');
+    }
+  });
+
+  it('maps validation domain error to ValidationAppError', () => {
+    const app = toApplicationError(
+      validationError({ field: 'LanguagePair', message: 'source and target must differ' }),
+    );
+    expect(app.type).toBe('validation');
+    expect(app.code).toBe('VALIDATION_FAILED');
+    if (app.type === 'validation') {
+      expect(app.field).toBe('LanguagePair');
+    }
+  });
+
+  it('maps session-state-transition domain error to ConflictAppError', () => {
+    const app = toApplicationError(
+      sessionStateTransitionError({
+        from: 'idle',
+        to: 'capturing',
+        reason: 'illegal shortcut',
+      }),
+    );
+    expect(app.type).toBe('conflict');
+    expect(app.code).toBe('INVALID_STATE_TRANSITION');
+    if (app.type === 'conflict') {
+      expect(app.details).toContain('idle');
+      expect(app.details).toContain('capturing');
+    }
+  });
+
+  it('maps invariant-violation domain error to ConflictAppError', () => {
+    const app = toApplicationError(
+      invariantViolationError({
+        invariant: 'concurrent-session-limit',
+        details: 'active count 3 would exceed limit 3',
+      }),
+    );
+    expect(app.type).toBe('conflict');
+    expect(app.code).toBe('INVALID_STATE_TRANSITION');
+    if (app.type === 'conflict') {
+      expect(app.details).toContain('concurrent-session-limit');
+    }
+  });
+
+  it('covers all four DomainError kinds (no default branch needed for defined kinds)', () => {
+    const app1 = toApplicationError(notFoundError({ resourceType: 'X', identifier: 'y' }));
+    const app2 = toApplicationError(validationError({ field: 'x', message: 'y' }));
+    const app3 = toApplicationError(
+      sessionStateTransitionError({ from: 'idle', to: 'stopped', reason: 'x' }),
+    );
+    const app4 = toApplicationError(invariantViolationError({ invariant: 'x', details: 'y' }));
+    const mapped: ApplicationError[] = [app1, app2, app3, app4];
+    expect(mapped.every((e) => e.type !== 'internal')).toBe(true);
+  });
+});

--- a/packages/extension/src/application/errors/application-errors.ts
+++ b/packages/extension/src/application/errors/application-errors.ts
@@ -1,0 +1,136 @@
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * アプリケーション層エラー (DD-230 / use-case.md §9.2)。
+ *
+ * ドメイン層の `DomainError` を UI 層が扱いやすい形に変換した
+ * discriminated union。`code` は UI のエラーメッセージ辞書やログ分析で
+ * 参照される固定文字列 (use-case.md §9.2 テーブル)。
+ *
+ * 責務分担:
+ * - DomainError: ドメイン不変条件違反を表す内部表現
+ * - ApplicationError: UI に返す「状態遷移情報のみ」(内部実装詳細を隠蔽)
+ *
+ * use-case.md §9.2 のマッピング:
+ * - `PermissionDeniedError` → `permission-required` (DomainError 側は
+ *   `PermissionGrant.denied` で Ok として扱い、UseCase 層で直接構築)
+ * - `SessionNotFoundError` → `session-not-found`
+ * - `UnsupportedLanguagePairError` → `validation` (code override 可)
+ * - `InvalidStateTransitionError` → `conflict`
+ * - 予期しない例外 → `internal`
+ */
+export type ApplicationError =
+  | Readonly<{
+      type: 'permission-required';
+      code: 'CAPTURE-PERMISSION-DENIED';
+      sourceType: string;
+      message: string;
+    }>
+  | Readonly<{
+      type: 'session-not-found';
+      code: 'SESSION_NOT_FOUND';
+      identifier: string;
+      message: string;
+    }>
+  | Readonly<{
+      type: 'validation';
+      code: 'VALIDATION_FAILED' | 'UNSUPPORTED_LANGUAGE_PAIR';
+      field: string | null;
+      message: string;
+    }>
+  | Readonly<{
+      type: 'conflict';
+      code: 'INVALID_STATE_TRANSITION';
+      details: string;
+      message: string;
+    }>
+  | Readonly<{
+      type: 'internal';
+      code: 'INTERNAL_ERROR';
+      message: string;
+    }>;
+
+export type PermissionRequiredAppError = Extract<ApplicationError, { type: 'permission-required' }>;
+export type SessionNotFoundAppError = Extract<ApplicationError, { type: 'session-not-found' }>;
+export type ValidationAppError = Extract<ApplicationError, { type: 'validation' }>;
+export type ConflictAppError = Extract<ApplicationError, { type: 'conflict' }>;
+export type InternalAppError = Extract<ApplicationError, { type: 'internal' }>;
+
+export const permissionRequiredAppError = (params: {
+  sourceType: string;
+  message: string;
+}): PermissionRequiredAppError => ({
+  type: 'permission-required',
+  code: 'CAPTURE-PERMISSION-DENIED',
+  sourceType: params.sourceType,
+  message: params.message,
+});
+
+export const sessionNotFoundAppError = (params: {
+  identifier: string;
+  message: string;
+}): SessionNotFoundAppError => ({
+  type: 'session-not-found',
+  code: 'SESSION_NOT_FOUND',
+  identifier: params.identifier,
+  message: params.message,
+});
+
+export const validationAppError = (params: {
+  field?: string;
+  message: string;
+  code?: 'VALIDATION_FAILED' | 'UNSUPPORTED_LANGUAGE_PAIR';
+}): ValidationAppError => ({
+  type: 'validation',
+  code: params.code ?? 'VALIDATION_FAILED',
+  field: params.field ?? null,
+  message: params.message,
+});
+
+export const conflictAppError = (params: {
+  details: string;
+  message: string;
+}): ConflictAppError => ({
+  type: 'conflict',
+  code: 'INVALID_STATE_TRANSITION',
+  details: params.details,
+  message: params.message,
+});
+
+export const internalAppError = (params: { message: string }): InternalAppError => ({
+  type: 'internal',
+  code: 'INTERNAL_ERROR',
+  message: params.message,
+});
+
+/**
+ * DomainError → ApplicationError マッパー (use-case.md §9.2 準拠)。
+ *
+ * ドメイン層から UseCase 層へ propagate してきた Err を UI 層向けに変換する。
+ * 内部実装詳細 (invariant 名、remove 詳細等) は message / details に集約して
+ * 流し、discriminator + code による分岐のみを UI に露出する。
+ */
+export const toApplicationError = (error: DomainError): ApplicationError => {
+  switch (error.kind) {
+    case 'not-found':
+      return sessionNotFoundAppError({
+        identifier: error.identifier,
+        message: `${error.resourceType} not found: ${error.identifier}`,
+      });
+    case 'validation':
+      return validationAppError({
+        field: error.field,
+        message: error.message,
+      });
+    case 'session-state-transition':
+      return conflictAppError({
+        details: `${error.from} -> ${error.to}: ${error.reason}`,
+        message: `invalid state transition from ${error.from} to ${error.to}`,
+      });
+    case 'invariant-violation':
+      return conflictAppError({
+        details: `${error.invariant}: ${error.details}`,
+        message: `domain invariant violated: ${error.invariant}`,
+      });
+  }
+};

--- a/packages/extension/src/application/use-cases/index.ts
+++ b/packages/extension/src/application/use-cases/index.ts
@@ -1,0 +1,6 @@
+export {
+  createStopSourceSessionUseCase,
+  type StopSourceSessionDependencies,
+  type StopSourceSessionUseCase,
+} from './stop-source-session-use-case';
+export { projectOverlayRenderModel } from './overlay-render-projector';

--- a/packages/extension/src/application/use-cases/overlay-render-projector.test.ts
+++ b/packages/extension/src/application/use-cases/overlay-render-projector.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import { createOverlaySettings, type OverlaySettings } from '../../domain/profile/overlay-settings';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { createTimestampRange } from '../../domain/transcript/timestamp-range';
+import {
+  appendPartialTranscriptSegment,
+  attachTranslationToSegment,
+  createTranscriptStream,
+  finalizeSegment,
+  type TranscriptStream,
+} from '../../domain/transcript/transcript-stream';
+import { projectOverlayRenderModel } from './overlay-render-projector';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+const SEGMENT_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7D2';
+const SEGMENT_ID_3 = '01HZX8Y1R8M7D3Q2P4T5V6W7D3';
+const TRANSLATION_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7E1';
+
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const baseSettings = (
+  overrides?: Partial<Parameters<typeof createOverlaySettings>[0]>,
+): OverlaySettings =>
+  createOverlaySettings({
+    positionPreset: 'bottom',
+    opacity: 0.8,
+    maxLines: 3,
+    fontScale: 1,
+    showOriginalText: true,
+    showTranslatedText: true,
+    ...overrides,
+  })._unsafeUnwrap();
+
+const range = (startMs: number, endMs: number) =>
+  createTimestampRange({ startMs, endMs })._unsafeUnwrap();
+
+const buildStream = (): TranscriptStream => {
+  let stream = createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+  stream = appendPartialTranscriptSegment(stream, {
+    segmentIdentifier: SEGMENT_ID_1,
+    revision: 1,
+    text: 'hello',
+    timeRange: range(0, 1000),
+  })._unsafeUnwrap();
+  stream = finalizeSegment(stream, { segmentIdentifier: SEGMENT_ID_1 })._unsafeUnwrap();
+  stream = attachTranslationToSegment(stream, {
+    translationIdentifier: TRANSLATION_ID_1,
+    segmentIdentifier: SEGMENT_ID_1,
+    targetLanguage: 'ja-JP',
+    text: 'こんにちは',
+  })._unsafeUnwrap();
+  stream = appendPartialTranscriptSegment(stream, {
+    segmentIdentifier: SEGMENT_ID_2,
+    revision: 1,
+    text: 'world',
+    timeRange: range(2000, 3000),
+  })._unsafeUnwrap();
+  stream = appendPartialTranscriptSegment(stream, {
+    segmentIdentifier: SEGMENT_ID_3,
+    revision: 1,
+    text: 'foo',
+    timeRange: range(4000, 5000),
+  })._unsafeUnwrap();
+  return stream;
+};
+
+describe('projectOverlayRenderModel', () => {
+  it('projects each segment into an OverlayLine with translation when available', () => {
+    const stream = buildStream();
+    const model = projectOverlayRenderModel({ stream, settings: baseSettings() });
+    expect(model.sessionIdentifier).toBe(sessionIdentifier);
+    expect(model.lines).toHaveLength(3);
+    const finalized = model.lines.find((line) => line.segmentIdentifier === SEGMENT_ID_1);
+    expect(finalized?.isFinal).toBe(true);
+    expect(finalized?.originalText).toBe('hello');
+    expect(finalized?.translatedText).toBe('こんにちは');
+    expect(finalized?.targetLanguage).toBe('ja-JP');
+  });
+
+  it('orders lines by startMs ascending', () => {
+    const stream = buildStream();
+    const model = projectOverlayRenderModel({ stream, settings: baseSettings() });
+    expect(model.lines[0]?.segmentIdentifier).toBe(SEGMENT_ID_1);
+    expect(model.lines[1]?.segmentIdentifier).toBe(SEGMENT_ID_2);
+    expect(model.lines[2]?.segmentIdentifier).toBe(SEGMENT_ID_3);
+  });
+
+  it('hides originalText when showOriginalText=false', () => {
+    const stream = buildStream();
+    const model = projectOverlayRenderModel({
+      stream,
+      settings: baseSettings({ showOriginalText: false }),
+    });
+    for (const line of model.lines) {
+      expect(line.originalText).toBeNull();
+    }
+  });
+
+  it('hides translatedText when showTranslatedText=false', () => {
+    const stream = buildStream();
+    const model = projectOverlayRenderModel({
+      stream,
+      settings: baseSettings({ showTranslatedText: false }),
+    });
+    for (const line of model.lines) {
+      expect(line.translatedText).toBeNull();
+      expect(line.targetLanguage).toBeNull();
+    }
+  });
+
+  it('caps the number of lines at OverlaySettings.maxLines (most recent kept)', () => {
+    const stream = buildStream();
+    const model = projectOverlayRenderModel({
+      stream,
+      settings: baseSettings({ maxLines: 2 }),
+    });
+    expect(model.lines).toHaveLength(2);
+    expect(model.lines[0]?.segmentIdentifier).toBe(SEGMENT_ID_2);
+    expect(model.lines[1]?.segmentIdentifier).toBe(SEGMENT_ID_3);
+  });
+
+  it('omits segments whose only visible field is hidden (original hidden + no translation)', () => {
+    const stream = buildStream();
+    const model = projectOverlayRenderModel({
+      stream,
+      settings: baseSettings({ showOriginalText: false, showTranslatedText: true }),
+    });
+    expect(model.lines.every((line) => line.translatedText !== null)).toBe(true);
+    expect(model.lines.every((line) => line.segmentIdentifier === SEGMENT_ID_1)).toBe(true);
+  });
+
+  it('returns an empty lines array for an empty stream', () => {
+    const stream = createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+    const model = projectOverlayRenderModel({ stream, settings: baseSettings() });
+    expect(model.lines).toEqual([]);
+  });
+
+  it('treats failed translations as missing (translatedText=null)', () => {
+    // buildStream only attaches a completed translation; here we verify the
+    // default contract that the projector reads `status === 'completed'`.
+    const stream = buildStream();
+    const model = projectOverlayRenderModel({ stream, settings: baseSettings() });
+    const row = model.lines.find((line) => line.segmentIdentifier === SEGMENT_ID_2);
+    expect(row?.translatedText).toBeNull();
+  });
+});

--- a/packages/extension/src/application/use-cases/overlay-render-projector.ts
+++ b/packages/extension/src/application/use-cases/overlay-render-projector.ts
@@ -1,0 +1,54 @@
+import { type OverlaySettings } from '../../domain/profile/overlay-settings';
+import { type TranscriptStream } from '../../domain/transcript/transcript-stream';
+import { type OverlayLine, type OverlayRenderModel } from '../ports/overlay-presenter';
+
+/**
+ * TranscriptStream を OverlayRenderModel に投影するユーティリティ。
+ *
+ * IMPL-211 / IMPL-213 / IMPL-214 の UseCase から共通利用される。
+ *
+ * 仕様:
+ * - segment を `timeRange.startMs` 昇順にソート
+ * - `settings.maxLines` で末尾 N 件に絞る (最新 N 件を保持)
+ * - `showOriginalText=false` の場合 `originalText` は `null`
+ * - `showTranslatedText=false` の場合 `translatedText` / `targetLanguage` は `null`
+ * - 翻訳は `status === 'completed'` のみ採用 (failed/未到着は `translatedText=null`)
+ * - `originalText` と `translatedText` の両方が `null` になる行は除外 (表示内容なし)
+ */
+export const projectOverlayRenderModel = (params: {
+  stream: TranscriptStream;
+  settings: OverlaySettings;
+}): OverlayRenderModel => {
+  const { stream, settings } = params;
+  const sortedSegments = [...stream.segments.values()].sort(
+    (a, b) => a.timeRange.startMs - b.timeRange.startMs,
+  );
+  const capped = sortedSegments.slice(-settings.maxLines);
+
+  const lines: OverlayLine[] = [];
+  for (const segment of capped) {
+    const originalText = settings.showOriginalText ? segment.text : null;
+    let translatedText: string | null = null;
+    let targetLanguage: string | null = null;
+    if (settings.showTranslatedText) {
+      const translation = stream.translations.get(segment.segmentIdentifier);
+      if (translation?.status === 'completed') {
+        translatedText = translation.text;
+        targetLanguage = translation.targetLanguage;
+      }
+    }
+    if (originalText === null && translatedText === null) continue;
+    lines.push({
+      segmentIdentifier: segment.segmentIdentifier,
+      originalText,
+      translatedText,
+      targetLanguage,
+      isFinal: segment.isFinal,
+    });
+  }
+
+  return {
+    sessionIdentifier: stream.sessionIdentifier,
+    lines,
+  };
+};

--- a/packages/extension/src/application/use-cases/stop-source-session-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/stop-source-session-use-case.test.ts
@@ -1,0 +1,166 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import { createSourceSession } from '../../domain/session/source-session';
+import {
+  invariantViolationError,
+  notFoundError,
+  type DomainError,
+} from '../../domain/shared/errors';
+import type { OverlayPresenter } from '../ports/overlay-presenter';
+import type { RelayGateway } from '../ports/relay-gateway';
+import type { SourceSessionRepository } from '../../domain/repositories/source-session-repository';
+import type { SourceSession } from '../../domain/session/source-session';
+import {
+  createStopSourceSessionUseCase,
+  type StopSourceSessionDependencies,
+} from './stop-source-session-use-case';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const STOPPED_AT = '2026-04-21T00:10:00.000Z';
+
+const buildActiveSession = (): SourceSession => {
+  const session = createSourceSession({
+    sessionIdentifier: SESSION_ID,
+    sourceIdentifier: SOURCE_ID,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt: '2026-04-21T00:00:00.000Z',
+  })._unsafeUnwrap();
+  return session;
+};
+
+const buildDependencies = (
+  overrides: Partial<StopSourceSessionDependencies> = {},
+): StopSourceSessionDependencies => {
+  const sourceSessionRepository: SourceSessionRepository = {
+    findById: vi.fn(() => okAsync(buildActiveSession())),
+    findActiveSessions: vi.fn(() => okAsync([])),
+    save: vi.fn(() => okAsync(undefined)),
+  };
+  const relayGateway: RelayGateway = {
+    openSession: vi.fn(() => okAsync(undefined)),
+    sendAudioFrame: vi.fn(() => okAsync(undefined)),
+    closeSession: vi.fn(() => okAsync(undefined)),
+    subscribe: vi.fn(() => () => {
+      /* noop */
+    }),
+  };
+  const overlayPresenter: OverlayPresenter = {
+    mount: vi.fn(() => okAsync(undefined)),
+    render: vi.fn(() => okAsync(undefined)),
+    updateSettings: vi.fn(() => okAsync(undefined)),
+    unmount: vi.fn(() => okAsync(undefined)),
+  };
+  return {
+    sourceSessionRepository,
+    relayGateway,
+    overlayPresenter,
+    clock: () => STOPPED_AT,
+    ...overrides,
+  };
+};
+
+describe('createStopSourceSessionUseCase (IMPL-215, DD-306)', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* silence */
+    });
+  });
+
+  it('stops an active session and returns the terminal state output', async () => {
+    const deps = buildDependencies();
+    const useCase = createStopSourceSessionUseCase(deps);
+    const result = await useCase({ sessionId: SESSION_ID, reason: 'user_requested' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessionId).toBe(SESSION_ID);
+      expect(result.value.state).toBe('stopped');
+      expect(result.value.stoppedAt).toBe(STOPPED_AT);
+    }
+    expect(deps.sourceSessionRepository.save).toHaveBeenCalledTimes(1);
+    expect(deps.relayGateway.closeSession).toHaveBeenCalledTimes(1);
+    expect(deps.overlayPresenter.unmount).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns validation error when input is invalid', async () => {
+    const deps = buildDependencies();
+    const useCase = createStopSourceSessionUseCase(deps);
+    const result = await useCase({ sessionId: '' });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('validation');
+  });
+
+  it('returns session-not-found when repository reports missing session', async () => {
+    const deps = buildDependencies({
+      sourceSessionRepository: {
+        findById: vi.fn(() =>
+          errAsync<SourceSession, DomainError>(
+            notFoundError({ resourceType: 'SourceSession', identifier: SESSION_ID }),
+          ),
+        ),
+        findActiveSessions: vi.fn(() => okAsync([])),
+        save: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const useCase = createStopSourceSessionUseCase(deps);
+    const result = await useCase({ sessionId: SESSION_ID });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('session-not-found');
+  });
+
+  it('returns conflict error when attempting to stop an already-stopped session', async () => {
+    const alreadyStopped = buildActiveSession();
+    const stopped = { ...alreadyStopped, state: 'stopped' as const, stoppedAt: STOPPED_AT };
+    const deps = buildDependencies({
+      sourceSessionRepository: {
+        findById: vi.fn(() => okAsync(stopped)),
+        findActiveSessions: vi.fn(() => okAsync([])),
+        save: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const useCase = createStopSourceSessionUseCase(deps);
+    const result = await useCase({ sessionId: SESSION_ID });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('conflict');
+  });
+
+  it('still succeeds when relayGateway.closeSession fails (fire-and-forget semantics)', async () => {
+    const deps = buildDependencies({
+      relayGateway: {
+        openSession: vi.fn(() => okAsync(undefined)),
+        sendAudioFrame: vi.fn(() => okAsync(undefined)),
+        closeSession: vi.fn(() =>
+          errAsync<void, DomainError>(
+            invariantViolationError({ invariant: 'relay-close-failed', details: 'socket error' }),
+          ),
+        ),
+        subscribe: vi.fn(() => () => {
+          /* noop */
+        }),
+      },
+    });
+    const useCase = createStopSourceSessionUseCase(deps);
+    const result = await useCase({ sessionId: SESSION_ID });
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('propagates save errors as conflict application errors', async () => {
+    const deps = buildDependencies({
+      sourceSessionRepository: {
+        findById: vi.fn(() => okAsync(buildActiveSession())),
+        findActiveSessions: vi.fn(() => okAsync([])),
+        save: vi.fn(() =>
+          errAsync<void, DomainError>(
+            invariantViolationError({ invariant: 'storage-write-failed', details: 'quota' }),
+          ),
+        ),
+      },
+    });
+    const useCase = createStopSourceSessionUseCase(deps);
+    const result = await useCase({ sessionId: SESSION_ID });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('conflict');
+  });
+});

--- a/packages/extension/src/application/use-cases/stop-source-session-use-case.ts
+++ b/packages/extension/src/application/use-cases/stop-source-session-use-case.ts
@@ -1,0 +1,66 @@
+import { type ResultAsync } from 'neverthrow';
+import { type SourceSessionRepository } from '../../domain/repositories/source-session-repository';
+import { parseSessionIdentifier } from '../../domain/session/session-identifier';
+import { stopSourceSession } from '../../domain/session/source-session';
+import { describeDomainError, type DomainError } from '../../domain/shared/errors';
+import {
+  parseStopSourceSessionInput,
+  type StopSourceSessionInput,
+  type StopSourceSessionOutput,
+} from '../dto/stop-source-session-dto';
+import { toApplicationError, type ApplicationError } from '../errors/application-errors';
+import { type OverlayPresenter } from '../ports/overlay-presenter';
+import { type RelayGateway } from '../ports/relay-gateway';
+
+export type StopSourceSessionDependencies = Readonly<{
+  sourceSessionRepository: SourceSessionRepository;
+  relayGateway: RelayGateway;
+  overlayPresenter: OverlayPresenter;
+  clock: () => string;
+}>;
+
+export type StopSourceSessionUseCase = (
+  input: StopSourceSessionInput,
+) => ResultAsync<StopSourceSessionOutput, ApplicationError>;
+
+const logWarn =
+  (scope: string) =>
+  (error: DomainError): void => {
+    console.warn(`[use-case:stop-source-session] ${scope} failed:`, describeDomainError(error));
+  };
+
+/**
+ * IMPL-215 StopSourceSessionUseCase (DD-306)。
+ *
+ * アクティブなセッションを停止し、Relay 接続とオーバーレイを解放する。
+ * `closeSession` / `unmount` は fire-and-forget (失敗しても UseCase は成功を
+ * 返す) で、結果整合性を優先する (use-case.md §6.1)。
+ */
+export const createStopSourceSessionUseCase = (
+  deps: StopSourceSessionDependencies,
+): StopSourceSessionUseCase => {
+  return (input) =>
+    parseStopSourceSessionInput(input)
+      .asyncAndThen((parsed) =>
+        parseSessionIdentifier(parsed.sessionId).asyncAndThen((sessionIdentifier) =>
+          deps.sourceSessionRepository
+            .findById(sessionIdentifier)
+            .andThen((session) => stopSourceSession(session, { stoppedAt: deps.clock() }))
+            .andThen((stopped) => deps.sourceSessionRepository.save(stopped).map(() => stopped))
+            .map((stopped): StopSourceSessionOutput => {
+              void deps.relayGateway
+                .closeSession(sessionIdentifier)
+                .match(() => undefined, logWarn('closeSession'));
+              void deps.overlayPresenter
+                .unmount(sessionIdentifier)
+                .match(() => undefined, logWarn('unmount'));
+              return {
+                sessionId: stopped.sessionIdentifier,
+                state: stopped.state,
+                stoppedAt: stopped.stoppedAt ?? deps.clock(),
+              };
+            }),
+        ),
+      )
+      .mapErr(toApplicationError);
+};


### PR DESCRIPTION
## Summary

Phase 2 §4.2 の最初の UseCase として `StopSourceSessionUseCase` を実装。後続 UseCase (IMPL-211 / 213 / 214) で共通利用する `overlay-render-projector` util を先行投入し、UseCase パターン (factory function + per-UseCase Dependencies + Result/ResultAsync chain + `mapErr(toApplicationError)`) を確立する。

### 実装

- **`projectOverlayRenderModel`** — `TranscriptStream` → `OverlayRenderModel` 投影。startMs 昇順 + maxLines 末尾 N 件 + show フラグフィルタ + 完了翻訳のみ採用
- **`createStopSourceSessionUseCase(deps)(input)`** (DD-306) — findById → stopSourceSession → save → closeSession/unmount (fire-and-forget) → output DTO
- **`index.ts`** — barrel export 骨格 (残り 6 UseCase は後続 PR で追加)

### 設計上の判断

- factory function + per-UseCase Dependencies (統一 type は作らない)
- `clock: () => string` を DI (deterministic test 用)
- `.asyncAndThen` で Result → ResultAsync 持ち上げ、末尾 1 回だけ `.mapErr(toApplicationError)`
- fire-and-forget: `void deps.xxx.yyy().match(noop, logWarn)` パターン

### base branch

PR #16 (IMPL-230) を base に stacked (本 PR merge 前にまず PR #16 merge される順序)。

## Test plan

- [x] `pnpm --filter @perapera/extension test` → 427 tests pass (+14 新規: projector 8 + stop UseCase 6)
- [x] `pnpm check` (fmt/lint/typecheck/test) 全緑
- [ ] CI `All Green` → auto merge