### PR TITLE
feat(application): IMPL-216/212/211 (Export / UpdateSettings / MonitorState)

### DIFF
--- a/packages/extension/src/application/use-cases/export-session-result-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/export-session-result-use-case.test.ts
@@ -1,0 +1,163 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import { type ExportRecordRepository } from '../../domain/repositories/export-record-repository';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import { createSourceSession } from '../../domain/session/source-session';
+import {
+  invariantViolationError,
+  notFoundError,
+  type DomainError,
+} from '../../domain/shared/errors';
+import { createTimestampRange } from '../../domain/transcript/timestamp-range';
+import {
+  appendPartialTranscriptSegment,
+  createTranscriptStream,
+  finalizeSegment,
+} from '../../domain/transcript/transcript-stream';
+import { type ExportBundle, type SessionStore } from '../ports/session-store';
+import {
+  createExportSessionResultUseCase,
+  type ExportSessionResultDependencies,
+} from './export-session-result-use-case';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+const EXPORT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7F1';
+const CREATED_AT = '2026-04-21T00:15:00.000Z';
+
+const buildBundle = (): ExportBundle => {
+  const session = createSourceSession({
+    sessionIdentifier: SESSION_ID,
+    sourceIdentifier: SOURCE_ID,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt: '2026-04-21T00:00:00.000Z',
+  })._unsafeUnwrap();
+  let stream = createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+  stream = appendPartialTranscriptSegment(stream, {
+    segmentIdentifier: SEGMENT_ID,
+    revision: 1,
+    text: 'hello world',
+    timeRange: createTimestampRange({ startMs: 0, endMs: 1500 })._unsafeUnwrap(),
+  })._unsafeUnwrap();
+  stream = finalizeSegment(stream, { segmentIdentifier: SEGMENT_ID })._unsafeUnwrap();
+  return { session, stream };
+};
+
+const buildDependencies = (
+  overrides: Partial<ExportSessionResultDependencies> = {},
+): ExportSessionResultDependencies => {
+  const sessionStore: SessionStore = {
+    saveSession: vi.fn(() => okAsync(undefined)),
+    appendTranscript: vi.fn(() => okAsync(undefined)),
+    appendTranslation: vi.fn(() => okAsync(undefined)),
+    loadExportBundle: vi.fn(() => okAsync(buildBundle())),
+  };
+  const exportRecordRepository: ExportRecordRepository = {
+    save: vi.fn(() => okAsync(undefined)),
+    findBySessionId: vi.fn(() => okAsync([])),
+  };
+  return {
+    sessionStore,
+    exportRecordRepository,
+    clock: () => CREATED_AT,
+    exportIdFactory: () => EXPORT_ID,
+    ...overrides,
+  };
+};
+
+describe('createExportSessionResultUseCase (IMPL-216, DD-307)', () => {
+  it('exports txt with bytes, exportId, and format on success', async () => {
+    const deps = buildDependencies();
+    const useCase = createExportSessionResultUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      format: 'txt',
+      includeOriginal: true,
+      includeTranslation: false,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.exportId).toBe(EXPORT_ID);
+      expect(result.value.format).toBe('txt');
+      expect(result.value.bytes).toBeGreaterThan(0);
+    }
+    expect(deps.exportRecordRepository.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns validation error for invalid input', async () => {
+    const deps = buildDependencies();
+    const useCase = createExportSessionResultUseCase(deps);
+    const result = await useCase({
+      sessionId: '',
+      format: 'txt',
+      includeOriginal: true,
+      includeTranslation: false,
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('validation');
+  });
+
+  it('returns session-not-found when loadExportBundle reports missing session', async () => {
+    const deps = buildDependencies({
+      sessionStore: {
+        saveSession: vi.fn(() => okAsync(undefined)),
+        appendTranscript: vi.fn(() => okAsync(undefined)),
+        appendTranslation: vi.fn(() => okAsync(undefined)),
+        loadExportBundle: vi.fn(() =>
+          errAsync<ExportBundle, DomainError>(
+            notFoundError({ resourceType: 'SourceSession', identifier: SESSION_ID }),
+          ),
+        ),
+      },
+    });
+    const useCase = createExportSessionResultUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      format: 'txt',
+      includeOriginal: true,
+      includeTranslation: true,
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('session-not-found');
+  });
+
+  it('returns conflict error when exportRecordRepository.save fails', async () => {
+    const deps = buildDependencies({
+      exportRecordRepository: {
+        save: vi.fn(() =>
+          errAsync<void, DomainError>(
+            invariantViolationError({ invariant: 'export-persistence', details: 'quota' }),
+          ),
+        ),
+        findBySessionId: vi.fn(() => okAsync([])),
+      },
+    });
+    const useCase = createExportSessionResultUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      format: 'txt',
+      includeOriginal: true,
+      includeTranslation: true,
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('conflict');
+  });
+
+  it('emits JSON format with correct bytes count', async () => {
+    const deps = buildDependencies();
+    const useCase = createExportSessionResultUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      format: 'json',
+      includeOriginal: true,
+      includeTranslation: false,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.format).toBe('json');
+      expect(result.value.bytes).toBeGreaterThan(10);
+    }
+  });
+});

--- a/packages/extension/src/application/use-cases/export-session-result-use-case.ts
+++ b/packages/extension/src/application/use-cases/export-session-result-use-case.ts
@@ -1,0 +1,86 @@
+import { err, ok, type ResultAsync } from 'neverthrow';
+import { createExportRecord } from '../../domain/export/export-record';
+import { type ExportRecordRepository } from '../../domain/repositories/export-record-repository';
+import {
+  assembleExport,
+  type ExportAssemblyOptions,
+} from '../../domain/services/export-assembly-service';
+import { parseSessionIdentifier } from '../../domain/session/session-identifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import {
+  parseExportSessionResultInput,
+  type ExportSessionResultInput,
+  type ExportSessionResultOutput,
+} from '../dto/export-session-result-dto';
+import { toApplicationError, type ApplicationError } from '../errors/application-errors';
+import { type SessionStore } from '../ports/session-store';
+
+export type ExportSessionResultDependencies = Readonly<{
+  sessionStore: SessionStore;
+  exportRecordRepository: ExportRecordRepository;
+  clock: () => string;
+  exportIdFactory: () => string;
+}>;
+
+export type ExportSessionResultUseCase = (
+  input: ExportSessionResultInput,
+) => ResultAsync<ExportSessionResultOutput, ApplicationError>;
+
+/**
+ * IMPL-216 ExportSessionResultUseCase (DD-307)。
+ *
+ * セッション永続データを取得し、`ExportAssemblyService` で TXT / JSON に
+ * 整形した後、`ExportRecord` として永続化する。UTF-8 bytes を出力に含める。
+ */
+export const createExportSessionResultUseCase = (
+  deps: ExportSessionResultDependencies,
+): ExportSessionResultUseCase => {
+  return (input) =>
+    parseExportSessionResultInput(input)
+      .asyncAndThen((parsed) =>
+        parseSessionIdentifier(parsed.sessionId).asyncAndThen((sessionIdentifier) =>
+          deps.sessionStore.loadExportBundle(sessionIdentifier).andThen((bundle) => {
+            const options: ExportAssemblyOptions = {
+              format: parsed.format,
+              includeOriginal: parsed.includeOriginal,
+              includeTranslation: parsed.includeTranslation,
+            };
+            return assembleExport(bundle.stream, options)
+              .andThen((content) => {
+                try {
+                  const bytes = new TextEncoder().encode(content).byteLength;
+                  return ok({ content, bytes });
+                } catch (cause) {
+                  return err<never, DomainError>(
+                    invariantViolationError({
+                      invariant: 'export-encoding-failed',
+                      details: cause instanceof Error ? cause.message : 'unknown encoding error',
+                    }),
+                  );
+                }
+              })
+              .asyncAndThen(({ bytes }) => {
+                const createdAt = deps.clock();
+                const exportId = deps.exportIdFactory();
+                return createExportRecord({
+                  exportIdentifier: exportId,
+                  sessionIdentifier: sessionIdentifier,
+                  format: parsed.format,
+                  includeOriginal: parsed.includeOriginal,
+                  includeTranslation: parsed.includeTranslation,
+                  createdAt,
+                }).asyncAndThen((record) =>
+                  deps.exportRecordRepository.save(record).map(
+                    (): ExportSessionResultOutput => ({
+                      exportId: record.exportIdentifier,
+                      format: record.format,
+                      bytes,
+                    }),
+                  ),
+                );
+              });
+          }),
+        ),
+      )
+      .mapErr(toApplicationError);
+};

--- a/packages/extension/src/application/use-cases/get-session-monitor-state-query.test.ts
+++ b/packages/extension/src/application/use-cases/get-session-monitor-state-query.test.ts
@@ -1,0 +1,204 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import { type SourceSessionRepository } from '../../domain/repositories/source-session-repository';
+import { type TranscriptStreamRepository } from '../../domain/repositories/transcript-stream-repository';
+import { createOverlaySettings } from '../../domain/profile/overlay-settings';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import { createSourceSession, type SourceSession } from '../../domain/session/source-session';
+import { notFoundError, type DomainError } from '../../domain/shared/errors';
+import { createTimestampRange } from '../../domain/transcript/timestamp-range';
+import {
+  appendPartialTranscriptSegment,
+  attachTranslationToSegment,
+  createTranscriptStream,
+  finalizeSegment,
+  type TranscriptStream,
+} from '../../domain/transcript/transcript-stream';
+import { type SettingsStore } from '../ports/settings-store';
+import {
+  createGetSessionMonitorStateQuery,
+  type GetSessionMonitorStateDependencies,
+} from './get-session-monitor-state-query';
+
+const SESSION_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SESSION_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+const SOURCE_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const SOURCE_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7B2';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+const TRANSLATION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7E1';
+
+const buildSession = (sessionId: string, sourceId: string): SourceSession =>
+  createSourceSession({
+    sessionIdentifier: sessionId,
+    sourceIdentifier: sourceId,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt: '2026-04-21T00:00:00.000Z',
+  })._unsafeUnwrap();
+
+const buildStreamWithTranslation = (sessionId: string): TranscriptStream => {
+  let stream = createTranscriptStream({ sessionIdentifier: sessionId })._unsafeUnwrap();
+  stream = appendPartialTranscriptSegment(stream, {
+    segmentIdentifier: SEGMENT_ID,
+    revision: 1,
+    text: 'hello',
+    timeRange: createTimestampRange({ startMs: 0, endMs: 1000 })._unsafeUnwrap(),
+  })._unsafeUnwrap();
+  stream = finalizeSegment(stream, { segmentIdentifier: SEGMENT_ID })._unsafeUnwrap();
+  stream = attachTranslationToSegment(stream, {
+    translationIdentifier: TRANSLATION_ID,
+    segmentIdentifier: SEGMENT_ID,
+    targetLanguage: 'ja-JP',
+    text: 'こんにちは',
+  })._unsafeUnwrap();
+  return stream;
+};
+
+const overlaySettings = createOverlaySettings({
+  positionPreset: 'bottom',
+  opacity: 0.8,
+  maxLines: 2,
+  fontScale: 1,
+  showOriginalText: true,
+  showTranslatedText: true,
+})._unsafeUnwrap();
+
+const buildDependencies = (
+  overrides: Partial<GetSessionMonitorStateDependencies> = {},
+): GetSessionMonitorStateDependencies => {
+  const sourceSessionRepository: SourceSessionRepository = {
+    findById: vi.fn(() => okAsync(buildSession(SESSION_ID_1, SOURCE_ID_1))),
+    findActiveSessions: vi.fn(() =>
+      okAsync([buildSession(SESSION_ID_1, SOURCE_ID_1), buildSession(SESSION_ID_2, SOURCE_ID_2)]),
+    ),
+    save: vi.fn(() => okAsync(undefined)),
+  };
+  const defaultFindBySessionId: TranscriptStreamRepository['findBySessionId'] = (id) =>
+    okAsync(buildStreamWithTranslation(id));
+  const transcriptStreamRepository: TranscriptStreamRepository = {
+    findBySessionId: vi.fn(defaultFindBySessionId),
+    appendPartial: vi.fn(() => okAsync(undefined)),
+    appendFinal: vi.fn(() => okAsync(undefined)),
+    appendTranslation: vi.fn(() => okAsync(undefined)),
+  };
+  const settingsStore: SettingsStore = {
+    getDefaultLanguagePair: vi.fn(() =>
+      okAsync(createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap()),
+    ),
+    saveDefaultLanguagePair: vi.fn(() => okAsync(undefined)),
+    getDefaultOverlaySettings: vi.fn(() => okAsync(overlaySettings)),
+    saveDefaultOverlaySettings: vi.fn(() => okAsync(undefined)),
+  };
+  return {
+    sourceSessionRepository,
+    transcriptStreamRepository,
+    settingsStore,
+    ...overrides,
+  };
+};
+
+describe('createGetSessionMonitorStateQuery (IMPL-211, DD-302)', () => {
+  it('returns active sessions with latest segments', async () => {
+    const deps = buildDependencies();
+    const query = createGetSessionMonitorStateQuery(deps);
+    const result = await query({ includeOverlayState: false });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessions).toHaveLength(2);
+      expect(result.value.latestSegments.length).toBeGreaterThan(0);
+      expect(result.value.overlayState).toBeUndefined();
+    }
+  });
+
+  it('filters sessions by provided sessionIds', async () => {
+    const deps = buildDependencies();
+    const query = createGetSessionMonitorStateQuery(deps);
+    const result = await query({
+      sessionIds: [SESSION_ID_2],
+      includeOverlayState: false,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessions).toHaveLength(1);
+      expect(result.value.sessions[0]?.sessionId).toBe(SESSION_ID_2);
+    }
+  });
+
+  it('includes overlayState when includeOverlayState=true and there is at least one session', async () => {
+    const deps = buildDependencies();
+    const query = createGetSessionMonitorStateQuery(deps);
+    const result = await query({ includeOverlayState: true });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.overlayState).toBeDefined();
+      expect(result.value.overlayState?.positionPreset).toBe('bottom');
+    }
+  });
+
+  it('returns empty result when no active sessions exist', async () => {
+    const deps = buildDependencies({
+      sourceSessionRepository: {
+        findById: vi.fn(() => okAsync(buildSession(SESSION_ID_1, SOURCE_ID_1))),
+        findActiveSessions: vi.fn(() => okAsync([])),
+        save: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const query = createGetSessionMonitorStateQuery(deps);
+    const result = await query({ includeOverlayState: true });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessions).toEqual([]);
+      expect(result.value.latestSegments).toEqual([]);
+    }
+  });
+
+  it('tolerates not-found streams (skips latestSegments for that session)', async () => {
+    const findBySessionId: TranscriptStreamRepository['findBySessionId'] = (id) => {
+      if (id === SESSION_ID_1) {
+        return errAsync<TranscriptStream, DomainError>(
+          notFoundError({ resourceType: 'TranscriptStream', identifier: id }),
+        );
+      }
+      return okAsync(buildStreamWithTranslation(id));
+    };
+    const deps = buildDependencies({
+      transcriptStreamRepository: {
+        findBySessionId: vi.fn(findBySessionId),
+        appendPartial: vi.fn(() => okAsync(undefined)),
+        appendFinal: vi.fn(() => okAsync(undefined)),
+        appendTranslation: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const query = createGetSessionMonitorStateQuery(deps);
+    const result = await query({ includeOverlayState: false });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const sessionsWithSegments = new Set(result.value.latestSegments.map((s) => s.sessionId));
+      expect(sessionsWithSegments.has(SESSION_ID_1)).toBe(false);
+      expect(sessionsWithSegments.has(SESSION_ID_2)).toBe(true);
+    }
+  });
+
+  it('skips overlayState silently when settingsStore has no default', async () => {
+    const deps = buildDependencies({
+      settingsStore: {
+        getDefaultLanguagePair: vi.fn(() =>
+          okAsync(createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap()),
+        ),
+        saveDefaultLanguagePair: vi.fn(() => okAsync(undefined)),
+        getDefaultOverlaySettings: vi.fn(() =>
+          errAsync<typeof overlaySettings, DomainError>(
+            notFoundError({ resourceType: 'OverlaySettings', identifier: 'default' }),
+          ),
+        ),
+        saveDefaultOverlaySettings: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const query = createGetSessionMonitorStateQuery(deps);
+    const result = await query({ includeOverlayState: true });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.overlayState).toBeUndefined();
+    }
+  });
+});

--- a/packages/extension/src/application/use-cases/get-session-monitor-state-query.ts
+++ b/packages/extension/src/application/use-cases/get-session-monitor-state-query.ts
@@ -1,0 +1,139 @@
+import { okAsync, ResultAsync } from 'neverthrow';
+import { type SourceSessionRepository } from '../../domain/repositories/source-session-repository';
+import { type TranscriptStreamRepository } from '../../domain/repositories/transcript-stream-repository';
+import { type SourceSession } from '../../domain/session/source-session';
+import { type DomainError } from '../../domain/shared/errors';
+import { type TranscriptStream } from '../../domain/transcript/transcript-stream';
+import {
+  parseGetSessionMonitorStateInput,
+  type GetSessionMonitorStateInput,
+  type SessionMonitorStateOutput,
+} from '../dto/get-session-monitor-state-dto';
+import { toApplicationError, type ApplicationError } from '../errors/application-errors';
+import { type SettingsStore } from '../ports/settings-store';
+
+export type GetSessionMonitorStateDependencies = Readonly<{
+  sourceSessionRepository: SourceSessionRepository;
+  transcriptStreamRepository: TranscriptStreamRepository;
+  settingsStore: SettingsStore;
+}>;
+
+export type GetSessionMonitorStateQuery = (
+  input: GetSessionMonitorStateInput,
+) => ResultAsync<SessionMonitorStateOutput, ApplicationError>;
+
+/** 1 stream あたり latestSegments に含める最大件数 */
+const MAX_LATEST_SEGMENTS_PER_STREAM = 3;
+
+type SessionSummary = SessionMonitorStateOutput['sessions'][number];
+type LatestSegment = SessionMonitorStateOutput['latestSegments'][number];
+type OverlayState = NonNullable<SessionMonitorStateOutput['overlayState']>;
+
+const projectSessionSummary = (session: SourceSession): SessionSummary => ({
+  sessionId: session.sessionIdentifier,
+  // NOTE: SourceSession 集約に displayName フィールドが無いため、現時点では
+  // `${sourceType}-${sessionId の末尾 6 文字}` で代替。将来 session に
+  // displayName を追加したらここを置き換える。
+  displayName: `${session.sourceType}-${session.sessionIdentifier.slice(-6)}`,
+  state: session.state,
+  sourceType: session.sourceType,
+});
+
+const projectLatestSegments = (
+  session: SourceSession,
+  stream: TranscriptStream,
+): LatestSegment[] => {
+  const finals = [...stream.segments.values()]
+    .filter((segment) => segment.isFinal)
+    .sort((a, b) => b.timeRange.startMs - a.timeRange.startMs)
+    .slice(0, MAX_LATEST_SEGMENTS_PER_STREAM);
+  return finals.map((segment): LatestSegment => {
+    const translation = stream.translations.get(segment.segmentIdentifier);
+    const entry: LatestSegment = {
+      sessionId: session.sessionIdentifier,
+      segmentId: segment.segmentIdentifier,
+      originalText: segment.text,
+    };
+    if (translation?.status === 'completed') {
+      return { ...entry, translatedText: translation.text };
+    }
+    return entry;
+  });
+};
+
+/**
+ * IMPL-211 GetSessionMonitorStateQuery (DD-302)。
+ * Side Panel / Popup の状態表示用 Query。読み取り専用。
+ */
+export const createGetSessionMonitorStateQuery = (
+  deps: GetSessionMonitorStateDependencies,
+): GetSessionMonitorStateQuery => {
+  return (input) =>
+    parseGetSessionMonitorStateInput(input)
+      .asyncAndThen((parsed) =>
+        deps.sourceSessionRepository.findActiveSessions().andThen((allSessions) => {
+          const filterIds = parsed.sessionIds;
+          const filtered =
+            filterIds !== undefined
+              ? allSessions.filter((session) =>
+                  filterIds.some((id) => id === session.sessionIdentifier),
+                )
+              : allSessions;
+
+          if (filtered.length === 0) {
+            const empty: SessionMonitorStateOutput = { sessions: [], latestSegments: [] };
+            return okAsync(empty);
+          }
+
+          const streamLookups = filtered.map((session) =>
+            deps.transcriptStreamRepository
+              .findBySessionId(session.sessionIdentifier)
+              .map((stream): { session: SourceSession; stream: TranscriptStream | null } => ({
+                session,
+                stream,
+              }))
+              .orElse(() =>
+                okAsync<{ session: SourceSession; stream: TranscriptStream | null }, DomainError>({
+                  session,
+                  stream: null,
+                }),
+              ),
+          );
+
+          return ResultAsync.combine(streamLookups).andThen((pairs) => {
+            const sessions = pairs.map(({ session }) => projectSessionSummary(session));
+            const latestSegments = pairs.flatMap(({ session, stream }) =>
+              stream === null ? [] : projectLatestSegments(session, stream),
+            );
+
+            const representativeSessionId = filtered[0]?.sessionIdentifier;
+            if (!parsed.includeOverlayState || representativeSessionId === undefined) {
+              const output: SessionMonitorStateOutput = { sessions, latestSegments };
+              return okAsync(output);
+            }
+
+            return deps.settingsStore
+              .getDefaultOverlaySettings()
+              .map(
+                (settings): OverlayState => ({
+                  sessionId: representativeSessionId,
+                  positionPreset: settings.positionPreset,
+                  opacity: settings.opacity,
+                  maxLines: settings.maxLines,
+                  fontScale: settings.fontScale,
+                  showOriginalText: settings.showOriginalText,
+                  showTranslatedText: settings.showTranslatedText,
+                }),
+              )
+              .orElse(() => okAsync<OverlayState | null, DomainError>(null))
+              .map((overlayState): SessionMonitorStateOutput => {
+                if (overlayState === null) {
+                  return { sessions, latestSegments };
+                }
+                return { sessions, latestSegments, overlayState };
+              });
+          });
+        }),
+      )
+      .mapErr(toApplicationError);
+};

--- a/packages/extension/src/application/use-cases/index.ts
+++ b/packages/extension/src/application/use-cases/index.ts
@@ -1,6 +1,21 @@
 export {
+  createExportSessionResultUseCase,
+  type ExportSessionResultDependencies,
+  type ExportSessionResultUseCase,
+} from './export-session-result-use-case';
+export {
+  createGetSessionMonitorStateQuery,
+  type GetSessionMonitorStateDependencies,
+  type GetSessionMonitorStateQuery,
+} from './get-session-monitor-state-query';
+export { projectOverlayRenderModel } from './overlay-render-projector';
+export {
   createStopSourceSessionUseCase,
   type StopSourceSessionDependencies,
   type StopSourceSessionUseCase,
 } from './stop-source-session-use-case';
-export { projectOverlayRenderModel } from './overlay-render-projector';
+export {
+  createUpdateSourceSettingsUseCase,
+  type UpdateSourceSettingsDependencies,
+  type UpdateSourceSettingsUseCase,
+} from './update-source-settings-use-case';

--- a/packages/extension/src/application/use-cases/update-source-settings-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/update-source-settings-use-case.test.ts
@@ -1,0 +1,166 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type SourceSessionRepository } from '../../domain/repositories/source-session-repository';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import { createSourceSession, type SourceSession } from '../../domain/session/source-session';
+import {
+  invariantViolationError,
+  notFoundError,
+  type DomainError,
+} from '../../domain/shared/errors';
+import { type OverlayPresenter } from '../ports/overlay-presenter';
+import {
+  createUpdateSourceSettingsUseCase,
+  type UpdateSourceSettingsDependencies,
+} from './update-source-settings-use-case';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const APPLIED_AT = '2026-04-21T00:05:00.000Z';
+
+const buildSession = (): SourceSession =>
+  createSourceSession({
+    sessionIdentifier: SESSION_ID,
+    sourceIdentifier: SOURCE_ID,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt: '2026-04-21T00:00:00.000Z',
+  })._unsafeUnwrap();
+
+const buildDependencies = (
+  overrides: Partial<UpdateSourceSettingsDependencies> = {},
+): UpdateSourceSettingsDependencies => {
+  const sourceSessionRepository: SourceSessionRepository = {
+    findById: vi.fn(() => okAsync(buildSession())),
+    findActiveSessions: vi.fn(() => okAsync([])),
+    save: vi.fn(() => okAsync(undefined)),
+  };
+  const overlayPresenter: OverlayPresenter = {
+    mount: vi.fn(() => okAsync(undefined)),
+    render: vi.fn(() => okAsync(undefined)),
+    updateSettings: vi.fn(() => okAsync(undefined)),
+    unmount: vi.fn(() => okAsync(undefined)),
+  };
+  return {
+    sourceSessionRepository,
+    overlayPresenter,
+    clock: () => APPLIED_AT,
+    ...overrides,
+  };
+};
+
+describe('createUpdateSourceSettingsUseCase (IMPL-212, DD-303)', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* silence */
+    });
+  });
+
+  it('updates target language only and saves the session', async () => {
+    const deps = buildDependencies();
+    const useCase = createUpdateSourceSettingsUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      targetLanguage: 'fr-FR',
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessionId).toBe(SESSION_ID);
+      expect(result.value.appliedAt).toBe(APPLIED_AT);
+    }
+    expect(deps.sourceSessionRepository.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates source language only (target unchanged)', async () => {
+    const deps = buildDependencies();
+    const useCase = createUpdateSourceSettingsUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      sourceLanguage: 'fr-FR',
+    });
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('skips save when no language fields and no overlay settings are provided', async () => {
+    const deps = buildDependencies();
+    const useCase = createUpdateSourceSettingsUseCase(deps);
+    const result = await useCase({ sessionId: SESSION_ID });
+    expect(result.isOk()).toBe(true);
+    expect(deps.sourceSessionRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('applies overlay settings via OverlayPresenter.updateSettings', async () => {
+    const deps = buildDependencies();
+    const useCase = createUpdateSourceSettingsUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      overlaySettings: {
+        positionPreset: 'bottom',
+        opacity: 0.6,
+        maxLines: 3,
+        fontScale: 1,
+        showOriginalText: true,
+        showTranslatedText: true,
+      },
+    });
+    expect(result.isOk()).toBe(true);
+    expect(deps.overlayPresenter.updateSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns validation error when source === target after update', async () => {
+    const deps = buildDependencies();
+    const useCase = createUpdateSourceSettingsUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      sourceLanguage: 'ja-JP',
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('validation');
+  });
+
+  it('returns session-not-found when repository reports missing session', async () => {
+    const deps = buildDependencies({
+      sourceSessionRepository: {
+        findById: vi.fn(() =>
+          errAsync<SourceSession, DomainError>(
+            notFoundError({ resourceType: 'SourceSession', identifier: SESSION_ID }),
+          ),
+        ),
+        findActiveSessions: vi.fn(() => okAsync([])),
+        save: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const useCase = createUpdateSourceSettingsUseCase(deps);
+    const result = await useCase({ sessionId: SESSION_ID, targetLanguage: 'fr-FR' });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('session-not-found');
+  });
+
+  it('still succeeds when overlayPresenter.updateSettings fails (fire-and-forget)', async () => {
+    const deps = buildDependencies({
+      overlayPresenter: {
+        mount: vi.fn(() => okAsync(undefined)),
+        render: vi.fn(() => okAsync(undefined)),
+        updateSettings: vi.fn(() =>
+          errAsync<void, DomainError>(
+            invariantViolationError({ invariant: 'overlay-update-failed', details: 'no host' }),
+          ),
+        ),
+        unmount: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const useCase = createUpdateSourceSettingsUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      overlaySettings: {
+        positionPreset: 'top',
+        opacity: 0.5,
+        maxLines: 2,
+        fontScale: 1,
+        showOriginalText: true,
+        showTranslatedText: true,
+      },
+    });
+    expect(result.isOk()).toBe(true);
+  });
+});

--- a/packages/extension/src/application/use-cases/update-source-settings-use-case.ts
+++ b/packages/extension/src/application/use-cases/update-source-settings-use-case.ts
@@ -1,0 +1,86 @@
+import { okAsync, type ResultAsync } from 'neverthrow';
+import { createOverlaySettings } from '../../domain/profile/overlay-settings';
+import { type SourceSessionRepository } from '../../domain/repositories/source-session-repository';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import { parseSessionIdentifier } from '../../domain/session/session-identifier';
+import { type SourceSession } from '../../domain/session/source-session';
+import { describeDomainError, type DomainError } from '../../domain/shared/errors';
+import {
+  parseUpdateSourceSettingsInput,
+  type UpdateSourceSettingsInput,
+  type UpdateSourceSettingsOutput,
+} from '../dto/update-source-settings-dto';
+import { toApplicationError, type ApplicationError } from '../errors/application-errors';
+import { type OverlayPresenter } from '../ports/overlay-presenter';
+
+export type UpdateSourceSettingsDependencies = Readonly<{
+  sourceSessionRepository: SourceSessionRepository;
+  overlayPresenter: OverlayPresenter;
+  clock: () => string;
+}>;
+
+export type UpdateSourceSettingsUseCase = (
+  input: UpdateSourceSettingsInput,
+) => ResultAsync<UpdateSourceSettingsOutput, ApplicationError>;
+
+const logWarn = (scope: string) => (error: DomainError) => {
+  console.warn(`[use-case:update-source-settings] ${scope} failed:`, describeDomainError(error));
+};
+
+/**
+ * IMPL-212 UpdateSourceSettingsUseCase (DD-303)。
+ *
+ * 利用者が明示的に設定を変更する際の UseCase。
+ * - `sourceLanguage` / `targetLanguage` が指定されれば、対応する `LanguagePair`
+ *   を更新し、session を永続化
+ * - `overlaySettings` が指定されれば `OverlayPresenter.updateSettings` に伝達
+ *   (fire-and-forget)。両者とも省略された場合は no-op
+ */
+export const createUpdateSourceSettingsUseCase = (
+  deps: UpdateSourceSettingsDependencies,
+): UpdateSourceSettingsUseCase => {
+  return (input) =>
+    parseUpdateSourceSettingsInput(input)
+      .asyncAndThen((parsed) =>
+        parseSessionIdentifier(parsed.sessionId).asyncAndThen((sessionIdentifier) =>
+          deps.sourceSessionRepository.findById(sessionIdentifier).andThen((session) => {
+            const hasSourceLanguage =
+              parsed.sourceLanguage !== undefined && parsed.sourceLanguage !== null;
+            const needsLanguageUpdate = hasSourceLanguage || parsed.targetLanguage !== undefined;
+            const savePromise: ResultAsync<SourceSession, DomainError> = needsLanguageUpdate
+              ? (() => {
+                  const nextSource = parsed.sourceLanguage ?? session.languagePair.source;
+                  const nextTarget = parsed.targetLanguage ?? session.languagePair.target;
+                  return createLanguagePair({
+                    source: nextSource,
+                    target: nextTarget,
+                  })
+                    .map((languagePair) => ({ ...session, languagePair }))
+                    .asyncAndThen((updated) =>
+                      deps.sourceSessionRepository.save(updated).map(() => updated),
+                    );
+                })()
+              : okAsync(session);
+
+            return savePromise.map((saved) => {
+              if (parsed.overlaySettings !== undefined) {
+                const overlayResult = createOverlaySettings(parsed.overlaySettings);
+                if (overlayResult.isOk()) {
+                  void deps.overlayPresenter
+                    .updateSettings(sessionIdentifier, overlayResult.value)
+                    .match(() => undefined, logWarn('overlayPresenter.updateSettings'));
+                } else {
+                  logWarn('createOverlaySettings')(overlayResult.error);
+                }
+              }
+              const output: UpdateSourceSettingsOutput = {
+                sessionId: saved.sessionIdentifier,
+                appliedAt: deps.clock(),
+              };
+              return output;
+            });
+          }),
+        ),
+      )
+      .mapErr(toApplicationError);
+};


### PR DESCRIPTION
## Summary

Phase 2 §4.2 UseCase 7 種のうち 3 種を実装。PR1 (IMPL-215) で確立した factory function パターンと `overlay-render-projector` util を展開する。

- **IMPL-216 ExportSessionResultUseCase** (DD-307) — loadExportBundle → assembleExport → bytes 計算 → ExportRecord save
- **IMPL-212 UpdateSourceSettingsUseCase** (DD-303) — 言語ペア部分更新 + overlay settings 配信 (fire-and-forget)
- **IMPL-211 GetSessionMonitorStateQuery** (DD-302) — 並列 stream lookup + overlayState 投影 + not-found tolerance

### 設計判断

- `ResultAsync.combine` で session ごとの stream lookup を並列実行
- `displayName` は集約に未追加のため暫定 `${sourceType}-${last6}` (将来置換)
- nullish coalescing `??` 徹底、`vi.fn<T['method']>(...)` 型明示で `no-unsafe-argument` 回避

## Test plan

- [x] 445 tests pass (+18: Export 5 + UpdateSettings 7 + MonitorState 6)
- [x] `pnpm check` 全緑
- [ ] CI `All Green` → auto merge