### PR TITLE
feat(application): IMPL-213/214/210 (Partial / Final / Start) — Phase 2 §4.2 完了

### DIFF
--- a/packages/extension/src/application/use-cases/handle-transcript-final-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/handle-transcript-final-use-case.test.ts
@@ -1,0 +1,231 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createOverlaySettings } from '../../domain/profile/overlay-settings';
+import { type TranscriptStreamRepository } from '../../domain/repositories/transcript-stream-repository';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import {
+  invariantViolationError,
+  notFoundError,
+  type DomainError,
+} from '../../domain/shared/errors';
+import { createTimestampRange } from '../../domain/transcript/timestamp-range';
+import {
+  appendPartialTranscriptSegment,
+  createTranscriptStream,
+  type TranscriptStream,
+} from '../../domain/transcript/transcript-stream';
+import { type OverlayPresenter } from '../ports/overlay-presenter';
+import { type SessionStore } from '../ports/session-store';
+import { type SettingsStore } from '../ports/settings-store';
+import {
+  createHandleTranscriptFinalUseCase,
+  type HandleTranscriptFinalDependencies,
+} from './handle-transcript-final-use-case';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+const TRANSLATION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7E1';
+
+const buildStreamWithPartial = (): TranscriptStream => {
+  const stream = createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+  return appendPartialTranscriptSegment(stream, {
+    segmentIdentifier: SEGMENT_ID,
+    revision: 1,
+    text: 'hello',
+    timeRange: createTimestampRange({ startMs: 0, endMs: 1000 })._unsafeUnwrap(),
+  })._unsafeUnwrap();
+};
+
+const overlaySettings = createOverlaySettings({
+  positionPreset: 'bottom',
+  opacity: 0.8,
+  maxLines: 2,
+  fontScale: 1,
+  showOriginalText: true,
+  showTranslatedText: true,
+})._unsafeUnwrap();
+
+const buildDependencies = (
+  overrides: Partial<HandleTranscriptFinalDependencies> = {},
+): HandleTranscriptFinalDependencies => {
+  const transcriptStreamRepository: TranscriptStreamRepository = {
+    findBySessionId: vi.fn(() => okAsync(buildStreamWithPartial())),
+    appendPartial: vi.fn(() => okAsync(undefined)),
+    appendFinal: vi.fn(() => okAsync(undefined)),
+    appendTranslation: vi.fn(() => okAsync(undefined)),
+  };
+  const overlayPresenter: OverlayPresenter = {
+    mount: vi.fn(() => okAsync(undefined)),
+    render: vi.fn(() => okAsync(undefined)),
+    updateSettings: vi.fn(() => okAsync(undefined)),
+    unmount: vi.fn(() => okAsync(undefined)),
+  };
+  const sessionStore: SessionStore = {
+    saveSession: vi.fn(() => okAsync(undefined)),
+    appendTranscript: vi.fn(() => okAsync(undefined)),
+    appendTranslation: vi.fn(() => okAsync(undefined)),
+    loadExportBundle: vi.fn(() =>
+      errAsync<never, DomainError>(
+        notFoundError({ resourceType: 'SourceSession', identifier: 'unused' }),
+      ),
+    ),
+  };
+  const defaultLanguagePair = createLanguagePair({
+    source: 'en-US',
+    target: 'ja-JP',
+  })._unsafeUnwrap();
+  const getDefaultLanguagePair: SettingsStore['getDefaultLanguagePair'] = () =>
+    okAsync(defaultLanguagePair);
+  const settingsStore: SettingsStore = {
+    getDefaultLanguagePair: vi.fn(getDefaultLanguagePair),
+    saveDefaultLanguagePair: vi.fn(() => okAsync(undefined)),
+    getDefaultOverlaySettings: vi.fn(() => okAsync(overlaySettings)),
+    saveDefaultOverlaySettings: vi.fn(() => okAsync(undefined)),
+  };
+  return {
+    transcriptStreamRepository,
+    overlayPresenter,
+    sessionStore,
+    settingsStore,
+    translationIdFactory: () => TRANSLATION_ID,
+    ...overrides,
+  };
+};
+
+describe('createHandleTranscriptFinalUseCase (IMPL-214, DD-305)', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* silence */
+    });
+  });
+
+  it('finalizes segment without translation (status=pending)', async () => {
+    const deps = buildDependencies();
+    const useCase = createHandleTranscriptFinalUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      text: 'hello',
+      timeRange: { startMs: 0, endMs: 1000 },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.translationStatus).toBe('pending');
+    }
+    expect(deps.transcriptStreamRepository.appendFinal).toHaveBeenCalledTimes(1);
+    expect(deps.transcriptStreamRepository.appendTranslation).not.toHaveBeenCalled();
+  });
+
+  it('finalizes segment with completed translation', async () => {
+    const deps = buildDependencies();
+    const useCase = createHandleTranscriptFinalUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      text: 'hello',
+      timeRange: { startMs: 0, endMs: 1000 },
+      translation: {
+        targetLanguage: 'ja-JP',
+        text: 'こんにちは',
+        status: 'completed',
+      },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.translationStatus).toBe('completed');
+    }
+    expect(deps.transcriptStreamRepository.appendTranslation).toHaveBeenCalledTimes(1);
+  });
+
+  it('records failed translation status without attaching to stream', async () => {
+    const deps = buildDependencies();
+    const useCase = createHandleTranscriptFinalUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      text: 'hello',
+      timeRange: { startMs: 0, endMs: 1000 },
+      translation: {
+        targetLanguage: 'ja-JP',
+        text: '',
+        status: 'failed',
+      },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.translationStatus).toBe('failed');
+    }
+    expect(deps.transcriptStreamRepository.appendTranslation).not.toHaveBeenCalled();
+  });
+
+  it('returns validation error when text is empty', async () => {
+    const deps = buildDependencies();
+    const useCase = createHandleTranscriptFinalUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      text: '',
+      timeRange: { startMs: 0, endMs: 1000 },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('validation');
+  });
+
+  it('still succeeds when overlay render fails (hot-path not rolled back)', async () => {
+    const deps = buildDependencies({
+      overlayPresenter: {
+        mount: vi.fn(() => okAsync(undefined)),
+        render: vi.fn(() =>
+          errAsync<void, DomainError>(
+            invariantViolationError({ invariant: 'render-failed', details: 'x' }),
+          ),
+        ),
+        updateSettings: vi.fn(() => okAsync(undefined)),
+        unmount: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const useCase = createHandleTranscriptFinalUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      text: 'hello',
+      timeRange: { startMs: 0, endMs: 1000 },
+    });
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('propagates finalize error as conflict', async () => {
+    const streamWithFinalized = (() => {
+      let s = createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+      s = appendPartialTranscriptSegment(s, {
+        segmentIdentifier: SEGMENT_ID,
+        revision: 1,
+        text: 'first',
+        timeRange: createTimestampRange({ startMs: 0, endMs: 1000 })._unsafeUnwrap(),
+      })._unsafeUnwrap();
+      // segment already finalized
+      const alreadyFinal = s.segments.get(SEGMENT_ID);
+      if (alreadyFinal === undefined) throw new Error('unreachable');
+      const finals = new Map(s.segments);
+      finals.set(SEGMENT_ID, { ...alreadyFinal, isFinal: true });
+      return { ...s, segments: finals };
+    })();
+    const deps = buildDependencies({
+      transcriptStreamRepository: {
+        findBySessionId: vi.fn(() => okAsync(streamWithFinalized)),
+        appendPartial: vi.fn(() => okAsync(undefined)),
+        appendFinal: vi.fn(() => okAsync(undefined)),
+        appendTranslation: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const useCase = createHandleTranscriptFinalUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      text: 'hello',
+      timeRange: { startMs: 0, endMs: 1000 },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('conflict');
+  });
+});

--- a/packages/extension/src/application/use-cases/handle-transcript-final-use-case.ts
+++ b/packages/extension/src/application/use-cases/handle-transcript-final-use-case.ts
@@ -1,0 +1,154 @@
+import { okAsync, type ResultAsync } from 'neverthrow';
+import { createOverlaySettings, type OverlaySettings } from '../../domain/profile/overlay-settings';
+import { type TranscriptStreamRepository } from '../../domain/repositories/transcript-stream-repository';
+import { parseSegmentIdentifier } from '../../domain/transcript/segment-identifier';
+import { createTimestampRange } from '../../domain/transcript/timestamp-range';
+import {
+  attachTranslationToSegment,
+  finalizeSegment,
+  type TranscriptStream,
+} from '../../domain/transcript/transcript-stream';
+import { parseSessionIdentifier } from '../../domain/session/session-identifier';
+import { describeDomainError, type DomainError } from '../../domain/shared/errors';
+import {
+  parseHandleTranscriptFinalInput,
+  type HandleTranscriptFinalInput,
+  type HandleTranscriptFinalOutput,
+} from '../dto/handle-transcript-final-dto';
+import { toApplicationError, type ApplicationError } from '../errors/application-errors';
+import { type OverlayPresenter } from '../ports/overlay-presenter';
+import { type SessionStore } from '../ports/session-store';
+import { type SettingsStore } from '../ports/settings-store';
+import { projectOverlayRenderModel } from './overlay-render-projector';
+
+export type HandleTranscriptFinalDependencies = Readonly<{
+  transcriptStreamRepository: TranscriptStreamRepository;
+  overlayPresenter: OverlayPresenter;
+  sessionStore: SessionStore;
+  settingsStore: SettingsStore;
+  translationIdFactory: () => string;
+}>;
+
+export type HandleTranscriptFinalUseCase = (
+  input: HandleTranscriptFinalInput,
+) => ResultAsync<HandleTranscriptFinalOutput, ApplicationError>;
+
+const logWarn = (scope: string) => (error: DomainError) => {
+  console.warn(`[use-case:handle-transcript-final] ${scope} failed:`, describeDomainError(error));
+};
+
+const resolveOverlaySettings = (
+  settingsStore: SettingsStore,
+): ResultAsync<OverlaySettings, DomainError> =>
+  settingsStore.getDefaultOverlaySettings().orElse(() => {
+    const fallback = createOverlaySettings({
+      positionPreset: 'bottom',
+      opacity: 0.8,
+      maxLines: 2,
+      fontScale: 1,
+      showOriginalText: true,
+      showTranslatedText: true,
+    });
+    return fallback.isOk() ? okAsync(fallback.value) : okAsync(fallback._unsafeUnwrap());
+  });
+
+const determineTranslationStatus = (
+  translation: HandleTranscriptFinalInput['translation'],
+): HandleTranscriptFinalOutput['translationStatus'] => {
+  if (translation === undefined) return 'pending';
+  return translation.status;
+};
+
+/**
+ * IMPL-214 HandleTranscriptFinalUseCase (DD-305)。
+ *
+ * 流れ:
+ * 1. `findBySessionId` → `finalizeSegment` (partial → final に遷移)
+ * 2. `translation.status === 'completed'` なら `attachTranslationToSegment`
+ *    (failed は Err 的な扱い、stream に attach せず status だけ反映)
+ * 3. `appendFinal` + (completed 時のみ) `appendTranslation` (hot-path I/O)
+ * 4. overlay render (結果整合、失敗しても Ok)
+ * 5. session store は fire-and-forget
+ */
+export const createHandleTranscriptFinalUseCase = (
+  deps: HandleTranscriptFinalDependencies,
+): HandleTranscriptFinalUseCase => {
+  return (input) =>
+    parseHandleTranscriptFinalInput(input)
+      .asyncAndThen((parsed) =>
+        parseSessionIdentifier(parsed.sessionId).asyncAndThen((sessionIdentifier) =>
+          parseSegmentIdentifier(parsed.segmentId).asyncAndThen((segmentIdentifier) =>
+            createTimestampRange({
+              startMs: parsed.timeRange.startMs,
+              endMs: parsed.timeRange.endMs,
+            }).asyncAndThen((timeRange) =>
+              deps.transcriptStreamRepository
+                .findBySessionId(sessionIdentifier)
+                .andThen((stream) =>
+                  finalizeSegment(stream, {
+                    segmentIdentifier,
+                    text: parsed.text,
+                    timeRange,
+                  }),
+                )
+                .andThen((finalizedStream): ResultAsync<TranscriptStream, DomainError> => {
+                  if (parsed.translation?.status === 'completed') {
+                    return attachTranslationToSegment(finalizedStream, {
+                      translationIdentifier: deps.translationIdFactory(),
+                      segmentIdentifier,
+                      targetLanguage: parsed.translation.targetLanguage,
+                      text: parsed.translation.text,
+                    }).asyncMap((stream) => Promise.resolve(stream));
+                  }
+                  return okAsync(finalizedStream);
+                })
+                .andThen((streamAfterTranslation) => {
+                  const segment = streamAfterTranslation.segments.get(segmentIdentifier);
+                  if (segment === undefined) {
+                    return okAsync({ stream: streamAfterTranslation, segment: null });
+                  }
+                  return deps.transcriptStreamRepository
+                    .appendFinal(sessionIdentifier, segment)
+                    .andThen(() => {
+                      const translation =
+                        streamAfterTranslation.translations.get(segmentIdentifier);
+                      if (translation === undefined) {
+                        return okAsync({ stream: streamAfterTranslation, segment });
+                      }
+                      return deps.transcriptStreamRepository
+                        .appendTranslation(sessionIdentifier, translation)
+                        .map(() => ({ stream: streamAfterTranslation, segment }));
+                    });
+                })
+                .andThen(({ stream, segment }) =>
+                  resolveOverlaySettings(deps.settingsStore).map((settings) => {
+                    const renderModel = projectOverlayRenderModel({ stream, settings });
+                    void deps.overlayPresenter
+                      .render(renderModel)
+                      .match(() => undefined, logWarn('overlayPresenter.render'));
+                    if (segment !== null) {
+                      void deps.sessionStore
+                        .appendTranscript(sessionIdentifier, segment)
+                        .match(() => undefined, logWarn('sessionStore.appendTranscript'));
+                      const translation = stream.translations.get(segmentIdentifier);
+                      if (translation !== undefined) {
+                        void deps.sessionStore
+                          .appendTranslation(sessionIdentifier, translation)
+                          .match(() => undefined, logWarn('sessionStore.appendTranslation'));
+                      }
+                    }
+                    const output: HandleTranscriptFinalOutput = {
+                      sessionId: sessionIdentifier,
+                      segmentId: segmentIdentifier,
+                      translationStatus: determineTranslationStatus(parsed.translation),
+                      renderModel,
+                    };
+                    return output;
+                  }),
+                ),
+            ),
+          ),
+        ),
+      )
+      .mapErr(toApplicationError);
+};

--- a/packages/extension/src/application/use-cases/handle-transcript-partial-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/handle-transcript-partial-use-case.test.ts
@@ -1,0 +1,199 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createOverlaySettings } from '../../domain/profile/overlay-settings';
+import { type TranscriptStreamRepository } from '../../domain/repositories/transcript-stream-repository';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import {
+  invariantViolationError,
+  notFoundError,
+  type DomainError,
+} from '../../domain/shared/errors';
+import {
+  createTranscriptStream,
+  type TranscriptStream,
+} from '../../domain/transcript/transcript-stream';
+import { type OverlayPresenter } from '../ports/overlay-presenter';
+import { type SessionStore } from '../ports/session-store';
+import { type SettingsStore } from '../ports/settings-store';
+import {
+  createHandleTranscriptPartialUseCase,
+  type HandleTranscriptPartialDependencies,
+} from './handle-transcript-partial-use-case';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+
+const buildStream = (): TranscriptStream =>
+  createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+
+const overlaySettings = createOverlaySettings({
+  positionPreset: 'bottom',
+  opacity: 0.8,
+  maxLines: 2,
+  fontScale: 1,
+  showOriginalText: true,
+  showTranslatedText: true,
+})._unsafeUnwrap();
+
+const buildDependencies = (
+  overrides: Partial<HandleTranscriptPartialDependencies> = {},
+): HandleTranscriptPartialDependencies => {
+  const transcriptStreamRepository: TranscriptStreamRepository = {
+    findBySessionId: vi.fn(() => okAsync(buildStream())),
+    appendPartial: vi.fn(() => okAsync(undefined)),
+    appendFinal: vi.fn(() => okAsync(undefined)),
+    appendTranslation: vi.fn(() => okAsync(undefined)),
+  };
+  const overlayPresenter: OverlayPresenter = {
+    mount: vi.fn(() => okAsync(undefined)),
+    render: vi.fn(() => okAsync(undefined)),
+    updateSettings: vi.fn(() => okAsync(undefined)),
+    unmount: vi.fn(() => okAsync(undefined)),
+  };
+  const sessionStore: SessionStore = {
+    saveSession: vi.fn(() => okAsync(undefined)),
+    appendTranscript: vi.fn(() => okAsync(undefined)),
+    appendTranslation: vi.fn(() => okAsync(undefined)),
+    loadExportBundle: vi.fn(() =>
+      errAsync<never, DomainError>(
+        notFoundError({ resourceType: 'SourceSession', identifier: 'unused' }),
+      ),
+    ),
+  };
+  const defaultLanguagePair = createLanguagePair({
+    source: 'en-US',
+    target: 'ja-JP',
+  })._unsafeUnwrap();
+  const getDefaultLanguagePair: SettingsStore['getDefaultLanguagePair'] = () =>
+    okAsync(defaultLanguagePair);
+  const settingsStore: SettingsStore = {
+    getDefaultLanguagePair: vi.fn(getDefaultLanguagePair),
+    saveDefaultLanguagePair: vi.fn(() => okAsync(undefined)),
+    getDefaultOverlaySettings: vi.fn(() => okAsync(overlaySettings)),
+    saveDefaultOverlaySettings: vi.fn(() => okAsync(undefined)),
+  };
+  return {
+    transcriptStreamRepository,
+    overlayPresenter,
+    sessionStore,
+    settingsStore,
+    ...overrides,
+  };
+};
+
+describe('createHandleTranscriptPartialUseCase (IMPL-213, DD-304)', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* silence */
+    });
+  });
+
+  it('appends partial segment and renders overlay', async () => {
+    const deps = buildDependencies();
+    const useCase = createHandleTranscriptPartialUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      revision: 1,
+      text: 'hello',
+      timeRange: { startMs: 0, endMs: 1000 },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessionId).toBe(SESSION_ID);
+      expect(result.value.segmentId).toBe(SEGMENT_ID);
+      expect(result.value.revision).toBe(1);
+      expect(result.value.renderModel.lines.length).toBeGreaterThan(0);
+    }
+    expect(deps.transcriptStreamRepository.appendPartial).toHaveBeenCalledTimes(1);
+    expect(deps.overlayPresenter.render).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns validation error on empty text', async () => {
+    const deps = buildDependencies();
+    const useCase = createHandleTranscriptPartialUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      revision: 1,
+      text: '',
+      timeRange: { startMs: 0, endMs: 1000 },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('validation');
+  });
+
+  it('returns session-not-found when stream repository reports missing session', async () => {
+    const deps = buildDependencies({
+      transcriptStreamRepository: {
+        findBySessionId: vi.fn(() =>
+          errAsync<TranscriptStream, DomainError>(
+            notFoundError({ resourceType: 'TranscriptStream', identifier: SESSION_ID }),
+          ),
+        ),
+        appendPartial: vi.fn(() => okAsync(undefined)),
+        appendFinal: vi.fn(() => okAsync(undefined)),
+        appendTranslation: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const useCase = createHandleTranscriptPartialUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      revision: 1,
+      text: 'hello',
+      timeRange: { startMs: 0, endMs: 1000 },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('session-not-found');
+  });
+
+  it('still succeeds when overlayPresenter.render fails (hot-path not rolled back)', async () => {
+    const deps = buildDependencies({
+      overlayPresenter: {
+        mount: vi.fn(() => okAsync(undefined)),
+        render: vi.fn(() =>
+          errAsync<void, DomainError>(
+            invariantViolationError({ invariant: 'render-failed', details: 'dom' }),
+          ),
+        ),
+        updateSettings: vi.fn(() => okAsync(undefined)),
+        unmount: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const useCase = createHandleTranscriptPartialUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      revision: 1,
+      text: 'hello',
+      timeRange: { startMs: 0, endMs: 1000 },
+    });
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('propagates appendPartial error as conflict', async () => {
+    const deps = buildDependencies({
+      transcriptStreamRepository: {
+        findBySessionId: vi.fn(() => okAsync(buildStream())),
+        appendPartial: vi.fn(() =>
+          errAsync<void, DomainError>(
+            invariantViolationError({ invariant: 'storage-write-failed', details: 'quota' }),
+          ),
+        ),
+        appendFinal: vi.fn(() => okAsync(undefined)),
+        appendTranslation: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const useCase = createHandleTranscriptPartialUseCase(deps);
+    const result = await useCase({
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      revision: 1,
+      text: 'hello',
+      timeRange: { startMs: 0, endMs: 1000 },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('conflict');
+  });
+});

--- a/packages/extension/src/application/use-cases/handle-transcript-partial-use-case.ts
+++ b/packages/extension/src/application/use-cases/handle-transcript-partial-use-case.ts
@@ -1,0 +1,124 @@
+import { okAsync, type ResultAsync } from 'neverthrow';
+import { createOverlaySettings, type OverlaySettings } from '../../domain/profile/overlay-settings';
+import { type TranscriptStreamRepository } from '../../domain/repositories/transcript-stream-repository';
+import { parseSegmentIdentifier } from '../../domain/transcript/segment-identifier';
+import { createTimestampRange } from '../../domain/transcript/timestamp-range';
+import { appendPartialTranscriptSegment } from '../../domain/transcript/transcript-stream';
+import { parseSessionIdentifier } from '../../domain/session/session-identifier';
+import { describeDomainError, type DomainError } from '../../domain/shared/errors';
+import {
+  parseHandleTranscriptPartialInput,
+  type HandleTranscriptPartialInput,
+  type HandleTranscriptPartialOutput,
+} from '../dto/handle-transcript-partial-dto';
+import { toApplicationError, type ApplicationError } from '../errors/application-errors';
+import { type OverlayPresenter } from '../ports/overlay-presenter';
+import { type SessionStore } from '../ports/session-store';
+import { type SettingsStore } from '../ports/settings-store';
+import { projectOverlayRenderModel } from './overlay-render-projector';
+
+export type HandleTranscriptPartialDependencies = Readonly<{
+  transcriptStreamRepository: TranscriptStreamRepository;
+  overlayPresenter: OverlayPresenter;
+  sessionStore: SessionStore;
+  settingsStore: SettingsStore;
+}>;
+
+export type HandleTranscriptPartialUseCase = (
+  input: HandleTranscriptPartialInput,
+) => ResultAsync<HandleTranscriptPartialOutput, ApplicationError>;
+
+const logWarn = (scope: string) => (error: DomainError) => {
+  console.warn(`[use-case:handle-transcript-partial] ${scope} failed:`, describeDomainError(error));
+};
+
+/**
+ * 設定ストアから overlay 設定を取得。not-found や失敗時は sensible default に
+ * フォールバックする (ホットパスで stuck しない)。
+ */
+const resolveOverlaySettings = (
+  settingsStore: SettingsStore,
+): ResultAsync<OverlaySettings, DomainError> =>
+  settingsStore.getDefaultOverlaySettings().orElse(() => {
+    const fallback = createOverlaySettings({
+      positionPreset: 'bottom',
+      opacity: 0.8,
+      maxLines: 2,
+      fontScale: 1,
+      showOriginalText: true,
+      showTranslatedText: true,
+    });
+    return fallback.isOk() ? okAsync(fallback.value) : okAsync(fallback._unsafeUnwrap());
+  });
+
+/**
+ * IMPL-213 HandleTranscriptPartialUseCase (DD-304)。
+ * ホットパス: Relay `transcript.partial` 受信 → domain update → storage append
+ * (hot) → overlay render → session store 永続化 (fire-and-forget)。
+ *
+ * 結果整合性: `overlayPresenter.render` の Err は WARN ログに留め、UseCase
+ * 自体は成功を返す (use-case.md §6.2)。`sessionStore.appendTranscript` は
+ * fire-and-forget で発火。
+ */
+export const createHandleTranscriptPartialUseCase = (
+  deps: HandleTranscriptPartialDependencies,
+): HandleTranscriptPartialUseCase => {
+  return (input) =>
+    parseHandleTranscriptPartialInput(input)
+      .asyncAndThen((parsed) =>
+        parseSessionIdentifier(parsed.sessionId).asyncAndThen((sessionIdentifier) =>
+          parseSegmentIdentifier(parsed.segmentId).asyncAndThen((segmentIdentifier) =>
+            createTimestampRange({
+              startMs: parsed.timeRange.startMs,
+              endMs: parsed.timeRange.endMs,
+            }).asyncAndThen((timeRange) =>
+              deps.transcriptStreamRepository
+                .findBySessionId(sessionIdentifier)
+                .andThen((stream) =>
+                  appendPartialTranscriptSegment(stream, {
+                    segmentIdentifier,
+                    revision: parsed.revision,
+                    text: parsed.text,
+                    timeRange,
+                  }),
+                )
+                .andThen((updatedStream) => {
+                  const segment = updatedStream.segments.get(segmentIdentifier);
+                  if (segment === undefined) {
+                    return okAsync({ updatedStream, segment: null });
+                  }
+                  return deps.transcriptStreamRepository
+                    .appendPartial(sessionIdentifier, segment)
+                    .map(() => ({ updatedStream, segment }));
+                })
+                .andThen(({ updatedStream, segment }) =>
+                  resolveOverlaySettings(deps.settingsStore).map((settings) => {
+                    const renderModel = projectOverlayRenderModel({
+                      stream: updatedStream,
+                      settings,
+                    });
+                    // render failure is swallowed (hot-path not rolled back)
+                    void deps.overlayPresenter
+                      .render(renderModel)
+                      .match(() => undefined, logWarn('overlayPresenter.render'));
+                    // persistence is fire-and-forget (結果整合性)
+                    if (segment !== null) {
+                      void deps.sessionStore
+                        .appendTranscript(sessionIdentifier, segment)
+                        .match(() => undefined, logWarn('sessionStore.appendTranscript'));
+                    }
+                    const output: HandleTranscriptPartialOutput = {
+                      sessionId: sessionIdentifier,
+                      segmentId: segmentIdentifier,
+                      revision: parsed.revision,
+                      renderModel,
+                    };
+                    return output;
+                  }),
+                ),
+            ),
+          ),
+        ),
+      )
+      .mapErr(toApplicationError);
+};

--- a/packages/extension/src/application/use-cases/index.ts
+++ b/packages/extension/src/application/use-cases/index.ts
@@ -8,7 +8,22 @@ export {
   type GetSessionMonitorStateDependencies,
   type GetSessionMonitorStateQuery,
 } from './get-session-monitor-state-query';
+export {
+  createHandleTranscriptFinalUseCase,
+  type HandleTranscriptFinalDependencies,
+  type HandleTranscriptFinalUseCase,
+} from './handle-transcript-final-use-case';
+export {
+  createHandleTranscriptPartialUseCase,
+  type HandleTranscriptPartialDependencies,
+  type HandleTranscriptPartialUseCase,
+} from './handle-transcript-partial-use-case';
 export { projectOverlayRenderModel } from './overlay-render-projector';
+export {
+  createStartSourceSessionUseCase,
+  type StartSourceSessionDependencies,
+  type StartSourceSessionUseCase,
+} from './start-source-session-use-case';
 export {
   createStopSourceSessionUseCase,
   type StopSourceSessionDependencies,

--- a/packages/extension/src/application/use-cases/start-source-session-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/start-source-session-use-case.test.ts
@@ -1,0 +1,253 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ExtensionProfileRepository } from '../../domain/repositories/extension-profile-repository';
+import { type SourceSessionRepository } from '../../domain/repositories/source-session-repository';
+import {
+  createExtensionProfile,
+  type ExtensionProfile,
+} from '../../domain/profile/extension-profile';
+import { createOverlaySettings } from '../../domain/profile/overlay-settings';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import { createSourceSession, type SourceSession } from '../../domain/session/source-session';
+import {
+  invariantViolationError,
+  notFoundError,
+  type DomainError,
+} from '../../domain/shared/errors';
+import { type PermissionCoordinator } from '../ports/permission-coordinator';
+import { type RelayGateway } from '../ports/relay-gateway';
+import {
+  createStartSourceSessionUseCase,
+  type StartSourceSessionDependencies,
+} from './start-source-session-use-case';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const PROFILE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
+const STARTED_AT = '2026-04-21T00:00:00.000Z';
+
+const buildProfile = (): ExtensionProfile =>
+  createExtensionProfile({
+    profileIdentifier: PROFILE_ID,
+    defaultLanguagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    defaultOverlaySettings: createOverlaySettings({
+      positionPreset: 'bottom',
+      opacity: 0.8,
+      maxLines: 2,
+      fontScale: 1,
+      showOriginalText: true,
+      showTranslatedText: true,
+    })._unsafeUnwrap(),
+    autoDetectEnabled: false,
+  })._unsafeUnwrap();
+
+const buildDependencies = (
+  overrides: Partial<StartSourceSessionDependencies> = {},
+): StartSourceSessionDependencies => {
+  const sourceSessionRepository: SourceSessionRepository = {
+    findById: vi.fn(() => okAsync(buildSessionIdle())),
+    findActiveSessions: vi.fn(() => okAsync([])),
+    save: vi.fn(() => okAsync(undefined)),
+  };
+  const extensionProfileRepository: ExtensionProfileRepository = {
+    getDefault: vi.fn(() => okAsync(buildProfile())),
+    save: vi.fn(() => okAsync(undefined)),
+  };
+  const relayGateway: RelayGateway = {
+    openSession: vi.fn(() => okAsync(undefined)),
+    sendAudioFrame: vi.fn(() => okAsync(undefined)),
+    closeSession: vi.fn(() => okAsync(undefined)),
+    subscribe: vi.fn(() => () => {
+      /* noop */
+    }),
+  };
+  const grantingRequestFor: PermissionCoordinator['requestFor'] = (sourceType) =>
+    okAsync({ status: 'granted', sourceType });
+  const permissionCoordinator: PermissionCoordinator = {
+    requestFor: vi.fn(grantingRequestFor),
+  };
+  return {
+    sourceSessionRepository,
+    extensionProfileRepository,
+    relayGateway,
+    permissionCoordinator,
+    clock: () => STARTED_AT,
+    idFactory: {
+      session: () => SESSION_ID,
+      source: () => SOURCE_ID,
+    },
+    ...overrides,
+  };
+};
+
+const buildSessionIdle = (
+  sessionId: string = SESSION_ID,
+  sourceId: string = SOURCE_ID,
+): SourceSession =>
+  createSourceSession({
+    sessionIdentifier: sessionId,
+    sourceIdentifier: sourceId,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt: STARTED_AT,
+  })._unsafeUnwrap();
+
+describe('createStartSourceSessionUseCase (IMPL-210, DD-301)', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* silence */
+    });
+  });
+
+  it('starts a session and transitions to connecting on granted permission', async () => {
+    const deps = buildDependencies();
+    const useCase = createStartSourceSessionUseCase(deps);
+    const result = await useCase({
+      sourceType: 'tab',
+      displayName: 'Example tab',
+      sourceLanguage: 'en-US',
+      autoDetectLanguage: false,
+      targetLanguage: 'ja-JP',
+      overlayTarget: { kind: 'tab', tabId: 1 },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessionId).toBe(SESSION_ID);
+      expect(result.value.state).toBe('connecting');
+      expect(result.value.startedAt).toBe(STARTED_AT);
+    }
+    expect(deps.sourceSessionRepository.save).toHaveBeenCalledTimes(2);
+    expect(deps.relayGateway.openSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when concurrent session limit is reached', async () => {
+    const existing = [
+      buildSessionIdle(),
+      buildSessionIdle('01HZX8Y1R8M7D3Q2P4T5V6W7A2', '01HZX8Y1R8M7D3Q2P4T5V6W7B2'),
+      buildSessionIdle('01HZX8Y1R8M7D3Q2P4T5V6W7A3', '01HZX8Y1R8M7D3Q2P4T5V6W7B3'),
+    ];
+    const deps = buildDependencies({
+      sourceSessionRepository: {
+        findById: vi.fn(() => okAsync(buildSessionIdle())),
+        findActiveSessions: vi.fn(() => okAsync(existing)),
+        save: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const useCase = createStartSourceSessionUseCase(deps);
+    const result = await useCase({
+      sourceType: 'tab',
+      displayName: 'over limit',
+      autoDetectLanguage: false,
+      targetLanguage: 'ja-JP',
+      overlayTarget: { kind: 'tab' },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('conflict');
+  });
+
+  it('returns permission-required when user denies capture', async () => {
+    const denyingRequestFor: PermissionCoordinator['requestFor'] = (sourceType) =>
+      okAsync({ status: 'denied', sourceType, reason: 'user-dismissed' });
+    const deps = buildDependencies({
+      permissionCoordinator: {
+        requestFor: vi.fn(denyingRequestFor),
+      },
+    });
+    const useCase = createStartSourceSessionUseCase(deps);
+    const result = await useCase({
+      sourceType: 'microphone',
+      displayName: 'mic',
+      autoDetectLanguage: false,
+      targetLanguage: 'ja-JP',
+      overlayTarget: { kind: 'extension-monitor' },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe('permission-required');
+      if (result.error.type === 'permission-required') {
+        expect(result.error.sourceType).toBe('microphone');
+      }
+    }
+    // Session is persisted in error state before returning permission-required
+    expect(deps.sourceSessionRepository.save).toHaveBeenCalledTimes(2);
+    expect(deps.relayGateway.openSession).not.toHaveBeenCalled();
+  });
+
+  it('falls back to profile defaults when sourceLanguage is null', async () => {
+    const deps = buildDependencies();
+    const useCase = createStartSourceSessionUseCase(deps);
+    const result = await useCase({
+      sourceType: 'tab',
+      displayName: 'auto',
+      sourceLanguage: null,
+      autoDetectLanguage: true,
+      targetLanguage: 'ja-JP',
+      overlayTarget: { kind: 'tab' },
+    });
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('returns validation error when input is malformed', async () => {
+    const deps = buildDependencies();
+    const useCase = createStartSourceSessionUseCase(deps);
+    const result = await useCase({
+      sourceType: 'tab',
+      displayName: '',
+      autoDetectLanguage: false,
+      targetLanguage: 'ja-JP',
+      overlayTarget: { kind: 'tab' },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('validation');
+  });
+
+  it('returns session-not-found when extension profile is missing', async () => {
+    const deps = buildDependencies({
+      extensionProfileRepository: {
+        getDefault: vi.fn(() =>
+          errAsync<ExtensionProfile, DomainError>(
+            notFoundError({ resourceType: 'ExtensionProfile', identifier: 'default' }),
+          ),
+        ),
+        save: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    const useCase = createStartSourceSessionUseCase(deps);
+    const result = await useCase({
+      sourceType: 'tab',
+      displayName: 'tab',
+      autoDetectLanguage: false,
+      targetLanguage: 'ja-JP',
+      overlayTarget: { kind: 'tab' },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('session-not-found');
+  });
+
+  it('propagates relay handshake failure as conflict', async () => {
+    const deps = buildDependencies({
+      relayGateway: {
+        openSession: vi.fn(() =>
+          errAsync<void, DomainError>(
+            invariantViolationError({ invariant: 'relay-handshake-failed', details: 'x' }),
+          ),
+        ),
+        sendAudioFrame: vi.fn(() => okAsync(undefined)),
+        closeSession: vi.fn(() => okAsync(undefined)),
+        subscribe: vi.fn(() => () => {
+          /* noop */
+        }),
+      },
+    });
+    const useCase = createStartSourceSessionUseCase(deps);
+    const result = await useCase({
+      sourceType: 'tab',
+      displayName: 'tab',
+      autoDetectLanguage: false,
+      targetLanguage: 'ja-JP',
+      overlayTarget: { kind: 'tab' },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('conflict');
+  });
+});

--- a/packages/extension/src/application/use-cases/start-source-session-use-case.ts
+++ b/packages/extension/src/application/use-cases/start-source-session-use-case.ts
@@ -1,0 +1,140 @@
+import { errAsync, ResultAsync } from 'neverthrow';
+import { type ExtensionProfileRepository } from '../../domain/repositories/extension-profile-repository';
+import { type SourceSessionRepository } from '../../domain/repositories/source-session-repository';
+import { validateSessionConcurrency } from '../../domain/services/session-concurrency-policy';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import {
+  createSourceSession,
+  startSourceSession,
+  transitionSourceSessionState,
+  type SourceSession,
+} from '../../domain/session/source-session';
+import { type DomainError } from '../../domain/shared/errors';
+import {
+  parseStartSourceSessionInput,
+  type StartSourceSessionInput,
+  type StartSourceSessionOutput,
+} from '../dto/start-source-session-dto';
+import {
+  permissionRequiredAppError,
+  toApplicationError,
+  type ApplicationError,
+} from '../errors/application-errors';
+import { type PermissionCoordinator } from '../ports/permission-coordinator';
+import { type RelayGateway } from '../ports/relay-gateway';
+
+export type StartSourceSessionDependencies = Readonly<{
+  sourceSessionRepository: SourceSessionRepository;
+  extensionProfileRepository: ExtensionProfileRepository;
+  relayGateway: RelayGateway;
+  permissionCoordinator: PermissionCoordinator;
+  clock: () => string;
+  idFactory: Readonly<{
+    session: () => string;
+    source: () => string;
+  }>;
+}>;
+
+export type StartSourceSessionUseCase = (
+  input: StartSourceSessionInput,
+) => ResultAsync<StartSourceSessionOutput, ApplicationError>;
+
+type ChainError = DomainError | ApplicationError;
+
+/**
+ * DomainError | ApplicationError のどちらが来ても ApplicationError に変換する。
+ * ApplicationError はそのまま通し、DomainError は `toApplicationError` で変換。
+ */
+const normalizeChainError = (error: ChainError): ApplicationError => {
+  if ('type' in error) return error;
+  return toApplicationError(error);
+};
+
+/**
+ * IMPL-210 StartSourceSessionUseCase (DD-301)。
+ *
+ * シーケンス:
+ * 1. `findActiveSessions` + `validateSessionConcurrency` (上限 3 未満)
+ * 2. `extensionProfileRepository.getDefault` で default 言語ペア取得
+ * 3. `createLanguagePair` で有効言語決定 (input 優先、fallback profile.default)
+ * 4. `createSourceSession` → `startSourceSession` (idle → requesting_permission)
+ * 5. `save` (1st: requesting_permission state)
+ * 6. `permissionCoordinator.requestFor` → granted / denied 分岐
+ *    - granted: `transitionSourceSessionState('connecting')` → `relayGateway.openSession` → `save` (2nd)
+ *    - denied: `transitionSourceSessionState('error')` → `save` (2nd) → errAsync(permissionRequiredAppError)
+ * 7. 出力 DTO: `{ sessionId, state, startedAt }`
+ */
+export const createStartSourceSessionUseCase = (
+  deps: StartSourceSessionDependencies,
+): StartSourceSessionUseCase => {
+  return (input) => {
+    const resultChain: ResultAsync<SourceSession, ChainError> = parseStartSourceSessionInput(
+      input,
+    ).asyncAndThen((parsed) =>
+      deps.sourceSessionRepository.findActiveSessions().andThen((active) =>
+        validateSessionConcurrency(active).asyncAndThen(() =>
+          deps.extensionProfileRepository.getDefault().andThen((profile) => {
+            const sourceLang = parsed.sourceLanguage ?? profile.defaultLanguagePair.source;
+            return createLanguagePair({
+              source: sourceLang,
+              target: parsed.targetLanguage,
+            })
+              .andThen((languagePair) =>
+                createSourceSession({
+                  sessionIdentifier: deps.idFactory.session(),
+                  sourceIdentifier: deps.idFactory.source(),
+                  sourceType: parsed.sourceType,
+                  languagePair,
+                  startedAt: deps.clock(),
+                }),
+              )
+              .andThen((idleSession) => startSourceSession(idleSession))
+              .asyncAndThen((requesting) =>
+                deps.sourceSessionRepository.save(requesting).map(() => requesting),
+              )
+              .andThen(
+                (savedSession): ResultAsync<SourceSession, ChainError> =>
+                  deps.permissionCoordinator
+                    .requestFor(parsed.sourceType)
+                    .andThen((grant): ResultAsync<SourceSession, ChainError> => {
+                      if (grant.status === 'granted') {
+                        return transitionSourceSessionState(
+                          savedSession,
+                          'connecting',
+                        ).asyncAndThen((connecting) =>
+                          deps.relayGateway
+                            .openSession(connecting)
+                            .andThen(() =>
+                              deps.sourceSessionRepository.save(connecting).map(() => connecting),
+                            ),
+                        );
+                      }
+                      return transitionSourceSessionState(savedSession, 'error').asyncAndThen(
+                        (errorSession) =>
+                          deps.sourceSessionRepository.save(errorSession).andThen(() =>
+                            errAsync<SourceSession, ChainError>(
+                              permissionRequiredAppError({
+                                sourceType: grant.sourceType,
+                                message:
+                                  grant.reason ?? `permission denied for ${grant.sourceType}`,
+                              }),
+                            ),
+                          ),
+                      );
+                    }),
+              );
+          }),
+        ),
+      ),
+    );
+    return resultChain
+      .map(
+        (session): StartSourceSessionOutput => ({
+          sessionId: session.sessionIdentifier,
+          state: session.state,
+          startedAt: session.startedAt,
+        }),
+      )
+      .mapErr(normalizeChainError);
+  };
+};


### PR DESCRIPTION
## Summary

Phase 2 §4.2 UseCase 7 種の最後の 3 種を実装し、**Phase 2 application 層を完成**。ホットパス 2 種 + 最複雑 (permission 分岐) を含む。

- **IMPL-213 HandleTranscriptPartialUseCase** (DD-304) — ホットパス: 部分字幕 → appendPartial → overlay render → sessionStore fire-and-forget
- **IMPL-214 HandleTranscriptFinalUseCase** (DD-305) — 確定字幕 + optional translation attach、translationStatus: completed/failed/pending
- **IMPL-210 StartSourceSessionUseCase** (DD-301) — 同時 3 session 上限 + profile 取得 + permission granted/denied 分岐

### 設計判断

- `resolveOverlaySettings` helper で settingsStore not-found 時に sensible default fallback (ホットパス stuck 防止)
- **ChainError union** (`DomainError | ApplicationError`) + `normalizeChainError` で StartSourceSession の permission-denied を末尾 1 回の変換で処理
- fire-and-forget: `void xxx.match(noop, logWarn)` で no-floating-promises クリア
- vi.fn 型推論回避: `const fn: T['method'] = ...; vi.fn(fn)` パターン

## Test plan

- [x] 463 tests pass (+18 新規: Partial 5 + Final 6 + Start 7)
- [x] `pnpm check` 全緑
- [ ] CI `All Green` → auto merge

## Phase 2 完了

本 PR merge で application 層 (IMPL-200〜230) が完了。次は Phase 3 infrastructure 層 (IMPL-300 系)。