### PR TITLE
feat(infrastructure): IMPL-310/311/312 Storage (IndexedDB + chrome.storage.local + Data Mapper)

### DIFF
--- a/packages/extension/src/infrastructure/storage/chrome-local-settings-store.test.ts
+++ b/packages/extension/src/infrastructure/storage/chrome-local-settings-store.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createOverlaySettings } from '../../domain/profile/overlay-settings';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import {
+  createChromeLocalSettingsStore,
+  type ChromeStorageAdapter,
+} from './chrome-local-settings-store';
+
+const LANGUAGE_KEY = 'settings.language.defaultLanguagePair';
+const OVERLAY_KEY = 'settings.overlay.defaultOverlaySettings';
+
+type MockAdapter = ChromeStorageAdapter & {
+  get: ReturnType<typeof vi.fn<ChromeStorageAdapter['get']>>;
+  set: ReturnType<typeof vi.fn<ChromeStorageAdapter['set']>>;
+};
+
+const buildAdapter = (): MockAdapter => {
+  const get = vi.fn<ChromeStorageAdapter['get']>(() => Promise.resolve({}));
+  const set = vi.fn<ChromeStorageAdapter['set']>(() => Promise.resolve());
+  return { get, set };
+};
+
+describe('createChromeLocalSettingsStore (IMPL-311, DD-107 / DB-005)', () => {
+  let adapter: MockAdapter;
+
+  beforeEach(() => {
+    adapter = buildAdapter();
+  });
+
+  describe('getDefaultLanguagePair', () => {
+    it('returns LanguagePair when valid row exists', async () => {
+      adapter.get.mockResolvedValue({
+        [LANGUAGE_KEY]: { source: 'en-US', target: 'ja-JP' },
+      });
+      const store = createChromeLocalSettingsStore(adapter);
+      const result = await store.getDefaultLanguagePair();
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.source).toBe('en-US');
+        expect(result.value.target).toBe('ja-JP');
+      }
+    });
+
+    it('returns notFoundError when key is missing', async () => {
+      adapter.get.mockResolvedValue({});
+      const store = createChromeLocalSettingsStore(adapter);
+      const result = await store.getDefaultLanguagePair();
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('not-found');
+    });
+
+    it('returns validation error when stored value is malformed', async () => {
+      adapter.get.mockResolvedValue({
+        [LANGUAGE_KEY]: { source: 'ja-JP', target: 'ja-JP' },
+      });
+      const store = createChromeLocalSettingsStore(adapter);
+      const result = await store.getDefaultLanguagePair();
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('validation');
+    });
+
+    it('returns invariant-violation when chrome.storage rejects', async () => {
+      adapter.get.mockRejectedValue(new Error('quota exceeded'));
+      const store = createChromeLocalSettingsStore(adapter);
+      const result = await store.getDefaultLanguagePair();
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    });
+  });
+
+  describe('saveDefaultLanguagePair', () => {
+    it('writes a primitive payload and resolves ok', async () => {
+      const store = createChromeLocalSettingsStore(adapter);
+      const pair = createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap();
+      const result = await store.saveDefaultLanguagePair(pair);
+      expect(result.isOk()).toBe(true);
+      expect(adapter.set).toHaveBeenCalledWith({
+        [LANGUAGE_KEY]: { source: 'en-US', target: 'ja-JP' },
+      });
+    });
+
+    it('returns invariant-violation when storage write fails', async () => {
+      adapter.set.mockRejectedValue(new Error('quota exceeded'));
+      const store = createChromeLocalSettingsStore(adapter);
+      const pair = createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap();
+      const result = await store.saveDefaultLanguagePair(pair);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    });
+  });
+
+  describe('getDefaultOverlaySettings', () => {
+    it('returns OverlaySettings when valid row exists', async () => {
+      adapter.get.mockResolvedValue({
+        [OVERLAY_KEY]: {
+          positionPreset: 'bottom',
+          opacity: 0.8,
+          maxLines: 3,
+          fontScale: 1.2,
+          showOriginalText: true,
+          showTranslatedText: false,
+        },
+      });
+      const store = createChromeLocalSettingsStore(adapter);
+      const result = await store.getDefaultOverlaySettings();
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.opacity).toBe(0.8);
+        expect(result.value.maxLines).toBe(3);
+      }
+    });
+
+    it('returns notFoundError when key is missing', async () => {
+      adapter.get.mockResolvedValue({});
+      const store = createChromeLocalSettingsStore(adapter);
+      const result = await store.getDefaultOverlaySettings();
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('not-found');
+    });
+
+    it('returns validation error when stored value violates OverlaySettings schema', async () => {
+      adapter.get.mockResolvedValue({
+        [OVERLAY_KEY]: {
+          positionPreset: 'bottom',
+          opacity: 1.5,
+          maxLines: 2,
+          fontScale: 1,
+          showOriginalText: true,
+          showTranslatedText: true,
+        },
+      });
+      const store = createChromeLocalSettingsStore(adapter);
+      const result = await store.getDefaultOverlaySettings();
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('validation');
+    });
+  });
+
+  describe('saveDefaultOverlaySettings', () => {
+    it('writes a primitive payload and resolves ok', async () => {
+      const store = createChromeLocalSettingsStore(adapter);
+      const settings = createOverlaySettings({
+        positionPreset: 'bottom',
+        opacity: 0.8,
+        maxLines: 2,
+        fontScale: 1,
+        showOriginalText: true,
+        showTranslatedText: true,
+      })._unsafeUnwrap();
+      const result = await store.saveDefaultOverlaySettings(settings);
+      expect(result.isOk()).toBe(true);
+      const lastCall = adapter.set.mock.calls[0]?.[0];
+      expect(lastCall).toHaveProperty(OVERLAY_KEY);
+    });
+  });
+});

--- a/packages/extension/src/infrastructure/storage/chrome-local-settings-store.ts
+++ b/packages/extension/src/infrastructure/storage/chrome-local-settings-store.ts
@@ -1,0 +1,106 @@
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+import { createOverlaySettings, type OverlaySettings } from '../../domain/profile/overlay-settings';
+import { createLanguagePair, type LanguagePair } from '../../domain/session/language-pair';
+import {
+  describeDomainError,
+  invariantViolationError,
+  notFoundError,
+  type DomainError,
+} from '../../domain/shared/errors';
+import { type SettingsStore } from '../../application/ports/settings-store';
+
+const LANGUAGE_KEY = 'settings.language.defaultLanguagePair';
+const OVERLAY_KEY = 'settings.overlay.defaultOverlaySettings';
+
+/**
+ * chrome.storage.local の overload を隠蔽した最小 adapter。
+ * テストでは直接 mock 実装を注入できる。production では `chrome.storage.local`
+ * を呼ぶ default 実装を使う。
+ */
+export type ChromeStorageAdapter = Readonly<{
+  get: (keys: readonly string[]) => Promise<Record<string, unknown>>;
+  set: (items: Record<string, unknown>) => Promise<void>;
+}>;
+
+export const defaultChromeStorageAdapter: ChromeStorageAdapter = {
+  get: async (keys) => {
+    const items: Record<string, unknown> = await chrome.storage.local.get([...keys]);
+    return items;
+  },
+  set: async (items) => {
+    await chrome.storage.local.set(items);
+  },
+};
+
+const toPersistenceError =
+  (scope: string) =>
+  (cause: unknown): DomainError =>
+    invariantViolationError({
+      invariant: 'chrome-storage-access',
+      details: `${scope}: ${cause instanceof Error ? cause.message : 'unknown error'}`,
+    });
+
+const readRaw = (adapter: ChromeStorageAdapter, key: string): ResultAsync<unknown, DomainError> =>
+  ResultAsync.fromPromise(adapter.get([key]), toPersistenceError(`get ${key}`)).map(
+    (items) => items[key],
+  );
+
+const writeRaw = (
+  adapter: ChromeStorageAdapter,
+  key: string,
+  value: unknown,
+): ResultAsync<void, DomainError> =>
+  ResultAsync.fromPromise(adapter.set({ [key]: value }), toPersistenceError(`set ${key}`));
+
+/**
+ * IMPL-311 ChromeLocalSettingsStore (DD-107, DB-005)。
+ *
+ * `chrome.storage.local` に拡張の既定値を保存・復元する `SettingsStore`
+ * 実装。キーは階層的命名 (`settings.language.*` / `settings.overlay.*`)。
+ *
+ * エラー:
+ * - 未初期化 (`key === undefined`): `notFoundError`
+ * - Zod スキーマ違反: `validationError` (VO factory から propagate)
+ * - chrome.storage I/O 失敗: `invariantViolationError({ invariant:
+ *   'chrome-storage-access' })`
+ */
+export const createChromeLocalSettingsStore = (
+  adapter: ChromeStorageAdapter = defaultChromeStorageAdapter,
+): SettingsStore => {
+  return {
+    getDefaultLanguagePair: () =>
+      readRaw(adapter, LANGUAGE_KEY).andThen((raw): ResultAsync<LanguagePair, DomainError> => {
+        if (raw === undefined) {
+          return errAsync<LanguagePair, DomainError>(
+            notFoundError({ resourceType: 'LanguagePair', identifier: 'default' }),
+          );
+        }
+        return okAsync<unknown, DomainError>(raw).andThen((value) => createLanguagePair(value));
+      }),
+
+    saveDefaultLanguagePair: (pair) =>
+      writeRaw(adapter, LANGUAGE_KEY, { source: pair.source, target: pair.target }),
+
+    getDefaultOverlaySettings: () =>
+      readRaw(adapter, OVERLAY_KEY).andThen((raw): ResultAsync<OverlaySettings, DomainError> => {
+        if (raw === undefined) {
+          return errAsync<OverlaySettings, DomainError>(
+            notFoundError({ resourceType: 'OverlaySettings', identifier: 'default' }),
+          );
+        }
+        return okAsync<unknown, DomainError>(raw).andThen((value) => createOverlaySettings(value));
+      }),
+
+    saveDefaultOverlaySettings: (settings) =>
+      writeRaw(adapter, OVERLAY_KEY, {
+        positionPreset: settings.positionPreset,
+        opacity: settings.opacity,
+        maxLines: settings.maxLines,
+        fontScale: settings.fontScale,
+        showOriginalText: settings.showOriginalText,
+        showTranslatedText: settings.showTranslatedText,
+      }),
+  };
+};
+
+export { describeDomainError };

--- a/packages/extension/src/infrastructure/storage/index.ts
+++ b/packages/extension/src/infrastructure/storage/index.ts
@@ -1,0 +1,22 @@
+export { createChromeLocalSettingsStore, describeDomainError } from './chrome-local-settings-store';
+export {
+  createIndexedDbSessionStore,
+  INDEXED_DB_NAME,
+  INDEXED_DB_VERSION,
+  type CloseableSessionStore,
+  type IndexedDbSessionStoreOptions,
+} from './indexed-db-session-store';
+export {
+  exportRecordFromRecord,
+  exportRecordToRecord,
+  sessionFromRecord,
+  sessionToRecord,
+  transcriptSegmentFromRecord,
+  transcriptSegmentToRecord,
+  translationSegmentFromRecord,
+  translationSegmentToRecord,
+  type ExportRecordRow,
+  type SessionRow,
+  type TranscriptSegmentRow,
+  type TranslationSegmentRow,
+} from './records';

--- a/packages/extension/src/infrastructure/storage/indexed-db-session-store.test.ts
+++ b/packages/extension/src/infrastructure/storage/indexed-db-session-store.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import { createSourceSession } from '../../domain/session/source-session';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { createTimestampRange } from '../../domain/transcript/timestamp-range';
+import {
+  createPartialTranscriptSegment,
+  finalizeTranscriptSegment,
+} from '../../domain/transcript/transcript-segment';
+import {
+  createCompletedTranslationSegment,
+  createFailedTranslationSegment,
+} from '../../domain/transcript/translation-segment';
+import {
+  createIndexedDbSessionStore,
+  INDEXED_DB_NAME,
+  type CloseableSessionStore,
+} from './indexed-db-session-store';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const SEGMENT_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+const SEGMENT_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7D2';
+const TRANSLATION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7E1';
+
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const buildSession = () =>
+  createSourceSession({
+    sessionIdentifier: SESSION_ID,
+    sourceIdentifier: SOURCE_ID,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt: '2026-04-21T00:00:00.000Z',
+  })._unsafeUnwrap();
+
+const buildPartial = (segmentId: string) =>
+  createPartialTranscriptSegment({
+    segmentIdentifier: segmentId,
+    revision: 1,
+    text: 'hello',
+    timeRange: createTimestampRange({ startMs: 0, endMs: 1000 })._unsafeUnwrap(),
+  })._unsafeUnwrap();
+
+const buildCompletedTranslation = () =>
+  createCompletedTranslationSegment({
+    translationIdentifier: TRANSLATION_ID,
+    segmentIdentifier: SEGMENT_ID_1,
+    targetLanguage: 'ja-JP',
+    text: 'こんにちは',
+  })._unsafeUnwrap();
+
+describe('createIndexedDbSessionStore (IMPL-310, DD-106 / DB-001〜004)', () => {
+  let store: CloseableSessionStore;
+  let databaseName: string;
+
+  beforeEach(() => {
+    // 各テストで独立した in-memory DB を使って干渉を避ける
+    databaseName = `${INDEXED_DB_NAME}-test-${String(Math.random()).slice(2)}`;
+    store = createIndexedDbSessionStore({ databaseName });
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  describe('saveSession', () => {
+    it('persists and retrieves a session via loadExportBundle', async () => {
+      const store = createIndexedDbSessionStore();
+      const session = buildSession();
+      const saveResult = await store.saveSession(session);
+      expect(saveResult.isOk()).toBe(true);
+
+      const bundleResult = await store.loadExportBundle(sessionIdentifier);
+      expect(bundleResult.isOk()).toBe(true);
+      if (bundleResult.isOk()) {
+        expect(bundleResult.value.session.sessionIdentifier).toBe(SESSION_ID);
+        expect(bundleResult.value.stream.segments.size).toBe(0);
+        expect(bundleResult.value.stream.translations.size).toBe(0);
+      }
+    });
+  });
+
+  describe('appendTranscript', () => {
+    it('stores partial and finalized segments and returns them in the bundle', async () => {
+      await store.saveSession(buildSession());
+
+      const partial = buildPartial(SEGMENT_ID_1);
+      await store.appendTranscript(sessionIdentifier, partial);
+      const finalized = finalizeTranscriptSegment(partial, {})._unsafeUnwrap();
+      await store.appendTranscript(sessionIdentifier, finalized);
+      await store.appendTranscript(sessionIdentifier, buildPartial(SEGMENT_ID_2));
+
+      const bundleResult = await store.loadExportBundle(sessionIdentifier);
+      expect(bundleResult.isOk()).toBe(true);
+      if (bundleResult.isOk()) {
+        expect(bundleResult.value.stream.segments.size).toBe(2);
+        const finalSegment = bundleResult.value.stream.segments.get(SEGMENT_ID_1);
+        expect(finalSegment?.isFinal).toBe(true);
+      }
+    });
+  });
+
+  describe('appendTranslation', () => {
+    it('stores completed translations and returns them in the bundle', async () => {
+      await store.saveSession(buildSession());
+      await store.appendTranscript(sessionIdentifier, buildPartial(SEGMENT_ID_1));
+      await store.appendTranslation(sessionIdentifier, buildCompletedTranslation());
+
+      const bundleResult = await store.loadExportBundle(sessionIdentifier);
+      expect(bundleResult.isOk()).toBe(true);
+      if (bundleResult.isOk()) {
+        const translation = bundleResult.value.stream.translations.get(SEGMENT_ID_1);
+        expect(translation?.status).toBe('completed');
+        if (translation?.status === 'completed') {
+          expect(translation.text).toBe('こんにちは');
+        }
+      }
+    });
+
+    it('stores failed translations (empty text)', async () => {
+      await store.saveSession(buildSession());
+      const failed = createFailedTranslationSegment({
+        translationIdentifier: TRANSLATION_ID,
+        segmentIdentifier: SEGMENT_ID_1,
+        targetLanguage: 'ja-JP',
+      })._unsafeUnwrap();
+      await store.appendTranslation(sessionIdentifier, failed);
+
+      const bundleResult = await store.loadExportBundle(sessionIdentifier);
+      expect(bundleResult.isOk()).toBe(true);
+      if (bundleResult.isOk()) {
+        const translation = bundleResult.value.stream.translations.get(SEGMENT_ID_1);
+        expect(translation?.status).toBe('failed');
+      }
+    });
+  });
+
+  describe('loadExportBundle', () => {
+    it('returns notFoundError when session does not exist', async () => {
+      const result = await store.loadExportBundle(sessionIdentifier);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('not-found');
+    });
+
+    it('isolates segments per sessionId via the sessionId index', async () => {
+      const OTHER_SESSION = '01HZX8Y1R8M7D3Q2P4T5V6W7A9';
+      const otherSessionId = parseSessionIdentifier(OTHER_SESSION)._unsafeUnwrap();
+
+      await store.saveSession(buildSession());
+      await store.saveSession(
+        createSourceSession({
+          sessionIdentifier: OTHER_SESSION,
+          sourceIdentifier: '01HZX8Y1R8M7D3Q2P4T5V6W7B2',
+          sourceType: 'microphone',
+          languagePair: createLanguagePair({
+            source: 'en-US',
+            target: 'ja-JP',
+          })._unsafeUnwrap(),
+          startedAt: '2026-04-21T00:01:00.000Z',
+        })._unsafeUnwrap(),
+      );
+      await store.appendTranscript(sessionIdentifier, buildPartial(SEGMENT_ID_1));
+      await store.appendTranscript(otherSessionId, buildPartial(SEGMENT_ID_2));
+
+      const a = await store.loadExportBundle(sessionIdentifier);
+      const b = await store.loadExportBundle(otherSessionId);
+      expect(a.isOk() && a.value.stream.segments.size).toBe(1);
+      expect(b.isOk() && b.value.stream.segments.size).toBe(1);
+      if (a.isOk()) {
+        expect(a.value.stream.segments.has(SEGMENT_ID_1)).toBe(true);
+        expect(a.value.stream.segments.has(SEGMENT_ID_2)).toBe(false);
+      }
+    });
+  });
+});

--- a/packages/extension/src/infrastructure/storage/indexed-db-session-store.ts
+++ b/packages/extension/src/infrastructure/storage/indexed-db-session-store.ts
@@ -1,0 +1,238 @@
+import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
+import { ResultAsync, err, errAsync, ok, okAsync, type Result } from 'neverthrow';
+import {
+  invariantViolationError,
+  notFoundError,
+  type DomainError,
+} from '../../domain/shared/errors';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type TranscriptSegment } from '../../domain/transcript/transcript-segment';
+import { type TranscriptStream } from '../../domain/transcript/transcript-stream';
+import { type TranslationSegment } from '../../domain/transcript/translation-segment';
+import { type ExportBundle, type SessionStore } from '../../application/ports/session-store';
+import {
+  sessionFromRecord,
+  sessionToRecord,
+  transcriptSegmentFromRecord,
+  transcriptSegmentToRecord,
+  translationSegmentFromRecord,
+  translationSegmentToRecord,
+  type SessionRow,
+  type TranscriptSegmentRow,
+  type TranslationSegmentRow,
+} from './records';
+
+export const INDEXED_DB_NAME = 'perapera';
+export const INDEXED_DB_VERSION = 1;
+
+const SESSIONS_STORE = 'sessions';
+const TRANSCRIPT_STORE = 'transcript_segments';
+const TRANSLATION_STORE = 'translation_segments';
+const EXPORT_STORE = 'export_records';
+
+interface PeraperaSchema extends DBSchema {
+  sessions: {
+    key: string;
+    value: SessionRow;
+  };
+  transcript_segments: {
+    key: string;
+    value: TranscriptSegmentRow;
+    indexes: { 'by-sessionId': string };
+  };
+  translation_segments: {
+    key: string;
+    value: TranslationSegmentRow;
+    indexes: { 'by-sessionId': string };
+  };
+  export_records: {
+    key: string;
+    value: {
+      exportId: string;
+      sessionId: string;
+      format: 'txt' | 'json';
+      includeOriginal: boolean;
+      includeTranslation: boolean;
+      createdAt: string;
+    };
+    indexes: { 'by-sessionId': string };
+  };
+}
+
+const openPeraperaDb = (databaseName: string): Promise<IDBPDatabase<PeraperaSchema>> =>
+  openDB<PeraperaSchema>(databaseName, INDEXED_DB_VERSION, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(SESSIONS_STORE)) {
+        db.createObjectStore(SESSIONS_STORE, { keyPath: 'sessionId' });
+      }
+      if (!db.objectStoreNames.contains(TRANSCRIPT_STORE)) {
+        const store = db.createObjectStore(TRANSCRIPT_STORE, { keyPath: 'segmentId' });
+        store.createIndex('by-sessionId', 'sessionId');
+      }
+      if (!db.objectStoreNames.contains(TRANSLATION_STORE)) {
+        const store = db.createObjectStore(TRANSLATION_STORE, { keyPath: 'translationId' });
+        store.createIndex('by-sessionId', 'sessionId');
+      }
+      if (!db.objectStoreNames.contains(EXPORT_STORE)) {
+        const store = db.createObjectStore(EXPORT_STORE, { keyPath: 'exportId' });
+        store.createIndex('by-sessionId', 'sessionId');
+      }
+    },
+  });
+
+const toPersistenceError =
+  (scope: string) =>
+  (cause: unknown): DomainError =>
+    invariantViolationError({
+      invariant: 'session-persistence',
+      details: `${scope}: ${cause instanceof Error ? cause.message : 'unknown error'}`,
+    });
+
+/**
+ * IndexedDB session store の拡張 interface。
+ * `SessionStore` port に加えて、test cleanup や session worker のシャットダウン
+ * 時にコネクションを閉じるための `close()` を提供する。
+ */
+export type CloseableSessionStore = SessionStore & {
+  close: () => Promise<void>;
+};
+
+/**
+ * IMPL-310 IndexedDbSessionStore (DD-106, DB-001〜004)。
+ *
+ * `idb` v8 で 4 object store を管理する `SessionStore` 実装。
+ *
+ * - `sessions` (DB-001): primary key = sessionId
+ * - `transcript_segments` (DB-002): primary key = segmentId、
+ *   `by-sessionId` index あり
+ * - `translation_segments` (DB-003): primary key = translationId、
+ *   `by-sessionId` index あり
+ * - `export_records` (DB-004): primary key = exportId (本 store は
+ *   ExportRecordRepository が使う)
+ *
+ * 非同期 append-only 設計 (CLAUDE.md §データ保存方針)。ホットパスから
+ * fire-and-forget で呼ばれる想定で、書き込み失敗は UseCase 層で WARN ログ
+ * に留める。
+ */
+export type IndexedDbSessionStoreOptions = Readonly<{
+  /** Override for tests. Production should omit this to use the default. */
+  databaseName?: string;
+}>;
+
+export const createIndexedDbSessionStore = (
+  options: IndexedDbSessionStoreOptions = {},
+): CloseableSessionStore => {
+  const databaseName = options.databaseName ?? INDEXED_DB_NAME;
+  let dbPromise: Promise<IDBPDatabase<PeraperaSchema>> | null = null;
+  const db = (): Promise<IDBPDatabase<PeraperaSchema>> => {
+    dbPromise ??= openPeraperaDb(databaseName);
+    return dbPromise;
+  };
+
+  const buildStream = (
+    sessionIdentifier: SessionIdentifier,
+    transcripts: readonly TranscriptSegmentRow[],
+    translations: readonly TranslationSegmentRow[],
+  ): Result<TranscriptStream, DomainError> => {
+    const segments = new Map<string, TranscriptSegment>();
+    for (const row of transcripts) {
+      const result = transcriptSegmentFromRecord(row);
+      if (result.isErr()) return err(result.error);
+      segments.set(result.value.segmentIdentifier, result.value);
+    }
+    const translationMap = new Map<string, TranslationSegment>();
+    for (const row of translations) {
+      const result = translationSegmentFromRecord(row);
+      if (result.isErr()) return err(result.error);
+      translationMap.set(result.value.segmentIdentifier, result.value);
+    }
+    const stream: TranscriptStream = {
+      sessionIdentifier,
+      segments,
+      translations: translationMap,
+    };
+    return ok(stream);
+  };
+
+  return {
+    saveSession: (session) =>
+      ResultAsync.fromPromise(
+        (async () => {
+          const connection = await db();
+          await connection.put(SESSIONS_STORE, sessionToRecord(session));
+        })(),
+        toPersistenceError('saveSession'),
+      ),
+
+    appendTranscript: (sessionIdentifier, segment) =>
+      ResultAsync.fromPromise(
+        (async () => {
+          const connection = await db();
+          await connection.put(
+            TRANSCRIPT_STORE,
+            transcriptSegmentToRecord(sessionIdentifier, segment),
+          );
+        })(),
+        toPersistenceError('appendTranscript'),
+      ),
+
+    appendTranslation: (sessionIdentifier, translation) =>
+      ResultAsync.fromPromise(
+        (async () => {
+          const connection = await db();
+          await connection.put(
+            TRANSLATION_STORE,
+            translationSegmentToRecord(sessionIdentifier, translation),
+          );
+        })(),
+        toPersistenceError('appendTranslation'),
+      ),
+
+    loadExportBundle: (sessionIdentifier) =>
+      ResultAsync.fromPromise(
+        (async () => {
+          const connection = await db();
+          const sessionRow = await connection.get(SESSIONS_STORE, sessionIdentifier);
+          if (sessionRow === undefined) return null;
+          const transcripts = await connection.getAllFromIndex(
+            TRANSCRIPT_STORE,
+            'by-sessionId',
+            sessionIdentifier,
+          );
+          const translations = await connection.getAllFromIndex(
+            TRANSLATION_STORE,
+            'by-sessionId',
+            sessionIdentifier,
+          );
+          return { sessionRow, transcripts, translations };
+        })(),
+        toPersistenceError('loadExportBundle'),
+      ).andThen((raw): ResultAsync<ExportBundle, DomainError> => {
+        if (raw === null) {
+          return errAsync<ExportBundle, DomainError>(
+            notFoundError({ resourceType: 'SourceSession', identifier: sessionIdentifier }),
+          );
+        }
+        const sessionResult = sessionFromRecord(raw.sessionRow);
+        if (sessionResult.isErr()) {
+          return errAsync<ExportBundle, DomainError>(sessionResult.error);
+        }
+        const streamResult = buildStream(sessionIdentifier, raw.transcripts, raw.translations);
+        if (streamResult.isErr()) {
+          return errAsync<ExportBundle, DomainError>(streamResult.error);
+        }
+        return okAsync<ExportBundle, DomainError>({
+          session: sessionResult.value,
+          stream: streamResult.value,
+        });
+      }),
+
+    close: async () => {
+      if (dbPromise !== null) {
+        const connection = await dbPromise;
+        connection.close();
+        dbPromise = null;
+      }
+    },
+  };
+};

--- a/packages/extension/src/infrastructure/storage/records.test.ts
+++ b/packages/extension/src/infrastructure/storage/records.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+import { createExportRecord } from '../../domain/export/export-record';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import { createSourceSession } from '../../domain/session/source-session';
+import { createTimestampRange } from '../../domain/transcript/timestamp-range';
+import {
+  createPartialTranscriptSegment,
+  finalizeTranscriptSegment,
+} from '../../domain/transcript/transcript-segment';
+import {
+  createCompletedTranslationSegment,
+  createFailedTranslationSegment,
+} from '../../domain/transcript/translation-segment';
+import {
+  exportRecordToRecord,
+  sessionFromRecord,
+  sessionToRecord,
+  transcriptSegmentFromRecord,
+  transcriptSegmentToRecord,
+  translationSegmentFromRecord,
+  translationSegmentToRecord,
+  type ExportRecordRow,
+  type SessionRow,
+  type TranscriptSegmentRow,
+  type TranslationSegmentRow,
+} from './records';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+const TRANSLATION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7E1';
+const EXPORT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7F1';
+const STARTED_AT = '2026-04-21T00:00:00.000Z';
+const STOPPED_AT = '2026-04-21T00:10:00.000Z';
+
+const buildSession = () =>
+  createSourceSession({
+    sessionIdentifier: SESSION_ID,
+    sourceIdentifier: SOURCE_ID,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt: STARTED_AT,
+  })._unsafeUnwrap();
+
+describe('SessionRow mapper (DD-106, DB-001)', () => {
+  it('round-trips a domain SourceSession through to/from record', () => {
+    const session = buildSession();
+    const row = sessionToRecord(session);
+    expect(row.sessionId).toBe(SESSION_ID);
+    expect(row.sourceId).toBe(SOURCE_ID);
+    expect(row.sourceType).toBe('tab');
+    expect(row.sourceLanguage).toBe('en-US');
+    expect(row.targetLanguage).toBe('ja-JP');
+    expect(row.state).toBe('idle');
+    expect(row.startedAt).toBe(STARTED_AT);
+    expect(row.stoppedAt).toBeNull();
+    expect(row.degradedReason).toBeNull();
+
+    const restored = sessionFromRecord(row);
+    expect(restored.isOk()).toBe(true);
+    if (restored.isOk()) {
+      expect(restored.value.sessionIdentifier).toBe(SESSION_ID);
+      expect(restored.value.sourceIdentifier).toBe(SOURCE_ID);
+      expect(restored.value.state).toBe('idle');
+      expect(restored.value.languagePair.source).toBe('en-US');
+    }
+  });
+
+  it('preserves stoppedAt and degradedReason', () => {
+    const row: SessionRow = {
+      sessionId: SESSION_ID,
+      sourceId: SOURCE_ID,
+      sourceType: 'microphone',
+      state: 'stopped',
+      sourceLanguage: 'en-US',
+      targetLanguage: 'ja-JP',
+      startedAt: STARTED_AT,
+      stoppedAt: STOPPED_AT,
+      degradedReason: 'translation timeout',
+    };
+    const restored = sessionFromRecord(row);
+    expect(restored.isOk()).toBe(true);
+    if (restored.isOk()) {
+      expect(restored.value.stoppedAt).toBe(STOPPED_AT);
+      expect(restored.value.degradedReason).toBe('translation timeout');
+      expect(restored.value.state).toBe('stopped');
+    }
+  });
+
+  it('returns validation error for malformed identifiers', () => {
+    const row: SessionRow = {
+      sessionId: 'not-a-ulid',
+      sourceId: SOURCE_ID,
+      sourceType: 'tab',
+      state: 'idle',
+      sourceLanguage: 'en-US',
+      targetLanguage: 'ja-JP',
+      startedAt: STARTED_AT,
+      stoppedAt: null,
+      degradedReason: null,
+    };
+    expect(sessionFromRecord(row).isErr()).toBe(true);
+  });
+
+  it('returns validation error for malformed language pair (same source/target)', () => {
+    const row: SessionRow = {
+      sessionId: SESSION_ID,
+      sourceId: SOURCE_ID,
+      sourceType: 'tab',
+      state: 'idle',
+      sourceLanguage: 'ja-JP',
+      targetLanguage: 'ja-JP',
+      startedAt: STARTED_AT,
+      stoppedAt: null,
+      degradedReason: null,
+    };
+    expect(sessionFromRecord(row).isErr()).toBe(true);
+  });
+});
+
+describe('TranscriptSegmentRow mapper (DB-002)', () => {
+  it('round-trips a partial segment', () => {
+    const segment = createPartialTranscriptSegment({
+      segmentIdentifier: SEGMENT_ID,
+      revision: 2,
+      text: 'hello',
+      timeRange: createTimestampRange({ startMs: 100, endMs: 500 })._unsafeUnwrap(),
+    })._unsafeUnwrap();
+    const row = transcriptSegmentToRecord(buildSession().sessionIdentifier, segment);
+    expect(row.segmentId).toBe(SEGMENT_ID);
+    expect(row.sessionId).toBe(SESSION_ID);
+    expect(row.revision).toBe(2);
+    expect(row.isFinal).toBe(false);
+    expect(row.startMs).toBe(100);
+    expect(row.endMs).toBe(500);
+    expect(row.text).toBe('hello');
+
+    const restored = transcriptSegmentFromRecord(row);
+    expect(restored.isOk()).toBe(true);
+    if (restored.isOk()) {
+      expect(restored.value.revision).toBe(2);
+      expect(restored.value.isFinal).toBe(false);
+    }
+  });
+
+  it('round-trips a finalized segment', () => {
+    const partial = createPartialTranscriptSegment({
+      segmentIdentifier: SEGMENT_ID,
+      revision: 1,
+      text: 'world',
+      timeRange: createTimestampRange({ startMs: 0, endMs: 1500 })._unsafeUnwrap(),
+    })._unsafeUnwrap();
+    const finalized = finalizeTranscriptSegment(partial, {})._unsafeUnwrap();
+    const row = transcriptSegmentToRecord(buildSession().sessionIdentifier, finalized);
+    expect(row.isFinal).toBe(true);
+    const restored = transcriptSegmentFromRecord(row);
+    expect(restored.isOk()).toBe(true);
+    if (restored.isOk()) expect(restored.value.isFinal).toBe(true);
+  });
+});
+
+describe('TranslationSegmentRow mapper (DB-003)', () => {
+  it('round-trips a completed translation', () => {
+    const translation = createCompletedTranslationSegment({
+      translationIdentifier: TRANSLATION_ID,
+      segmentIdentifier: SEGMENT_ID,
+      targetLanguage: 'ja-JP',
+      text: 'こんにちは',
+    })._unsafeUnwrap();
+    const row = translationSegmentToRecord(buildSession().sessionIdentifier, translation);
+    expect(row.translationId).toBe(TRANSLATION_ID);
+    expect(row.status).toBe('completed');
+    expect(row.text).toBe('こんにちは');
+    const restored = translationSegmentFromRecord(row);
+    expect(restored.isOk()).toBe(true);
+    if (restored.isOk() && restored.value.status === 'completed') {
+      expect(restored.value.text).toBe('こんにちは');
+    }
+  });
+
+  it('round-trips a failed translation (empty text)', () => {
+    const translation = createFailedTranslationSegment({
+      translationIdentifier: TRANSLATION_ID,
+      segmentIdentifier: SEGMENT_ID,
+      targetLanguage: 'ja-JP',
+    })._unsafeUnwrap();
+    const row = translationSegmentToRecord(buildSession().sessionIdentifier, translation);
+    expect(row.status).toBe('failed');
+    expect(row.text).toBe('');
+    const restored = translationSegmentFromRecord(row);
+    expect(restored.isOk()).toBe(true);
+    if (restored.isOk()) expect(restored.value.status).toBe('failed');
+  });
+
+  it('rejects rows with invalid status', () => {
+    const row: TranslationSegmentRow = {
+      translationId: TRANSLATION_ID,
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      targetLanguage: 'ja-JP',
+      status: 'unknown',
+      text: '',
+    };
+    expect(translationSegmentFromRecord(row).isErr()).toBe(true);
+  });
+});
+
+describe('ExportRecordRow mapper (DB-004)', () => {
+  it('serializes an ExportRecord to a row', () => {
+    const record = createExportRecord({
+      exportIdentifier: EXPORT_ID,
+      sessionIdentifier: SESSION_ID,
+      format: 'txt',
+      includeOriginal: true,
+      includeTranslation: false,
+      createdAt: STARTED_AT,
+    })._unsafeUnwrap();
+    const row: ExportRecordRow = exportRecordToRecord(record);
+    expect(row.exportId).toBe(EXPORT_ID);
+    expect(row.sessionId).toBe(SESSION_ID);
+    expect(row.format).toBe('txt');
+    expect(row.includeOriginal).toBe(true);
+    expect(row.includeTranslation).toBe(false);
+    expect(row.createdAt).toBe(STARTED_AT);
+  });
+});
+
+describe('Type shape checks', () => {
+  it('TranscriptSegmentRow and SessionRow are plain data types suitable for IndexedDB', () => {
+    const sRow: SessionRow = {
+      sessionId: SESSION_ID,
+      sourceId: SOURCE_ID,
+      sourceType: 'tab',
+      state: 'idle',
+      sourceLanguage: 'en-US',
+      targetLanguage: 'ja-JP',
+      startedAt: STARTED_AT,
+      stoppedAt: null,
+      degradedReason: null,
+    };
+    const tRow: TranscriptSegmentRow = {
+      segmentId: SEGMENT_ID,
+      sessionId: SESSION_ID,
+      revision: 1,
+      isFinal: false,
+      startMs: 0,
+      endMs: 100,
+      text: 'x',
+    };
+    expect(JSON.parse(JSON.stringify(sRow))).toEqual(sRow);
+    expect(JSON.parse(JSON.stringify(tRow))).toEqual(tRow);
+  });
+});

--- a/packages/extension/src/infrastructure/storage/records.ts
+++ b/packages/extension/src/infrastructure/storage/records.ts
@@ -1,0 +1,200 @@
+import { type Result } from 'neverthrow';
+import {
+  createExportRecord,
+  type ExportFormat,
+  type ExportRecord,
+} from '../../domain/export/export-record';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import { createSourceSession, type SourceSession } from '../../domain/session/source-session';
+import { type SessionState } from '../../domain/session/session-state';
+import { type SourceType } from '../../domain/session/source-type';
+import { type DomainError } from '../../domain/shared/errors';
+import { createTimestampRange } from '../../domain/transcript/timestamp-range';
+import {
+  createPartialTranscriptSegment,
+  finalizeTranscriptSegment,
+  type TranscriptSegment,
+} from '../../domain/transcript/transcript-segment';
+import {
+  createCompletedTranslationSegment,
+  createFailedTranslationSegment,
+  type TranslationSegment,
+} from '../../domain/transcript/translation-segment';
+
+/**
+ * 永続モデル (IndexedDB object store の row) ↔ ドメインモデル変換
+ * (infrastructure.md §3.3 Data Mapper、DD-1xx)。
+ *
+ * 永続モデル (Row 型) はプレーンな JSON 互換で、IndexedDB のシリアライゼーション
+ * 要件を満たす。ドメインモデル変換は `createXxx` factory を通すことで Zod
+ * バリデーションと branded type の復元を保証する。
+ */
+
+// ---------- DB-001 sessions ----------
+
+export type SessionRow = {
+  sessionId: string;
+  sourceId: string;
+  sourceType: SourceType;
+  state: SessionState;
+  sourceLanguage: string;
+  targetLanguage: string;
+  startedAt: string;
+  stoppedAt: string | null;
+  degradedReason: string | null;
+};
+
+export const sessionToRecord = (session: SourceSession): SessionRow => ({
+  sessionId: session.sessionIdentifier,
+  sourceId: session.sourceIdentifier,
+  sourceType: session.sourceType,
+  state: session.state,
+  sourceLanguage: session.languagePair.source,
+  targetLanguage: session.languagePair.target,
+  startedAt: session.startedAt,
+  stoppedAt: session.stoppedAt,
+  degradedReason: session.degradedReason,
+});
+
+export const sessionFromRecord = (row: SessionRow): Result<SourceSession, DomainError> =>
+  createLanguagePair({ source: row.sourceLanguage, target: row.targetLanguage }).andThen(
+    (languagePair) =>
+      createSourceSession({
+        sessionIdentifier: row.sessionId,
+        sourceIdentifier: row.sourceId,
+        sourceType: row.sourceType,
+        languagePair,
+        startedAt: row.startedAt,
+      }).map((session) => ({
+        ...session,
+        state: row.state,
+        stoppedAt: row.stoppedAt,
+        degradedReason: row.degradedReason,
+      })),
+  );
+
+// ---------- DB-002 transcript_segments ----------
+
+export type TranscriptSegmentRow = {
+  segmentId: string;
+  sessionId: string;
+  revision: number;
+  isFinal: boolean;
+  startMs: number;
+  endMs: number;
+  text: string;
+};
+
+export const transcriptSegmentToRecord = (
+  sessionIdentifier: string,
+  segment: TranscriptSegment,
+): TranscriptSegmentRow => ({
+  segmentId: segment.segmentIdentifier,
+  sessionId: sessionIdentifier,
+  revision: segment.revision,
+  isFinal: segment.isFinal,
+  startMs: segment.timeRange.startMs,
+  endMs: segment.timeRange.endMs,
+  text: segment.text,
+});
+
+export const transcriptSegmentFromRecord = (
+  row: TranscriptSegmentRow,
+): Result<TranscriptSegment, DomainError> =>
+  createTimestampRange({ startMs: row.startMs, endMs: row.endMs }).andThen((timeRange) => {
+    const partial = createPartialTranscriptSegment({
+      segmentIdentifier: row.segmentId,
+      revision: row.revision,
+      text: row.text,
+      timeRange,
+    });
+    if (!row.isFinal) return partial;
+    return partial.andThen((p) => finalizeTranscriptSegment(p, {}));
+  });
+
+// ---------- DB-003 translation_segments ----------
+
+export type TranslationSegmentRow = {
+  translationId: string;
+  sessionId: string;
+  segmentId: string;
+  targetLanguage: string;
+  status: string;
+  text: string;
+};
+
+export const translationSegmentToRecord = (
+  sessionIdentifier: string,
+  translation: TranslationSegment,
+): TranslationSegmentRow => ({
+  translationId: translation.translationIdentifier,
+  sessionId: sessionIdentifier,
+  segmentId: translation.segmentIdentifier,
+  targetLanguage: translation.targetLanguage,
+  status: translation.status,
+  text: translation.status === 'completed' ? translation.text : '',
+});
+
+export const translationSegmentFromRecord = (
+  row: TranslationSegmentRow,
+): Result<TranslationSegment, DomainError> => {
+  if (row.status === 'completed') {
+    return createCompletedTranslationSegment({
+      translationIdentifier: row.translationId,
+      segmentIdentifier: row.segmentId,
+      targetLanguage: row.targetLanguage,
+      text: row.text,
+    });
+  }
+  if (row.status === 'failed') {
+    return createFailedTranslationSegment({
+      translationIdentifier: row.translationId,
+      segmentIdentifier: row.segmentId,
+      targetLanguage: row.targetLanguage,
+    });
+  }
+  // Unknown status → route through the completed factory which will reject
+  // via validation (status must be 'completed' or 'failed').
+  return createCompletedTranslationSegment({
+    translationIdentifier: row.translationId,
+    segmentIdentifier: row.segmentId,
+    targetLanguage: row.targetLanguage,
+    text: row.text,
+  }).andThen(() =>
+    createFailedTranslationSegment({
+      translationIdentifier: 'invalid',
+      segmentIdentifier: row.segmentId,
+      targetLanguage: row.targetLanguage,
+    }),
+  );
+};
+
+// ---------- DB-004 export_records ----------
+
+export type ExportRecordRow = {
+  exportId: string;
+  sessionId: string;
+  format: ExportFormat;
+  includeOriginal: boolean;
+  includeTranslation: boolean;
+  createdAt: string;
+};
+
+export const exportRecordToRecord = (record: ExportRecord): ExportRecordRow => ({
+  exportId: record.exportIdentifier,
+  sessionId: record.sessionIdentifier,
+  format: record.format,
+  includeOriginal: record.includeOriginal,
+  includeTranslation: record.includeTranslation,
+  createdAt: record.createdAt,
+});
+
+export const exportRecordFromRecord = (row: ExportRecordRow): Result<ExportRecord, DomainError> =>
+  createExportRecord({
+    exportIdentifier: row.exportId,
+    sessionIdentifier: row.sessionId,
+    format: row.format,
+    includeOriginal: row.includeOriginal,
+    includeTranslation: row.includeTranslation,
+    createdAt: row.createdAt,
+  });


### PR DESCRIPTION
## Summary

Phase 3 §5.2 Storage を TDD で実装。`SessionStore` と `SettingsStore` ポートの infrastructure 実装を提供する。

- **IMPL-312 Data Mapper** (`records.ts`) — 4 種 Row ↔ ドメインモデル変換。復元時は `createXxx` factory を通して Zod validation + branded type 復元
- **IMPL-311 ChromeLocalSettingsStore** — `ChromeStorageAdapter` 注入型で `chrome.storage.local.get/set` の overload を隠蔽。production の default adapter と test の mock adapter 両対応
- **IMPL-310 IndexedDbSessionStore** — `idb` v8 で 4 object store + `by-sessionId` index。`CloseableSessionStore` 型 (close() 付き)、test 用 `databaseName` option で独立 DB

### 設計判断

- **ChromeStorageAdapter injection**: `@types/chrome` の overload (callback vs Promise) で vi.mocked が void 推論するのを回避
- **データベース名注入**: 各 test が独立 DB を持つことで fake-indexeddb の干渉を排除
- **エラーマッピング**:
  - not-found → `notFoundError`
  - schema 違反 → `validationError` (VO factory propagate)
  - I/O 失敗 → `invariantViolationError({ invariant: 'chrome-storage-access' | 'session-persistence' })`

### base branch

PR #19 (Phase 2 完了) に stacked。

## Test plan

- [x] 490 tests pass (+27 新規: records 11 + settings-store 9 + session-store 7)
- [x] `pnpm check` 全緑
- [ ] CI `All Green` → auto merge

## Phase 3 進捗

Storage 完了。残りは 音声取得 (IMPL-300-303) / 通信 (IMPL-320-322) / 表示 (IMPL-330) / 統括 (IMPL-340-344)。