### PR TITLE
feat(infrastructure): IMPL-320/321/322 Communication + Storage mock-leak fix

### DIFF
--- a/packages/extension/src/infrastructure/relay/in-memory-translation-cache.test.ts
+++ b/packages/extension/src/infrastructure/relay/in-memory-translation-cache.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createInMemoryTranslationCache,
+  DEFAULT_TRANSLATION_CACHE_TTL_MS,
+  type TranslationCacheEntry,
+} from './in-memory-translation-cache';
+
+const entry: TranslationCacheEntry = {
+  targetLanguage: 'ja-JP',
+  text: 'こんにちは',
+};
+
+describe('createInMemoryTranslationCache (IMPL-322, DD-133)', () => {
+  it('returns null for a missing key', () => {
+    const cache = createInMemoryTranslationCache({ clock: () => 0 });
+    expect(cache.get('missing')).toBeNull();
+    expect(cache.has('missing')).toBe(false);
+  });
+
+  it('returns the stored entry while within TTL', () => {
+    let now = 1000;
+    const cache = createInMemoryTranslationCache({ clock: () => now });
+    cache.set('k1', entry);
+    now += DEFAULT_TRANSLATION_CACHE_TTL_MS - 1;
+    expect(cache.get('k1')).toEqual(entry);
+    expect(cache.has('k1')).toBe(true);
+  });
+
+  it('evicts an entry exactly at TTL boundary', () => {
+    let now = 1000;
+    const cache = createInMemoryTranslationCache({ clock: () => now });
+    cache.set('k1', entry);
+    now += DEFAULT_TRANSLATION_CACHE_TTL_MS;
+    expect(cache.get('k1')).toBeNull();
+    expect(cache.has('k1')).toBe(false);
+  });
+
+  it('overwrites an existing key and resets TTL', () => {
+    let now = 0;
+    const cache = createInMemoryTranslationCache({ clock: () => now });
+    cache.set('k1', entry);
+    now += 25000;
+    cache.set('k1', { targetLanguage: 'ja-JP', text: 'こんばんは' });
+    now += 25000; // total 50000 from first set, but second reset it at 25000
+    expect(cache.get('k1')?.text).toBe('こんばんは');
+  });
+
+  it('clear() removes all entries', () => {
+    const cache = createInMemoryTranslationCache({ clock: () => 0 });
+    cache.set('a', entry);
+    cache.set('b', entry);
+    cache.clear();
+    expect(cache.has('a')).toBe(false);
+    expect(cache.has('b')).toBe(false);
+  });
+
+  it('accepts a custom ttlMs override', () => {
+    let now = 0;
+    const cache = createInMemoryTranslationCache({ clock: () => now, ttlMs: 1000 });
+    cache.set('k', entry);
+    now += 500;
+    expect(cache.has('k')).toBe(true);
+    now += 500;
+    expect(cache.has('k')).toBe(false);
+  });
+
+  it('DEFAULT_TRANSLATION_CACHE_TTL_MS is 30000ms (30 seconds per DD-133)', () => {
+    expect(DEFAULT_TRANSLATION_CACHE_TTL_MS).toBe(30000);
+  });
+
+  it('requires clock dependency (compile-time: must be provided)', () => {
+    // This test documents that `clock` is a required field in the
+    // dependencies. Production code must pass `() => Date.now()` explicitly
+    // via entrypoint wiring (no default to prevent mock leakage).
+    const cache = createInMemoryTranslationCache({ clock: () => 12345 });
+    expect(cache).toBeDefined();
+  });
+});

--- a/packages/extension/src/infrastructure/relay/in-memory-translation-cache.ts
+++ b/packages/extension/src/infrastructure/relay/in-memory-translation-cache.ts
@@ -1,0 +1,69 @@
+/**
+ * IMPL-322 InMemoryTranslationCache (DD-133)。
+ *
+ * ホットパスで同一原文の翻訳結果を 30 秒間短期保持するキャッシュ。
+ * 再翻訳要求を重複させないことで Relay API / 翻訳プロバイダへの負荷を抑える
+ * (`infrastructure.md` §7.3)。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - `clock: () => number` を **必須** DI (default 引数なし)
+ * - production の entrypoint で `() => Date.now()` を明示的に渡す
+ * - `ttlMs` は仕様定数 (30000) で default を許容 (mock ではない)
+ * - 呼び出し側は必ず自分で clock を選択するため、production で
+ *   偶発的に mock clock が使われる事故を防ぐ
+ */
+
+export const DEFAULT_TRANSLATION_CACHE_TTL_MS = 30000 as const;
+
+export type TranslationCacheEntry = Readonly<{
+  targetLanguage: string;
+  text: string;
+}>;
+
+export type TranslationCache = Readonly<{
+  get: (key: string) => TranslationCacheEntry | null;
+  set: (key: string, entry: TranslationCacheEntry) => void;
+  has: (key: string) => boolean;
+  clear: () => void;
+}>;
+
+export type TranslationCacheDependencies = Readonly<{
+  clock: () => number;
+  ttlMs?: number;
+}>;
+
+type StoredEntry = {
+  entry: TranslationCacheEntry;
+  expiresAt: number;
+};
+
+export const createInMemoryTranslationCache = (
+  deps: TranslationCacheDependencies,
+): TranslationCache => {
+  const ttl = deps.ttlMs ?? DEFAULT_TRANSLATION_CACHE_TTL_MS;
+  const store = new Map<string, StoredEntry>();
+
+  const evictIfExpired = (key: string): void => {
+    const stored = store.get(key);
+    if (stored !== undefined && stored.expiresAt <= deps.clock()) {
+      store.delete(key);
+    }
+  };
+
+  return {
+    get: (key) => {
+      evictIfExpired(key);
+      return store.get(key)?.entry ?? null;
+    },
+    set: (key, entry) => {
+      store.set(key, { entry, expiresAt: deps.clock() + ttl });
+    },
+    has: (key) => {
+      evictIfExpired(key);
+      return store.has(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+};

--- a/packages/extension/src/infrastructure/relay/index.ts
+++ b/packages/extension/src/infrastructure/relay/index.ts
@@ -1,0 +1,19 @@
+export {
+  DEFAULT_TRANSLATION_CACHE_TTL_MS,
+  createInMemoryTranslationCache,
+  type TranslationCache,
+  type TranslationCacheDependencies,
+  type TranslationCacheEntry,
+} from './in-memory-translation-cache';
+export { parseRelayServerMessage } from './relay-event-mapper';
+export {
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  createRelayWebSocketGateway,
+  type RelayWebSocketGatewayDependencies,
+  type StreamTokenIssuer,
+} from './relay-websocket-gateway';
+export {
+  createBrowserWebSocketFactory,
+  type WebSocketFactory,
+  type WebSocketLike,
+} from './websocket-factory';

--- a/packages/extension/src/infrastructure/relay/relay-event-mapper.test.ts
+++ b/packages/extension/src/infrastructure/relay/relay-event-mapper.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { parseRelayServerMessage } from './relay-event-mapper';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const wrap = (eventType: string, payload: Record<string, unknown>): string =>
+  JSON.stringify({
+    eventType,
+    sessionId: SESSION_ID,
+    sequence: 1,
+    timestamp: '2026-04-21T00:00:00.000Z',
+    payload,
+  });
+
+describe('parseRelayServerMessage (IMPL-321, DD-411)', () => {
+  it('parses session.ready', () => {
+    const raw = wrap('session.ready', {
+      state: 'capturing',
+      heartbeatIntervalSec: 15,
+      streamToken: 'tkn_xxx',
+    });
+    const result = parseRelayServerMessage(raw);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && result.value !== null) {
+      expect(result.value.type).toBe('session.ready');
+      if (result.value.type === 'session.ready') {
+        expect(result.value.streamToken).toBe('tkn_xxx');
+        expect(result.value.sessionIdentifier).toBe(sessionIdentifier);
+      }
+    }
+  });
+
+  it('parses transcript.partial', () => {
+    const raw = wrap('transcript.partial', {
+      segmentId: '01HZX8Y1R8M7D3Q2P4T5V6W7D1',
+      revision: 2,
+      text: 'hello world',
+      language: 'en-US',
+      startOffsetMs: 0,
+      endOffsetMs: 1500,
+    });
+    const result = parseRelayServerMessage(raw);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && result.value !== null && result.value.type === 'transcript.partial') {
+      expect(result.value.segmentIdentifier).toBe('01HZX8Y1R8M7D3Q2P4T5V6W7D1');
+      expect(result.value.revision).toBe(2);
+      expect(result.value.text).toBe('hello world');
+    }
+  });
+
+  it('parses transcript.final', () => {
+    const raw = wrap('transcript.final', {
+      segmentId: '01HZX8Y1R8M7D3Q2P4T5V6W7D1',
+      text: 'hello',
+      finalizedAt: '2026-04-21T00:00:05.000Z',
+    });
+    const result = parseRelayServerMessage(raw);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && result.value !== null && result.value.type === 'transcript.final') {
+      expect(result.value.segmentIdentifier).toBe('01HZX8Y1R8M7D3Q2P4T5V6W7D1');
+      expect(result.value.finalizedAt).toBe('2026-04-21T00:00:05.000Z');
+    }
+  });
+
+  it('parses translation.final', () => {
+    const raw = wrap('translation.final', {
+      translationId: '01HZX8Y1R8M7D3Q2P4T5V6W7E1',
+      sourceSegmentId: '01HZX8Y1R8M7D3Q2P4T5V6W7D1',
+      text: 'こんにちは',
+      targetLanguage: 'ja-JP',
+    });
+    const result = parseRelayServerMessage(raw);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && result.value !== null && result.value.type === 'translation.final') {
+      expect(result.value.translationIdentifier).toBe('01HZX8Y1R8M7D3Q2P4T5V6W7E1');
+      expect(result.value.targetLanguage).toBe('ja-JP');
+      expect(result.value.text).toBe('こんにちは');
+    }
+  });
+
+  it('parses session.state.changed', () => {
+    const raw = wrap('session.state.changed', {
+      currentState: 'reconnecting',
+    });
+    const result = parseRelayServerMessage(raw);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && result.value !== null && result.value.type === 'session.state.changed') {
+      expect(result.value.state).toBe('reconnecting');
+    }
+  });
+
+  it('parses session.error with retryable/fatal flags', () => {
+    const raw = wrap('session.error', {
+      code: 'TRANSLATION_TIMEOUT',
+      message: 'translation provider timed out',
+      retryable: true,
+      fatal: false,
+    });
+    const result = parseRelayServerMessage(raw);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && result.value !== null && result.value.type === 'session.error') {
+      expect(result.value.code).toBe('TRANSLATION_TIMEOUT');
+      expect(result.value.retryable).toBe(true);
+      expect(result.value.fatal).toBe(false);
+    }
+  });
+
+  it('returns null for session.pong (heartbeat — not a domain event)', () => {
+    const raw = wrap('session.pong', {});
+    const result = parseRelayServerMessage(raw);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBeNull();
+  });
+
+  it('returns validation error for unknown eventType', () => {
+    const raw = wrap('session.unknown', {});
+    const result = parseRelayServerMessage(raw);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('returns validation error for malformed JSON', () => {
+    const result = parseRelayServerMessage('not-json{');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('returns validation error for missing required fields', () => {
+    const result = parseRelayServerMessage(JSON.stringify({ eventType: 'transcript.partial' }));
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('returns validation error for invalid sessionId format', () => {
+    const raw = JSON.stringify({
+      eventType: 'session.ready',
+      sessionId: 'not-a-ulid',
+      sequence: 0,
+      timestamp: '2026-04-21T00:00:00.000Z',
+      payload: { state: 'capturing', heartbeatIntervalSec: 15, streamToken: 'x' },
+    });
+    const result = parseRelayServerMessage(raw);
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/extension/src/infrastructure/relay/relay-event-mapper.ts
+++ b/packages/extension/src/infrastructure/relay/relay-event-mapper.ts
@@ -1,0 +1,192 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { parseSessionIdentifier } from '../../domain/session/session-identifier';
+import { parseSessionState } from '../../domain/session/session-state';
+import { type DomainError, validationError } from '../../domain/shared/errors';
+import { type RelayEvent } from '../../application/ports/relay-gateway';
+
+/**
+ * Relay API サーバーイベント (`api-specification.md` §6.3) を `RelayEvent`
+ * discriminated union (application/ports) にマップする純粋パーサ。
+ *
+ * `session.pong` はハートビート応答で、`RelayEvent` に含まれない。この場合は
+ * `ok(null)` で返し、呼び出し側が無視する。
+ *
+ * Zod で入力 validate し、既存ドメイン型 (SessionIdentifier / SessionState)
+ * は対応する parse / create ヘルパを通す。
+ */
+
+const isoSchema = z.string().datetime();
+const baseEnvelopeSchema = z.object({
+  eventType: z.string(),
+  sessionId: z.string(),
+  sequence: z.number().int().nonnegative(),
+  timestamp: isoSchema,
+  payload: z.record(z.unknown()).optional().default({}),
+});
+
+const readyPayload = z.object({
+  state: z.string(),
+  heartbeatIntervalSec: z.number().positive(),
+  streamToken: z.string().min(1),
+});
+
+const transcriptPartialPayload = z.object({
+  segmentId: z.string().min(1),
+  revision: z.number().int().positive(),
+  text: z.string().min(1),
+  language: z.string().optional(),
+  startOffsetMs: z.number().int().nonnegative().optional(),
+  endOffsetMs: z.number().int().nonnegative().optional(),
+});
+
+const transcriptFinalPayload = z.object({
+  segmentId: z.string().min(1),
+  text: z.string().min(1),
+  finalizedAt: isoSchema,
+});
+
+const translationFinalPayload = z.object({
+  translationId: z.string().min(1),
+  sourceSegmentId: z.string().min(1),
+  text: z.string().min(1),
+  targetLanguage: z.string().min(1),
+  sourceLanguage: z.string().optional(),
+});
+
+const stateChangedPayload = z.object({
+  currentState: z.string(),
+  previousState: z.string().optional(),
+  reason: z.string().optional(),
+});
+
+const sessionErrorPayload = z.object({
+  code: z.string().min(1),
+  message: z.string().min(1),
+  retryable: z.boolean(),
+  fatal: z.boolean(),
+});
+
+const asValidation = (message: string): DomainError =>
+  validationError({ field: 'RelayServerMessage', message });
+
+/**
+ * WebSocket 受信メッセージを parse。
+ * - `session.pong` → `ok(null)`
+ * - 他の既知イベント → `ok(RelayEvent)`
+ * - 未知 eventType / schema 違反 / JSON パース失敗 → `err(validationError)`
+ */
+export const parseRelayServerMessage = (raw: string): Result<RelayEvent | null, DomainError> => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    return err(
+      asValidation(`JSON parse failed: ${cause instanceof Error ? cause.message : 'unknown'}`),
+    );
+  }
+
+  const envelopeResult = baseEnvelopeSchema.safeParse(parsed);
+  if (!envelopeResult.success) {
+    return err(asValidation(envelopeResult.error.issues.map((i) => i.message).join('; ')));
+  }
+  const envelope = envelopeResult.data;
+
+  const sessionIdentifierResult = parseSessionIdentifier(envelope.sessionId);
+  if (sessionIdentifierResult.isErr()) {
+    return err(sessionIdentifierResult.error);
+  }
+  const sessionIdentifier = sessionIdentifierResult.value;
+
+  switch (envelope.eventType) {
+    case 'session.pong':
+      return ok(null);
+
+    case 'session.ready': {
+      const payload = readyPayload.safeParse(envelope.payload);
+      if (!payload.success) {
+        return err(asValidation(payload.error.issues.map((i) => i.message).join('; ')));
+      }
+      return ok({
+        type: 'session.ready',
+        sessionIdentifier,
+        streamToken: payload.data.streamToken,
+      });
+    }
+
+    case 'transcript.partial': {
+      const payload = transcriptPartialPayload.safeParse(envelope.payload);
+      if (!payload.success) {
+        return err(asValidation(payload.error.issues.map((i) => i.message).join('; ')));
+      }
+      return ok({
+        type: 'transcript.partial',
+        sessionIdentifier,
+        segmentIdentifier: payload.data.segmentId,
+        revision: payload.data.revision,
+        text: payload.data.text,
+      });
+    }
+
+    case 'transcript.final': {
+      const payload = transcriptFinalPayload.safeParse(envelope.payload);
+      if (!payload.success) {
+        return err(asValidation(payload.error.issues.map((i) => i.message).join('; ')));
+      }
+      return ok({
+        type: 'transcript.final',
+        sessionIdentifier,
+        segmentIdentifier: payload.data.segmentId,
+        text: payload.data.text,
+        finalizedAt: payload.data.finalizedAt,
+      });
+    }
+
+    case 'translation.final': {
+      const payload = translationFinalPayload.safeParse(envelope.payload);
+      if (!payload.success) {
+        return err(asValidation(payload.error.issues.map((i) => i.message).join('; ')));
+      }
+      return ok({
+        type: 'translation.final',
+        sessionIdentifier,
+        segmentIdentifier: payload.data.sourceSegmentId,
+        translationIdentifier: payload.data.translationId,
+        targetLanguage: payload.data.targetLanguage,
+        text: payload.data.text,
+      });
+    }
+
+    case 'session.state.changed': {
+      const payload = stateChangedPayload.safeParse(envelope.payload);
+      if (!payload.success) {
+        return err(asValidation(payload.error.issues.map((i) => i.message).join('; ')));
+      }
+      const stateResult = parseSessionState(payload.data.currentState);
+      if (stateResult.isErr()) return err(stateResult.error);
+      return ok({
+        type: 'session.state.changed',
+        sessionIdentifier,
+        state: stateResult.value,
+      });
+    }
+
+    case 'session.error': {
+      const payload = sessionErrorPayload.safeParse(envelope.payload);
+      if (!payload.success) {
+        return err(asValidation(payload.error.issues.map((i) => i.message).join('; ')));
+      }
+      return ok({
+        type: 'session.error',
+        sessionIdentifier,
+        code: payload.data.code,
+        message: payload.data.message,
+        retryable: payload.data.retryable,
+        fatal: payload.data.fatal,
+      });
+    }
+
+    default:
+      return err(asValidation(`unknown eventType: ${envelope.eventType}`));
+  }
+};

--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.test.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.test.ts
@@ -1,0 +1,335 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { invariantViolationError } from '../../domain/shared/errors';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import { createSourceSession, type SourceSession } from '../../domain/session/source-session';
+import { parseSessionIdentifier } from '../../domain/session/session-identifier';
+import { type RelayEvent } from '../../application/ports/relay-gateway';
+import {
+  createRelayWebSocketGateway,
+  type RelayWebSocketGatewayDependencies,
+} from './relay-websocket-gateway';
+import type { WebSocketLike } from './websocket-factory';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const STREAM_TOKEN = 'stream-token-xxx';
+
+const sessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const buildSession = (): SourceSession =>
+  createSourceSession({
+    sessionIdentifier: SESSION_ID,
+    sourceIdentifier: SOURCE_ID,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt: '2026-04-21T00:00:00.000Z',
+  })._unsafeUnwrap();
+
+type MockSocket = WebSocketLike & {
+  sentMessages: string[];
+  simulateOpen: () => void;
+  simulateMessage: (data: string) => void;
+  simulateClose: () => void;
+  listenerCount: (type: string) => number;
+  isClosed: boolean;
+};
+
+const createMockSocket = (): MockSocket => {
+  const listeners = new Map<string, Set<(event: Event) => void>>();
+  const sentMessages: string[] = [];
+  let readyState = 0; // CONNECTING
+  let closed = false;
+  return {
+    get readyState() {
+      return readyState;
+    },
+    send: (data) => {
+      sentMessages.push(data);
+    },
+    close: () => {
+      readyState = 3;
+      closed = true;
+      const closeListeners = listeners.get('close');
+      if (closeListeners !== undefined) {
+        for (const listener of closeListeners) listener(new Event('close'));
+      }
+    },
+    addEventListener: (type, listener) => {
+      let set = listeners.get(type);
+      if (set === undefined) {
+        set = new Set();
+        listeners.set(type, set);
+      }
+      set.add(listener);
+    },
+    removeEventListener: (type, listener) => {
+      listeners.get(type)?.delete(listener);
+    },
+    sentMessages,
+    simulateOpen: () => {
+      readyState = 1;
+      const openListeners = listeners.get('open');
+      if (openListeners !== undefined) {
+        for (const listener of openListeners) listener(new Event('open'));
+      }
+    },
+    simulateMessage: (data) => {
+      const messageListeners = listeners.get('message');
+      if (messageListeners !== undefined) {
+        const event = new MessageEvent('message', { data });
+        for (const listener of messageListeners) listener(event);
+      }
+    },
+    simulateClose: () => {
+      readyState = 3;
+      closed = true;
+      const closeListeners = listeners.get('close');
+      if (closeListeners !== undefined) {
+        for (const listener of closeListeners) listener(new Event('close'));
+      }
+    },
+    listenerCount: (type) => listeners.get(type)?.size ?? 0,
+    get isClosed() {
+      return closed;
+    },
+  };
+};
+
+const flushUntilSocketCreated = async (sockets: MockSocket[]): Promise<void> => {
+  for (let i = 0; i < 50 && sockets.length === 0; i += 1) {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+};
+
+const buildDependencies = (
+  overrides: Partial<RelayWebSocketGatewayDependencies> = {},
+): RelayWebSocketGatewayDependencies & { createdSockets: MockSocket[] } => {
+  const createdSockets: MockSocket[] = [];
+  const webSocketFactory = vi.fn((_url: string) => {
+    const socket = createMockSocket();
+    createdSockets.push(socket);
+    return socket;
+  });
+  const tokenIssuer = vi.fn(() => okAsync(STREAM_TOKEN));
+  const wsEndpointBuilder = vi.fn(
+    (id: string, token: string) =>
+      `wss://relay.example/api/v1/relay?sessionId=${id}&token=${token}`,
+  );
+  const clock = vi.fn(() => Date.parse('2026-04-21T00:00:00.000Z'));
+
+  return Object.assign(
+    {
+      webSocketFactory,
+      tokenIssuer,
+      wsEndpointBuilder,
+      clock,
+      ...overrides,
+    },
+    { createdSockets },
+  );
+};
+
+describe('createRelayWebSocketGateway (IMPL-320, DD-105 / DD-411)', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* silence */
+    });
+  });
+
+  describe('openSession', () => {
+    it('builds a URL via wsEndpointBuilder with the stream token', async () => {
+      const deps = buildDependencies();
+      const gateway = createRelayWebSocketGateway(deps);
+      const resultPromise = gateway.openSession(buildSession());
+      await flushUntilSocketCreated(deps.createdSockets);
+      deps.createdSockets[0]?.simulateOpen();
+      const result = await resultPromise;
+      expect(result.isOk()).toBe(true);
+      expect(deps.wsEndpointBuilder).toHaveBeenCalledWith(SESSION_ID, STREAM_TOKEN);
+      expect(deps.webSocketFactory).toHaveBeenCalledWith(
+        expect.stringContaining('sessionId=01HZX8Y1R8M7D3Q2P4T5V6W7A1'),
+      );
+    });
+
+    it('sends session.start envelope on open', async () => {
+      const deps = buildDependencies();
+      const gateway = createRelayWebSocketGateway(deps);
+      const resultPromise = gateway.openSession(buildSession());
+      await flushUntilSocketCreated(deps.createdSockets);
+      const socket = deps.createdSockets[0];
+      socket?.simulateOpen();
+      await resultPromise;
+      expect(socket?.sentMessages.length).toBeGreaterThan(0);
+      const first = socket?.sentMessages[0] ?? '';
+      const parsed: unknown = JSON.parse(first);
+      expect(parsed).toMatchObject({
+        eventType: 'session.start',
+        sessionId: SESSION_ID,
+        payload: {
+          sourceLanguage: 'en-US',
+          targetLanguage: 'ja-JP',
+        },
+      });
+    });
+
+    it('propagates tokenIssuer failure as DomainError', async () => {
+      const deps = buildDependencies({
+        tokenIssuer: () =>
+          errAsync(
+            invariantViolationError({
+              invariant: 'token-issuance-failed',
+              details: 'http 401',
+            }),
+          ),
+      });
+      const gateway = createRelayWebSocketGateway(deps);
+      const result = await gateway.openSession(buildSession());
+      expect(result.isErr()).toBe(true);
+      expect(deps.createdSockets).toHaveLength(0);
+    });
+  });
+
+  describe('sendAudioFrame', () => {
+    it('sends audio.frame envelope with pcm16Base64 payload', async () => {
+      const deps = buildDependencies();
+      const gateway = createRelayWebSocketGateway(deps);
+      const openPromise = gateway.openSession(buildSession());
+      await flushUntilSocketCreated(deps.createdSockets);
+      deps.createdSockets[0]?.simulateOpen();
+      await openPromise;
+
+      const result = await gateway.sendAudioFrame({
+        sessionIdentifier,
+        sequenceNumber: 5,
+        sampleRate: 16000,
+        channels: 1,
+        pcm16Base64: 'AAABAAIAAwA=',
+        capturedAt: '2026-04-21T00:00:01.000Z',
+        durationMs: 100,
+      });
+      expect(result.isOk()).toBe(true);
+      const sent = deps.createdSockets[0]?.sentMessages ?? [];
+      const last: unknown = JSON.parse(sent[sent.length - 1] ?? '{}');
+      expect(last).toMatchObject({
+        eventType: 'audio.frame',
+        sessionId: SESSION_ID,
+        payload: {
+          audioBase64: 'AAABAAIAAwA=',
+          encoding: 'pcm_s16le',
+          sampleRateHz: 16000,
+          channels: 1,
+          frameDurationMs: 100,
+        },
+      });
+    });
+
+    it('fails when no session has been opened yet', async () => {
+      const deps = buildDependencies();
+      const gateway = createRelayWebSocketGateway(deps);
+      const result = await gateway.sendAudioFrame({
+        sessionIdentifier,
+        sequenceNumber: 1,
+        sampleRate: 16000,
+        channels: 1,
+        pcm16Base64: 'AAA=',
+        capturedAt: '2026-04-21T00:00:00.000Z',
+        durationMs: 100,
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('subscribe', () => {
+    it('dispatches parsed RelayEvents to registered listeners', async () => {
+      const deps = buildDependencies();
+      const gateway = createRelayWebSocketGateway(deps);
+      const openPromise = gateway.openSession(buildSession());
+      await flushUntilSocketCreated(deps.createdSockets);
+      deps.createdSockets[0]?.simulateOpen();
+      await openPromise;
+
+      const received: RelayEvent[] = [];
+      const unsubscribe = gateway.subscribe(sessionIdentifier, (event) => {
+        received.push(event);
+      });
+
+      deps.createdSockets[0]?.simulateMessage(
+        JSON.stringify({
+          eventType: 'session.ready',
+          sessionId: SESSION_ID,
+          sequence: 1,
+          timestamp: '2026-04-21T00:00:00.500Z',
+          payload: { state: 'capturing', heartbeatIntervalSec: 15, streamToken: 'tok' },
+        }),
+      );
+
+      expect(received).toHaveLength(1);
+      expect(received[0]?.type).toBe('session.ready');
+      unsubscribe();
+
+      deps.createdSockets[0]?.simulateMessage(
+        JSON.stringify({
+          eventType: 'session.ready',
+          sessionId: SESSION_ID,
+          sequence: 2,
+          timestamp: '2026-04-21T00:00:01.000Z',
+          payload: { state: 'capturing', heartbeatIntervalSec: 15, streamToken: 'tok2' },
+        }),
+      );
+      expect(received).toHaveLength(1);
+    });
+
+    it('ignores session.pong messages (heartbeat response)', async () => {
+      const deps = buildDependencies();
+      const gateway = createRelayWebSocketGateway(deps);
+      const openPromise = gateway.openSession(buildSession());
+      await flushUntilSocketCreated(deps.createdSockets);
+      deps.createdSockets[0]?.simulateOpen();
+      await openPromise;
+
+      const received: RelayEvent[] = [];
+      gateway.subscribe(sessionIdentifier, (event) => {
+        received.push(event);
+      });
+
+      deps.createdSockets[0]?.simulateMessage(
+        JSON.stringify({
+          eventType: 'session.pong',
+          sessionId: SESSION_ID,
+          sequence: 0,
+          timestamp: '2026-04-21T00:00:15.000Z',
+          payload: {},
+        }),
+      );
+      expect(received).toHaveLength(0);
+    });
+  });
+
+  describe('closeSession', () => {
+    it('closes the socket and sends session.stop envelope', async () => {
+      const deps = buildDependencies();
+      const gateway = createRelayWebSocketGateway(deps);
+      const openPromise = gateway.openSession(buildSession());
+      await flushUntilSocketCreated(deps.createdSockets);
+      deps.createdSockets[0]?.simulateOpen();
+      await openPromise;
+
+      const result = await gateway.closeSession(sessionIdentifier);
+      expect(result.isOk()).toBe(true);
+      expect(deps.createdSockets[0]?.isClosed).toBe(true);
+      const sent = deps.createdSockets[0]?.sentMessages ?? [];
+      const stopEnvelope = sent.find((s) => s.includes('session.stop'));
+      expect(stopEnvelope).toBeDefined();
+    });
+
+    it('is a no-op when session was never opened', async () => {
+      const deps = buildDependencies();
+      const gateway = createRelayWebSocketGateway(deps);
+      const result = await gateway.closeSession(sessionIdentifier);
+      expect(result.isOk()).toBe(true);
+    });
+  });
+});

--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
@@ -1,0 +1,257 @@
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+import {
+  describeDomainError,
+  invariantViolationError,
+  type DomainError,
+} from '../../domain/shared/errors';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type SourceSession } from '../../domain/session/source-session';
+import { type AudioFrameEnvelope } from '../../application/ports/audio-preprocessor';
+import {
+  type RelayEventListener,
+  type RelayGateway,
+  type Unsubscribe,
+} from '../../application/ports/relay-gateway';
+import { parseRelayServerMessage } from './relay-event-mapper';
+import { type WebSocketFactory, type WebSocketLike } from './websocket-factory';
+
+/**
+ * Stream token 発行器。`POST /sessions` 経由で Relay API から短命トークンを
+ * 取得する HTTP クライアントを注入する。production entrypoint で
+ * 実装を渡す (test では okAsync で mock)。
+ */
+export type StreamTokenIssuer = (session: SourceSession) => ResultAsync<string, DomainError>;
+
+export type RelayWebSocketGatewayDependencies = Readonly<{
+  webSocketFactory: WebSocketFactory;
+  tokenIssuer: StreamTokenIssuer;
+  clock: () => number;
+  wsEndpointBuilder: (sessionIdentifier: SessionIdentifier, streamToken: string) => string;
+  /**
+   * ハートビート間隔 (ms)。default 15000 (api-specification.md §2.6 準拠)。
+   * 定数なので default を許容 (mock ではない)。
+   */
+  heartbeatIntervalMs?: number;
+}>;
+
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 15000 as const;
+
+type SessionConnection = {
+  socket: WebSocketLike;
+  sequence: number;
+  listeners: Set<RelayEventListener>;
+  heartbeatTimer: ReturnType<typeof setInterval> | null;
+};
+
+const toIsoString = (clock: () => number): string => new Date(clock()).toISOString();
+
+const buildEnvelope = (
+  eventType: string,
+  sessionIdentifier: SessionIdentifier,
+  sequence: number,
+  timestamp: string,
+  payload: Record<string, unknown>,
+): string =>
+  JSON.stringify({
+    eventType,
+    sessionId: sessionIdentifier,
+    sequence,
+    timestamp,
+    payload,
+  });
+
+const logWarn =
+  (scope: string) =>
+  (error: DomainError): void => {
+    console.warn(`[relay-gateway] ${scope} failed:`, describeDomainError(error));
+  };
+
+/**
+ * IMPL-320 RelayWebSocketGateway (DD-105 / DD-411)。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - `webSocketFactory` / `tokenIssuer` / `wsEndpointBuilder` / `clock` は
+ *   **必須引数** (default なし)。production entrypoint で
+ *   `createBrowserWebSocketFactory()` と実 HTTP クライアントを明示注入
+ * - `heartbeatIntervalMs` のみ定数の default を許容 (mock ではない)
+ *
+ * ハートビート: 15 秒間隔で `session.ping` 送信。Relay からの `session.pong` は
+ * `RelayEventMapper` が null として落とし、listener には届かない。
+ *
+ * NOTE: MVP スコープの simplification:
+ * - 再接続ロジック (指数バックオフ) は現状未実装。上位 UseCase 層で
+ *   `openSession` を再呼び出しする形で最低限の回復を達成できる
+ * - サーキットブレーカーは acl.md §6 に従い後続タスクで導入
+ */
+export const createRelayWebSocketGateway = (
+  deps: RelayWebSocketGatewayDependencies,
+): RelayGateway => {
+  const heartbeatMs = deps.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const connections = new Map<SessionIdentifier, SessionConnection>();
+
+  const dispatchMessage = (sessionIdentifier: SessionIdentifier, data: string): void => {
+    const connection = connections.get(sessionIdentifier);
+    if (connection === undefined) return;
+    const parseResult = parseRelayServerMessage(data);
+    if (parseResult.isErr()) {
+      logWarn('message-parse')(parseResult.error);
+      return;
+    }
+    if (parseResult.value === null) return; // session.pong, silently drop
+    for (const listener of connection.listeners) {
+      listener(parseResult.value);
+    }
+  };
+
+  const startHeartbeat = (
+    sessionIdentifier: SessionIdentifier,
+    connection: SessionConnection,
+  ): void => {
+    connection.heartbeatTimer = setInterval(() => {
+      if (connection.socket.readyState !== 1) return;
+      connection.socket.send(
+        buildEnvelope(
+          'session.ping',
+          sessionIdentifier,
+          connection.sequence++,
+          toIsoString(deps.clock),
+          {},
+        ),
+      );
+    }, heartbeatMs);
+  };
+
+  return {
+    openSession: (session) =>
+      deps.tokenIssuer(session).andThen(
+        (streamToken): ResultAsync<void, DomainError> =>
+          ResultAsync.fromPromise<void, DomainError>(
+            new Promise<void>((resolve, reject) => {
+              const url = deps.wsEndpointBuilder(session.sessionIdentifier, streamToken);
+              const socket = deps.webSocketFactory(url);
+
+              const onOpen = (): void => {
+                socket.removeEventListener('open', onOpen);
+                const sequence = 0;
+                socket.send(
+                  buildEnvelope(
+                    'session.start',
+                    session.sessionIdentifier,
+                    sequence,
+                    toIsoString(deps.clock),
+                    {
+                      sourceLanguage: session.languagePair.source,
+                      targetLanguage: session.languagePair.target,
+                      translationEnabled: true,
+                    },
+                  ),
+                );
+                const connection: SessionConnection = {
+                  socket,
+                  sequence: sequence + 1,
+                  listeners: new Set(),
+                  heartbeatTimer: null,
+                };
+                socket.addEventListener('message', (event) => {
+                  if (event instanceof MessageEvent && typeof event.data === 'string') {
+                    dispatchMessage(session.sessionIdentifier, event.data);
+                  }
+                });
+                startHeartbeat(session.sessionIdentifier, connection);
+                connections.set(session.sessionIdentifier, connection);
+                resolve();
+              };
+              socket.addEventListener('open', onOpen);
+              socket.addEventListener('error', () => {
+                reject(new Error('WebSocket error before open'));
+              });
+            }),
+            (cause) =>
+              invariantViolationError({
+                invariant: 'relay-handshake-failed',
+                details: cause instanceof Error ? cause.message : 'unknown error',
+              }),
+          ),
+      ),
+
+    sendAudioFrame: (frame: AudioFrameEnvelope) => {
+      const connection = connections.get(frame.sessionIdentifier);
+      if (connection === undefined) {
+        return errAsync<void, DomainError>(
+          invariantViolationError({
+            invariant: 'relay-no-active-session',
+            details: `sendAudioFrame called before openSession for ${frame.sessionIdentifier}`,
+          }),
+        );
+      }
+      if (connection.socket.readyState !== 1) {
+        return errAsync<void, DomainError>(
+          invariantViolationError({
+            invariant: 'relay-socket-not-open',
+            details: `socket readyState=${String(connection.socket.readyState)}`,
+          }),
+        );
+      }
+      const payload = {
+        chunkId: `chk_${String(frame.sequenceNumber).padStart(6, '0')}`,
+        audioBase64: frame.pcm16Base64,
+        encoding: 'pcm_s16le',
+        sampleRateHz: frame.sampleRate,
+        channels: frame.channels,
+        frameDurationMs: frame.durationMs,
+        capturedAt: frame.capturedAt,
+      };
+      connection.socket.send(
+        buildEnvelope(
+          'audio.frame',
+          frame.sessionIdentifier,
+          connection.sequence++,
+          toIsoString(deps.clock),
+          payload,
+        ),
+      );
+      return okAsync(undefined);
+    },
+
+    closeSession: (sessionIdentifier) => {
+      const connection = connections.get(sessionIdentifier);
+      if (connection === undefined) return okAsync(undefined);
+      if (connection.heartbeatTimer !== null) clearInterval(connection.heartbeatTimer);
+      if (connection.socket.readyState === 1) {
+        connection.socket.send(
+          buildEnvelope(
+            'session.stop',
+            sessionIdentifier,
+            connection.sequence++,
+            toIsoString(deps.clock),
+            { reason: 'user_requested' },
+          ),
+        );
+      }
+      connection.socket.close(1000, 'normal closure');
+      connections.delete(sessionIdentifier);
+      return okAsync(undefined);
+    },
+
+    subscribe: (sessionIdentifier, listener): Unsubscribe => {
+      let connection = connections.get(sessionIdentifier);
+      if (connection === undefined) {
+        // Register a "pending" connection placeholder. When openSession runs
+        // for this identifier, it will replace this entry but listeners will
+        // need to be re-registered. To keep the API simple, we require
+        // subscribe to be called *after* openSession completes (per the port
+        // contract — subscribe docs assume an active session).
+        // For safety, attach to a detached listener set that gets discarded.
+        const detached = new Set<RelayEventListener>([listener]);
+        return () => {
+          detached.delete(listener);
+        };
+      }
+      connection.listeners.add(listener);
+      return () => {
+        connection = connections.get(sessionIdentifier);
+        connection?.listeners.delete(listener);
+      };
+    },
+  };
+};

--- a/packages/extension/src/infrastructure/relay/websocket-factory.ts
+++ b/packages/extension/src/infrastructure/relay/websocket-factory.ts
@@ -1,0 +1,33 @@
+/**
+ * WebSocket 生成を抽象化する factory type と、production 用の実装。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - `createRelayWebSocketGateway` は `WebSocketFactory` を必須 DI として取り、
+ *   default を持たない
+ * - production entrypoint (Service Worker / Background) で
+ *   `createBrowserWebSocketFactory()` を明示的に呼び、その戻り値を渡す
+ * - test では自前の mock factory を渡す
+ * - この分離により、呼び出し忘れで mock が production で走る事故を防ぐ
+ */
+
+/**
+ * 最小 WebSocket contract。ブラウザ native `WebSocket` も test mock も
+ * 同じ形で使えるよう、必要メソッドのみを列挙。
+ */
+export type WebSocketLike = {
+  readonly readyState: number;
+  send: (data: string) => void;
+  close: (code?: number, reason?: string) => void;
+  addEventListener: (type: string, listener: (event: Event) => void) => void;
+  removeEventListener: (type: string, listener: (event: Event) => void) => void;
+};
+
+export type WebSocketFactory = (url: string) => WebSocketLike;
+
+/**
+ * Production の WebSocket factory。呼び出し元 (entrypoint) は本関数で生成した
+ * factory を DI として `createRelayWebSocketGateway` に渡す。
+ */
+export const createBrowserWebSocketFactory = (): WebSocketFactory => {
+  return (url) => new WebSocket(url);
+};

--- a/packages/extension/src/infrastructure/storage/chrome-local-settings-store.ts
+++ b/packages/extension/src/infrastructure/storage/chrome-local-settings-store.ts
@@ -64,9 +64,7 @@ const writeRaw = (
  * - chrome.storage I/O 失敗: `invariantViolationError({ invariant:
  *   'chrome-storage-access' })`
  */
-export const createChromeLocalSettingsStore = (
-  adapter: ChromeStorageAdapter = defaultChromeStorageAdapter,
-): SettingsStore => {
+export const createChromeLocalSettingsStore = (adapter: ChromeStorageAdapter): SettingsStore => {
   return {
     getDefaultLanguagePair: () =>
       readRaw(adapter, LANGUAGE_KEY).andThen((raw): ResultAsync<LanguagePair, DomainError> => {


### PR DESCRIPTION
## Summary

Phase 3 §5.3 通信層を TDD で実装。WebSocket / Event mapper / 翻訳 Cache を **本番 mock 混入を防ぐ必須 DI パターン** で構築。併せて PR #20 の `ChromeLocalSettingsStore` の default parameter を排除して、同方針を全 infrastructure に徹底。

### 実装

- **IMPL-321 RelayEventMapper** (DD-411) — `parseRelayServerMessage` で Zod validate + `RelayEvent` discriminated union 変換。`session.pong` は `ok(null)` (listener 対象外)
- **IMPL-322 InMemoryTranslationCache** (DD-133) — TTL 30 秒、`clock` 必須 DI
- **IMPL-320 RelayWebSocketGateway** (DD-105/DD-411) — WebSocket 接続 / sendAudioFrame / subscribe / closeSession / ハートビート 15s。全依存を必須 DI

### 本番 mock 混入防止の設計

- **全 factory で adapter / factory / clock / issuer を必須引数**に (default なし)
- production helper は別 module で提供:
  - `createBrowserWebSocketFactory()` (`websocket-factory.ts`)
  - `defaultChromeStorageAdapter` (`chrome-local-settings-store.ts`)
- entrypoint で明示的に DI を組み立てる (呼び忘れで mock が使われる事故を防止)
- default が許容されるのは **仕様定数のみ** (TTL 30s / ハートビート 15s)

### ChromeLocalSettingsStore の修正 (retroactive)

- Before: `createChromeLocalSettingsStore(adapter = defaultChromeStorageAdapter)`
- After:  `createChromeLocalSettingsStore(adapter)` — adapter 必須

### base branch

PR #20 (Phase 3 Storage) に stacked。

## Test plan

- [x] 518 tests pass (+28 新規: mapper 11 + cache 8 + gateway 9)
- [x] `pnpm check` 全緑
- [ ] CI `All Green` → auto merge

## Phase 3 進捗

- §5.2 Storage ✅ (PR #20)
- §5.3 Communication ✅ (本 PR)
- 次: §5.1 音声取得 (IMPL-300-303) / §5.4 表示 (IMPL-330) / §5.5 統括 (IMPL-340-344)