### PR TITLE
feat(infrastructure): IMPL-300/301/302/303 capture adapters + audio preprocessor

### DIFF
--- a/packages/extension/src/infrastructure/audio/audio-preprocessor.test.ts
+++ b/packages/extension/src/infrastructure/audio/audio-preprocessor.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import {
+  createAudioPreprocessor,
+  type AudioContextFactory,
+  type AudioContextLike,
+} from './audio-preprocessor';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+type MockContext = AudioContextLike & {
+  close: ReturnType<typeof vi.fn<AudioContextLike['close']>>;
+  audioWorklet: { addModule: ReturnType<typeof vi.fn<(url: string) => Promise<void>>> };
+  createMediaStreamSource: ReturnType<typeof vi.fn<AudioContextLike['createMediaStreamSource']>>;
+};
+
+const createMockContext = (): MockContext => {
+  const ctx: MockContext = {
+    sampleRate: 16000,
+    audioWorklet: {
+      addModule: vi.fn((_url: string) => Promise.resolve()),
+    },
+    close: vi.fn(() => Promise.resolve()),
+    createMediaStreamSource: vi.fn((_stream: MediaStream) => ({
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    })),
+  };
+  return ctx;
+};
+
+const buildFactory = (
+  context: AudioContextLike,
+): AudioContextFactory & ReturnType<typeof vi.fn<AudioContextFactory>> => {
+  return vi.fn<AudioContextFactory>(() => context);
+};
+
+describe('createAudioPreprocessor (IMPL-303, DD-104)', () => {
+  it('constructs an AudioContext via the injected factory at 16kHz', async () => {
+    const ctx = createMockContext();
+    const factory = buildFactory(ctx);
+    const preprocessor = createAudioPreprocessor({
+      audioContextFactory: factory,
+      workletModuleUrl: 'https://example/audio-worklet.js',
+      clock: () => 0,
+    });
+
+    const stream = new MediaStream();
+    const result = await preprocessor.attach(stream, sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    expect(factory).toHaveBeenCalledTimes(1);
+    const options = factory.mock.calls[0]?.[0];
+    expect(options).toMatchObject({ sampleRate: 16000 });
+  });
+
+  it('loads the AudioWorklet module from the injected URL', async () => {
+    const ctx = createMockContext();
+    const preprocessor = createAudioPreprocessor({
+      audioContextFactory: buildFactory(ctx),
+      workletModuleUrl: 'https://example/audio-worklet.js',
+      clock: () => 0,
+    });
+    await preprocessor.attach(new MediaStream(), sessionIdentifier);
+    expect(ctx.audioWorklet.addModule).toHaveBeenCalledWith('https://example/audio-worklet.js');
+  });
+
+  it('returns invariantViolationError when addModule rejects', async () => {
+    const ctx = createMockContext();
+    ctx.audioWorklet.addModule.mockRejectedValue(new Error('module load failed'));
+    const preprocessor = createAudioPreprocessor({
+      audioContextFactory: buildFactory(ctx),
+      workletModuleUrl: 'https://example/audio-worklet.js',
+      clock: () => 0,
+    });
+    const result = await preprocessor.attach(new MediaStream(), sessionIdentifier);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+  });
+
+  it('attach returns an AudioFrameChannel with AsyncIterable frames', async () => {
+    const ctx = createMockContext();
+    const preprocessor = createAudioPreprocessor({
+      audioContextFactory: buildFactory(ctx),
+      workletModuleUrl: 'https://example/worklet.js',
+      clock: () => 0,
+    });
+    const result = await preprocessor.attach(new MediaStream(), sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(typeof result.value.close).toBe('function');
+      expect(Symbol.asyncIterator in result.value.frames).toBe(true);
+    }
+  });
+
+  it('detach closes the AudioContext', async () => {
+    const ctx = createMockContext();
+    const preprocessor = createAudioPreprocessor({
+      audioContextFactory: buildFactory(ctx),
+      workletModuleUrl: 'https://example/worklet.js',
+      clock: () => 0,
+    });
+    await preprocessor.attach(new MediaStream(), sessionIdentifier);
+    const result = await preprocessor.detach(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    expect(ctx.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('detach is a no-op when session was never attached', async () => {
+    const ctx = createMockContext();
+    const preprocessor = createAudioPreprocessor({
+      audioContextFactory: buildFactory(ctx),
+      workletModuleUrl: 'https://example/worklet.js',
+      clock: () => 0,
+    });
+    const result = await preprocessor.detach(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    expect(ctx.close).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/src/infrastructure/audio/audio-preprocessor.ts
+++ b/packages/extension/src/infrastructure/audio/audio-preprocessor.ts
@@ -1,0 +1,115 @@
+import { ResultAsync, okAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import {
+  type AudioFrameChannel,
+  type AudioPreprocessor,
+} from '../../application/ports/audio-preprocessor';
+
+/**
+ * AudioContext の最小 contract。実装側で必要な property のみを列挙。
+ * production の `AudioContext` は本 interface を structurally に満たす。
+ */
+export type AudioContextLike = {
+  readonly sampleRate: number;
+  readonly audioWorklet: {
+    addModule: (url: string) => Promise<void>;
+  };
+  close: () => Promise<void>;
+  createMediaStreamSource: (stream: MediaStream) => unknown;
+};
+
+export type AudioContextFactory = (options?: AudioContextOptions) => AudioContextLike;
+
+/**
+ * Production `AudioContextFactory` (mock ではない)。entrypoint で
+ * `{ audioContextFactory: defaultAudioContextFactory }` として明示注入。
+ */
+export const defaultAudioContextFactory: AudioContextFactory = (options) =>
+  new AudioContext(options);
+
+export type AudioPreprocessorDependencies = Readonly<{
+  audioContextFactory: AudioContextFactory;
+  /** AudioWorklet module の URL (通常は `chrome.runtime.getURL('/audio-worklet.js')`) */
+  workletModuleUrl: string;
+  clock: () => number;
+}>;
+
+/**
+ * 空の AsyncIterable を返すシンプルな channel。実際の PCM フレーム生成は
+ * AudioWorklet 内で行い、本 MVP の unit test では動作確認対象外。
+ * E2E / manual test で production 挙動を確認する。
+ */
+const createEmptyFrameChannel = (context: AudioContextLike): AudioFrameChannel => {
+  let closed = false;
+  return {
+    frames: {
+      [Symbol.asyncIterator]: () => ({
+        next: () =>
+          Promise.resolve<IteratorResult<never>>({
+            done: true,
+            value: undefined,
+          }),
+      }),
+    },
+    close: () => {
+      if (closed) return;
+      closed = true;
+      void context.close();
+    },
+  };
+};
+
+/**
+ * IMPL-303 AudioPreprocessor (DD-104)。
+ *
+ * `MediaStream` を受け取り AudioContext 16kHz で AudioWorklet をロードし、
+ * PCM16 モノラル 100ms フレームを `AudioFrameChannel` で配信する。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - `audioContextFactory` / `workletModuleUrl` / `clock` は全て必須 DI
+ *   (default なし)
+ * - production entrypoint で `defaultAudioContextFactory` と
+ *   `chrome.runtime.getURL('/audio-worklet.js')` を明示的に渡す
+ *
+ * NOTE: MVP スコープでは AudioWorklet 内部の PCM 処理は content script 側の
+ * `audio-worklet.js` (別モジュール) に委譲し、本 factory では AudioContext の
+ * ライフサイクル管理と worklet module のロード、channel 提供のみを扱う。
+ * 実際のフレーム生成は E2E で検証する。
+ */
+export const createAudioPreprocessor = (deps: AudioPreprocessorDependencies): AudioPreprocessor => {
+  const contexts = new Map<SessionIdentifier, AudioContextLike>();
+
+  return {
+    attach: (stream, sessionIdentifier) =>
+      ResultAsync.fromPromise<AudioFrameChannel, DomainError>(
+        (async () => {
+          const context = deps.audioContextFactory({ sampleRate: 16000 });
+          await context.audioWorklet.addModule(deps.workletModuleUrl);
+          // 本 MVP では MediaStreamAudioSourceNode → AudioWorkletNode の
+          // 接続確認のみ; worklet 側の `postMessage(frame)` によるフレーム
+          // 生成は `audio-worklet.js` で実装される (E2E 対象)
+          context.createMediaStreamSource(stream);
+          contexts.set(sessionIdentifier, context);
+          return createEmptyFrameChannel(context);
+        })(),
+        (cause) =>
+          invariantViolationError({
+            invariant: 'audio-preprocessor-attach-failed',
+            details: cause instanceof Error ? cause.message : 'unknown error',
+          }),
+      ),
+
+    detach: (sessionIdentifier) => {
+      const context = contexts.get(sessionIdentifier);
+      if (context === undefined) return okAsync(undefined);
+      contexts.delete(sessionIdentifier);
+      return ResultAsync.fromPromise<void, DomainError>(context.close(), (cause) =>
+        invariantViolationError({
+          invariant: 'audio-preprocessor-detach-failed',
+          details: cause instanceof Error ? cause.message : 'unknown error',
+        }),
+      );
+    },
+  };
+};

--- a/packages/extension/src/infrastructure/audio/index.ts
+++ b/packages/extension/src/infrastructure/audio/index.ts
@@ -1,0 +1,7 @@
+export {
+  createAudioPreprocessor,
+  defaultAudioContextFactory,
+  type AudioContextFactory,
+  type AudioContextLike,
+  type AudioPreprocessorDependencies,
+} from './audio-preprocessor';

--- a/packages/extension/src/infrastructure/capture/desktop-capture-source-adapter.test.ts
+++ b/packages/extension/src/infrastructure/capture/desktop-capture-source-adapter.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { type StartSourceCommand } from '../../application/ports/source-adapter';
+import { addFakeTrack } from '../../../tests/helpers/media-stream';
+import {
+  createDesktopCaptureSourceAdapter,
+  type DesktopCaptureApi,
+} from './desktop-capture-source-adapter';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const buildCommand = (): StartSourceCommand => ({
+  sourceType: 'desktop',
+  sessionIdentifier,
+});
+
+const buildApi = (): DesktopCaptureApi & {
+  getDisplayMedia: ReturnType<typeof vi.fn<DesktopCaptureApi['getDisplayMedia']>>;
+} => {
+  const stream = new MediaStream();
+  const getDisplayMedia = vi.fn<DesktopCaptureApi['getDisplayMedia']>(() =>
+    Promise.resolve(stream),
+  );
+  return { getDisplayMedia };
+};
+
+describe('createDesktopCaptureSourceAdapter (IMPL-302, DD-103)', () => {
+  it('captures via getDisplayMedia with audio enabled', async () => {
+    const api = buildApi();
+    const adapter = createDesktopCaptureSourceAdapter({ desktopCaptureApi: api });
+    const result = await adapter.open(buildCommand());
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBeInstanceOf(MediaStream);
+    const constraints = api.getDisplayMedia.mock.calls[0]?.[0];
+    expect(constraints).toMatchObject({ audio: true });
+  });
+
+  it('rejects a non-desktop command', async () => {
+    const api = buildApi();
+    const adapter = createDesktopCaptureSourceAdapter({ desktopCaptureApi: api });
+    const result = await adapter.open({
+      sourceType: 'tab',
+      sessionIdentifier,
+      tabId: 1,
+    });
+    expect(result.isErr()).toBe(true);
+    expect(api.getDisplayMedia).not.toHaveBeenCalled();
+  });
+
+  it('returns invariant-violation when getDisplayMedia rejects', async () => {
+    const api: DesktopCaptureApi = {
+      getDisplayMedia: () => Promise.reject(new Error('NotAllowedError')),
+    };
+    const adapter = createDesktopCaptureSourceAdapter({ desktopCaptureApi: api });
+    const result = await adapter.open(buildCommand());
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+  });
+
+  it('close stops tracks on the captured stream', async () => {
+    const stop = vi.fn();
+    const stream = new MediaStream();
+    addFakeTrack(stream, { stop });
+    const api: DesktopCaptureApi = { getDisplayMedia: () => Promise.resolve(stream) };
+    const adapter = createDesktopCaptureSourceAdapter({ desktopCaptureApi: api });
+    await adapter.open(buildCommand());
+    const result = await adapter.close(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('close is a no-op when session was never opened', async () => {
+    const api = buildApi();
+    const adapter = createDesktopCaptureSourceAdapter({ desktopCaptureApi: api });
+    const result = await adapter.close(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+  });
+});

--- a/packages/extension/src/infrastructure/capture/desktop-capture-source-adapter.ts
+++ b/packages/extension/src/infrastructure/capture/desktop-capture-source-adapter.ts
@@ -1,0 +1,94 @@
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import {
+  type SourceAdapter,
+  type StartSourceCommand,
+} from '../../application/ports/source-adapter';
+
+/**
+ * `navigator.mediaDevices.getDisplayMedia` を抽象化した adapter。
+ * production では default 実装、test では mock を注入する。
+ *
+ * `getDisplayMedia` は browser 側が source (screen / window / tab) 選択の
+ * prompt を表示する。MV3 の `chrome.desktopCapture.chooseDesktopMedia` は
+ * 拡張 background からの低レベル API だが、本 MVP では getDisplayMedia
+ * のみを使用 (content script / offscreen document 側の簡潔性優先)。
+ */
+export type DesktopCaptureApi = {
+  getDisplayMedia: (constraints: DisplayMediaStreamOptions) => Promise<MediaStream>;
+};
+
+/**
+ * Production `DesktopCaptureApi` 実装 (mock ではない)。
+ */
+export const defaultDesktopCaptureApi: DesktopCaptureApi = {
+  getDisplayMedia: (constraints) => navigator.mediaDevices.getDisplayMedia(constraints),
+};
+
+export type DesktopCaptureSourceAdapterDependencies = Readonly<{
+  desktopCaptureApi: DesktopCaptureApi;
+}>;
+
+const hasStopMethod = (value: unknown): value is { stop: () => void } => {
+  if (typeof value !== 'object' || value === null) return false;
+  const stop: unknown = Reflect.get(value, 'stop');
+  return typeof stop === 'function';
+};
+
+const stopAllTracks = (stream: MediaStream): void => {
+  for (const track of stream.getTracks()) {
+    if (hasStopMethod(track)) {
+      track.stop();
+    }
+  }
+};
+
+/**
+ * IMPL-302 DesktopCaptureSourceAdapter (DD-103)。
+ *
+ * 入力ソース `desktop` 用 `SourceAdapter` 実装。audio capture を主目的と
+ * するが、`getDisplayMedia` は video を伴う場合があるため `video: true` を
+ * 指定して成功率を上げる (取得後に audio track のみ使用)。
+ */
+export const createDesktopCaptureSourceAdapter = (
+  deps: DesktopCaptureSourceAdapterDependencies,
+): SourceAdapter => {
+  const openStreams = new Map<SessionIdentifier, MediaStream>();
+
+  return {
+    open: (command: StartSourceCommand) => {
+      if (command.sourceType !== 'desktop') {
+        return errAsync<MediaStream, DomainError>(
+          invariantViolationError({
+            invariant: 'desktop-capture-source-mismatch',
+            details: `expected desktop, received ${command.sourceType}`,
+          }),
+        );
+      }
+      const constraints: DisplayMediaStreamOptions = {
+        audio: true,
+        video: true,
+      };
+      return ResultAsync.fromPromise<MediaStream, DomainError>(
+        deps.desktopCaptureApi.getDisplayMedia(constraints),
+        (cause) =>
+          invariantViolationError({
+            invariant: 'desktop-capture-failed',
+            details: cause instanceof Error ? cause.message : 'unknown error',
+          }),
+      ).map((stream) => {
+        openStreams.set(command.sessionIdentifier, stream);
+        return stream;
+      });
+    },
+
+    close: (sessionIdentifier) => {
+      const stream = openStreams.get(sessionIdentifier);
+      if (stream === undefined) return okAsync(undefined);
+      stopAllTracks(stream);
+      openStreams.delete(sessionIdentifier);
+      return okAsync(undefined);
+    },
+  };
+};

--- a/packages/extension/src/infrastructure/capture/index.ts
+++ b/packages/extension/src/infrastructure/capture/index.ts
@@ -1,0 +1,22 @@
+export {
+  createDesktopCaptureSourceAdapter,
+  defaultDesktopCaptureApi,
+  type DesktopCaptureApi,
+  type DesktopCaptureSourceAdapterDependencies,
+} from './desktop-capture-source-adapter';
+export {
+  createSourceAdapterFactory,
+  type SourceAdapterFactoryDependencies,
+} from './source-adapter-factory';
+export {
+  createTabCaptureSourceAdapter,
+  defaultTabCaptureApi,
+  type TabCaptureApi,
+  type TabCaptureSourceAdapterDependencies,
+} from './tab-capture-source-adapter';
+export {
+  createUserMediaSourceAdapter,
+  defaultUserMediaApi,
+  type UserMediaApi,
+  type UserMediaSourceAdapterDependencies,
+} from './user-media-source-adapter';

--- a/packages/extension/src/infrastructure/capture/source-adapter-factory.test.ts
+++ b/packages/extension/src/infrastructure/capture/source-adapter-factory.test.ts
@@ -1,0 +1,47 @@
+import { okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { type SourceAdapter } from '../../application/ports/source-adapter';
+import { createSourceAdapterFactory } from './source-adapter-factory';
+
+const noopAdapter = (): SourceAdapter => ({
+  open: () => okAsync(new MediaStream()),
+  close: () => okAsync(undefined),
+});
+
+describe('createSourceAdapterFactory (IMPL-341 subset — DI routing)', () => {
+  it('returns the tab adapter for sourceType=tab', () => {
+    const tab = noopAdapter();
+    const mic = noopAdapter();
+    const desktop = noopAdapter();
+    const factory = createSourceAdapterFactory({
+      tabCaptureSourceAdapter: tab,
+      userMediaSourceAdapter: mic,
+      desktopCaptureSourceAdapter: desktop,
+    });
+    expect(factory.create('tab')).toBe(tab);
+  });
+
+  it('returns the microphone adapter for sourceType=microphone', () => {
+    const tab = noopAdapter();
+    const mic = noopAdapter();
+    const desktop = noopAdapter();
+    const factory = createSourceAdapterFactory({
+      tabCaptureSourceAdapter: tab,
+      userMediaSourceAdapter: mic,
+      desktopCaptureSourceAdapter: desktop,
+    });
+    expect(factory.create('microphone')).toBe(mic);
+  });
+
+  it('returns the desktop adapter for sourceType=desktop', () => {
+    const tab = noopAdapter();
+    const mic = noopAdapter();
+    const desktop = noopAdapter();
+    const factory = createSourceAdapterFactory({
+      tabCaptureSourceAdapter: tab,
+      userMediaSourceAdapter: mic,
+      desktopCaptureSourceAdapter: desktop,
+    });
+    expect(factory.create('desktop')).toBe(desktop);
+  });
+});

--- a/packages/extension/src/infrastructure/capture/source-adapter-factory.ts
+++ b/packages/extension/src/infrastructure/capture/source-adapter-factory.ts
@@ -1,0 +1,36 @@
+import {
+  type SourceAdapter,
+  type SourceAdapterFactory,
+} from '../../application/ports/source-adapter';
+
+/**
+ * SourceAdapterFactory の実装。3 種類の `SourceAdapter` (tab / microphone /
+ * desktop) を必須 DI で受け取り、`sourceType` に応じたアダプタを返す。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - 3 adapter は全て必須引数 (default なし)
+ * - production entrypoint で `createTabCaptureSourceAdapter` 等を組み立て、
+ *   その結果を本 factory に渡す
+ */
+export type SourceAdapterFactoryDependencies = Readonly<{
+  tabCaptureSourceAdapter: SourceAdapter;
+  userMediaSourceAdapter: SourceAdapter;
+  desktopCaptureSourceAdapter: SourceAdapter;
+}>;
+
+export const createSourceAdapterFactory = (
+  deps: SourceAdapterFactoryDependencies,
+): SourceAdapterFactory => {
+  return {
+    create: (sourceType) => {
+      switch (sourceType) {
+        case 'tab':
+          return deps.tabCaptureSourceAdapter;
+        case 'microphone':
+          return deps.userMediaSourceAdapter;
+        case 'desktop':
+          return deps.desktopCaptureSourceAdapter;
+      }
+    },
+  };
+};

--- a/packages/extension/src/infrastructure/capture/tab-capture-source-adapter.test.ts
+++ b/packages/extension/src/infrastructure/capture/tab-capture-source-adapter.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { type StartSourceCommand } from '../../application/ports/source-adapter';
+import { addFakeTrack } from '../../../tests/helpers/media-stream';
+import { createTabCaptureSourceAdapter, type TabCaptureApi } from './tab-capture-source-adapter';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const buildCommand = (overrides: Partial<StartSourceCommand> = {}): StartSourceCommand => ({
+  sourceType: 'tab',
+  sessionIdentifier,
+  tabId: 42,
+  ...overrides,
+});
+
+const buildApi = (): TabCaptureApi & {
+  capture: ReturnType<typeof vi.fn<TabCaptureApi['capture']>>;
+} => {
+  const stream = new MediaStream();
+  const capture = vi.fn<TabCaptureApi['capture']>(() => Promise.resolve(stream));
+  return { capture };
+};
+
+describe('createTabCaptureSourceAdapter (IMPL-300, DD-101)', () => {
+  it('captures a MediaStream with audio-only constraints', async () => {
+    const api = buildApi();
+    const adapter = createTabCaptureSourceAdapter({ tabCaptureApi: api });
+    const result = await adapter.open(buildCommand());
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBeInstanceOf(MediaStream);
+    const options = api.capture.mock.calls[0]?.[0];
+    expect(options).toMatchObject({ audio: true, video: false });
+  });
+
+  it('rejects a non-tab command', async () => {
+    const api = buildApi();
+    const adapter = createTabCaptureSourceAdapter({ tabCaptureApi: api });
+    const result = await adapter.open({
+      sourceType: 'microphone',
+      sessionIdentifier,
+      deviceId: 'default',
+    });
+    expect(result.isErr()).toBe(true);
+    expect(api.capture).not.toHaveBeenCalled();
+  });
+
+  it('returns invariant-violation when capture returns null (tab no longer audible)', async () => {
+    const api: TabCaptureApi = {
+      capture: () => Promise.resolve(null),
+    };
+    const adapter = createTabCaptureSourceAdapter({ tabCaptureApi: api });
+    const result = await adapter.open(buildCommand());
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+  });
+
+  it('returns invariant-violation when the api throws (e.g., chrome.runtime.lastError)', async () => {
+    const api: TabCaptureApi = {
+      capture: () => Promise.reject(new Error('Tab is not currently being captured')),
+    };
+    const adapter = createTabCaptureSourceAdapter({ tabCaptureApi: api });
+    const result = await adapter.open(buildCommand());
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.kind).toBe('invariant-violation');
+      if (result.error.kind === 'invariant-violation') {
+        expect(result.error.details).toContain('Tab is not currently being captured');
+      }
+    }
+  });
+
+  it('close stops tracks on the captured stream', async () => {
+    const stop = vi.fn();
+    const stream = new MediaStream();
+    addFakeTrack(stream, { stop });
+    const api: TabCaptureApi = { capture: () => Promise.resolve(stream) };
+    const adapter = createTabCaptureSourceAdapter({ tabCaptureApi: api });
+    await adapter.open(buildCommand());
+    const result = await adapter.close(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('close is a no-op when session was never opened', async () => {
+    const api = buildApi();
+    const adapter = createTabCaptureSourceAdapter({ tabCaptureApi: api });
+    const result = await adapter.close(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+  });
+});

--- a/packages/extension/src/infrastructure/capture/tab-capture-source-adapter.ts
+++ b/packages/extension/src/infrastructure/capture/tab-capture-source-adapter.ts
@@ -1,0 +1,116 @@
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import {
+  type SourceAdapter,
+  type StartSourceCommand,
+} from '../../application/ports/source-adapter';
+
+/**
+ * `chrome.tabCapture.capture` を最小 contract で抽象化した adapter。
+ * production では callback を Promise に wrap した default 実装、test では
+ * mock を注入する。
+ */
+export type TabCaptureApi = {
+  capture: (options: chrome.tabCapture.CaptureOptions) => Promise<MediaStream | null>;
+};
+
+/**
+ * Production `TabCaptureApi` 実装 (mock ではない)。callback を Promise に
+ * wrap し、`chrome.runtime.lastError` を Error に変換する。
+ */
+export const defaultTabCaptureApi: TabCaptureApi = {
+  capture: (options) =>
+    new Promise<MediaStream | null>((resolve, reject) => {
+      try {
+        chrome.tabCapture.capture(options, (stream) => {
+          const lastError = chrome.runtime.lastError;
+          if (lastError !== undefined) {
+            reject(new Error(lastError.message ?? 'unknown tabCapture error'));
+            return;
+          }
+          resolve(stream);
+        });
+      } catch (cause) {
+        reject(cause instanceof Error ? cause : new Error(String(cause)));
+      }
+    }),
+};
+
+export type TabCaptureSourceAdapterDependencies = Readonly<{
+  tabCaptureApi: TabCaptureApi;
+}>;
+
+const hasStopMethod = (value: unknown): value is { stop: () => void } => {
+  if (typeof value !== 'object' || value === null) return false;
+  const stop: unknown = Reflect.get(value, 'stop');
+  return typeof stop === 'function';
+};
+
+const stopAllTracks = (stream: MediaStream): void => {
+  for (const track of stream.getTracks()) {
+    if (hasStopMethod(track)) {
+      track.stop();
+    }
+  }
+};
+
+/**
+ * IMPL-300 TabCaptureSourceAdapter (DD-101)。
+ *
+ * 入力ソース `tab` 用 `SourceAdapter` 実装。`tabCaptureApi` は必須 DI。
+ * production では `defaultTabCaptureApi` を明示的に渡す。
+ *
+ * `chrome.tabCapture.capture` は audio-only で呼ぶ (設計書 §5 / api-spec §6.2
+ * の PCM 転送経路に合わせる)。`tabId` 指定は拡張 API として MV3 の
+ * `getMediaStreamId` 経由が必要だが、MVP は最小 options のみ。
+ */
+export const createTabCaptureSourceAdapter = (
+  deps: TabCaptureSourceAdapterDependencies,
+): SourceAdapter => {
+  const openStreams = new Map<SessionIdentifier, MediaStream>();
+
+  return {
+    open: (command: StartSourceCommand) => {
+      if (command.sourceType !== 'tab') {
+        return errAsync<MediaStream, DomainError>(
+          invariantViolationError({
+            invariant: 'tab-capture-source-mismatch',
+            details: `expected tab, received ${command.sourceType}`,
+          }),
+        );
+      }
+      const options: chrome.tabCapture.CaptureOptions = {
+        audio: true,
+        video: false,
+      };
+      return ResultAsync.fromPromise<MediaStream | null, DomainError>(
+        deps.tabCaptureApi.capture(options),
+        (cause) =>
+          invariantViolationError({
+            invariant: 'tab-capture-failed',
+            details: cause instanceof Error ? cause.message : 'unknown error',
+          }),
+      ).andThen((stream): ResultAsync<MediaStream, DomainError> => {
+        if (stream === null) {
+          return errAsync<MediaStream, DomainError>(
+            invariantViolationError({
+              invariant: 'tab-capture-null-stream',
+              details: 'chrome.tabCapture returned null (tab not audible or permission revoked)',
+            }),
+          );
+        }
+        openStreams.set(command.sessionIdentifier, stream);
+        return okAsync<MediaStream, DomainError>(stream);
+      });
+    },
+
+    close: (sessionIdentifier) => {
+      const stream = openStreams.get(sessionIdentifier);
+      if (stream === undefined) return okAsync(undefined);
+      stopAllTracks(stream);
+      openStreams.delete(sessionIdentifier);
+      return okAsync(undefined);
+    },
+  };
+};

--- a/packages/extension/src/infrastructure/capture/user-media-source-adapter.test.ts
+++ b/packages/extension/src/infrastructure/capture/user-media-source-adapter.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { type StartSourceCommand } from '../../application/ports/source-adapter';
+import { addFakeTrack } from '../../../tests/helpers/media-stream';
+import { createUserMediaSourceAdapter, type UserMediaApi } from './user-media-source-adapter';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const buildCommand = (overrides: Partial<StartSourceCommand> = {}): StartSourceCommand => ({
+  sourceType: 'microphone',
+  sessionIdentifier,
+  deviceId: 'default',
+  ...overrides,
+});
+
+const buildApi = (): UserMediaApi & {
+  getUserMedia: ReturnType<typeof vi.fn<UserMediaApi['getUserMedia']>>;
+} => {
+  const stream = new MediaStream();
+  const getUserMedia = vi.fn<UserMediaApi['getUserMedia']>(() => Promise.resolve(stream));
+  return { getUserMedia };
+};
+
+describe('createUserMediaSourceAdapter (IMPL-301, DD-102)', () => {
+  it('returns MediaStream from getUserMedia on open', async () => {
+    const api = buildApi();
+    const adapter = createUserMediaSourceAdapter({ userMediaApi: api });
+    const result = await adapter.open(buildCommand());
+    expect(result.isOk()).toBe(true);
+    expect(api.getUserMedia).toHaveBeenCalledTimes(1);
+    if (result.isOk()) {
+      expect(result.value).toBeInstanceOf(MediaStream);
+    }
+  });
+
+  it('passes deviceId through audio constraints', async () => {
+    const api = buildApi();
+    const adapter = createUserMediaSourceAdapter({ userMediaApi: api });
+    await adapter.open(buildCommand({ deviceId: 'mic-123' }));
+    expect(api.getUserMedia).toHaveBeenCalledWith({
+      audio: { deviceId: { exact: 'mic-123' } },
+      video: false,
+    });
+  });
+
+  it('falls back to audio: true when deviceId is omitted', async () => {
+    const api = buildApi();
+    const adapter = createUserMediaSourceAdapter({ userMediaApi: api });
+    await adapter.open({ sourceType: 'microphone', sessionIdentifier });
+    expect(api.getUserMedia).toHaveBeenCalledWith({ audio: true, video: false });
+  });
+
+  it('returns invariant-violation when getUserMedia rejects', async () => {
+    const api: UserMediaApi = {
+      getUserMedia: () => Promise.reject(new Error('NotAllowedError')),
+    };
+    const adapter = createUserMediaSourceAdapter({ userMediaApi: api });
+    const result = await adapter.open(buildCommand());
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+  });
+
+  it('rejects a command whose sourceType is not microphone', async () => {
+    const api = buildApi();
+    const adapter = createUserMediaSourceAdapter({ userMediaApi: api });
+    const result = await adapter.open({
+      sourceType: 'tab',
+      sessionIdentifier,
+      tabId: 1,
+    });
+    expect(result.isErr()).toBe(true);
+    expect(api.getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it('close stops all tracks on the captured stream', async () => {
+    const trackStop = vi.fn();
+    const stream = new MediaStream();
+    addFakeTrack(stream, { stop: trackStop });
+    const api: UserMediaApi = {
+      getUserMedia: () => Promise.resolve(stream),
+    };
+    const adapter = createUserMediaSourceAdapter({ userMediaApi: api });
+    await adapter.open(buildCommand());
+    const result = await adapter.close(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    expect(trackStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('close is a no-op if session was never opened', async () => {
+    const api = buildApi();
+    const adapter = createUserMediaSourceAdapter({ userMediaApi: api });
+    const result = await adapter.close(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+  });
+});

--- a/packages/extension/src/infrastructure/capture/user-media-source-adapter.ts
+++ b/packages/extension/src/infrastructure/capture/user-media-source-adapter.ts
@@ -1,0 +1,103 @@
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import {
+  type SourceAdapter,
+  type StartSourceCommand,
+} from '../../application/ports/source-adapter';
+
+/**
+ * `navigator.mediaDevices.getUserMedia` を最小限の contract に抽象化した
+ * adapter。production では default 実装、test では mock を注入する。
+ */
+export type UserMediaApi = {
+  getUserMedia: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+};
+
+/**
+ * Production `UserMediaApi` 実装 (mock ではない)。entrypoint で
+ * `createUserMediaSourceAdapter({ userMediaApi: defaultUserMediaApi })` と
+ * 明示注入する。
+ */
+export const defaultUserMediaApi: UserMediaApi = {
+  getUserMedia: (constraints) => navigator.mediaDevices.getUserMedia(constraints),
+};
+
+export type UserMediaSourceAdapterDependencies = Readonly<{
+  userMediaApi: UserMediaApi;
+}>;
+
+const buildConstraints = (command: StartSourceCommand): MediaStreamConstraints => {
+  if (command.sourceType !== 'microphone') {
+    return { audio: true, video: false };
+  }
+  if (command.deviceId !== undefined) {
+    return {
+      audio: { deviceId: { exact: command.deviceId } },
+      video: false,
+    };
+  }
+  return { audio: true, video: false };
+};
+
+const hasStopMethod = (value: unknown): value is { stop: () => void } => {
+  if (typeof value !== 'object' || value === null) return false;
+  const stop: unknown = Reflect.get(value, 'stop');
+  return typeof stop === 'function';
+};
+
+const stopAllTracks = (stream: MediaStream): void => {
+  for (const track of stream.getTracks()) {
+    if (hasStopMethod(track)) {
+      track.stop();
+    }
+  }
+};
+
+/**
+ * IMPL-301 UserMediaSourceAdapter (DD-102)。
+ *
+ * 入力ソース `microphone` 用の `SourceAdapter` 実装。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - `userMediaApi` は必須 DI (default なし)
+ * - production entrypoint で `defaultUserMediaApi` を明示的に渡す
+ */
+export const createUserMediaSourceAdapter = (
+  deps: UserMediaSourceAdapterDependencies,
+): SourceAdapter => {
+  const openStreams = new Map<SessionIdentifier, MediaStream>();
+
+  return {
+    open: (command) => {
+      if (command.sourceType !== 'microphone') {
+        return errAsync<MediaStream, DomainError>(
+          invariantViolationError({
+            invariant: 'user-media-source-mismatch',
+            details: `expected microphone, received ${command.sourceType}`,
+          }),
+        );
+      }
+      const constraints = buildConstraints(command);
+      return ResultAsync.fromPromise<MediaStream, DomainError>(
+        deps.userMediaApi.getUserMedia(constraints),
+        (cause) =>
+          invariantViolationError({
+            invariant: 'user-media-capture-failed',
+            details: cause instanceof Error ? cause.message : 'unknown error',
+          }),
+      ).map((stream) => {
+        openStreams.set(command.sessionIdentifier, stream);
+        return stream;
+      });
+    },
+
+    close: (sessionIdentifier) => {
+      const stream = openStreams.get(sessionIdentifier);
+      if (stream === undefined) return okAsync(undefined);
+      stopAllTracks(stream);
+      openStreams.delete(sessionIdentifier);
+      return okAsync(undefined);
+    },
+  };
+};

--- a/packages/extension/tests/helpers/media-stream.ts
+++ b/packages/extension/tests/helpers/media-stream.ts
@@ -1,0 +1,22 @@
+/**
+ * jsdom の `MediaStream` スタブ (tests/setup.ts) に対し、テストから
+ * `track` を追加するためのヘルパ。DOM の `MediaStream.addTrack` は
+ * 完全な `MediaStreamTrack` を要求するため、最小 `{ stop }` を持つ
+ * fake track をスタブの内部配列へ挿入する。
+ *
+ * `as` 禁止の制約下で成立させるため、`unknown` 型ガードで narrow する。
+ */
+
+export type FakeMediaStreamTrack = Readonly<{ stop: () => void }>;
+
+const isUnknownArray = (value: unknown): value is unknown[] => Array.isArray(value);
+
+export const addFakeTrack = (stream: MediaStream, track: FakeMediaStreamTrack): void => {
+  const tracks: unknown = Reflect.get(stream, 'tracks');
+  if (!isUnknownArray(tracks)) {
+    throw new Error(
+      'MediaStream stub tracks array not found. Ensure tests/setup.ts is loaded before calling addFakeTrack.',
+    );
+  }
+  tracks.push(track);
+};

--- a/packages/extension/tests/setup.ts
+++ b/packages/extension/tests/setup.ts
@@ -37,3 +37,40 @@ Object.defineProperty(globalThis, 'chrome', {
   writable: true,
   configurable: true,
 });
+
+// jsdom does not provide MediaStream / MediaStreamTrack globals. We polyfill
+// minimal class stubs so test code can reference the DOM type when
+// constructing fake streams (adapter tests only validate DI wiring, not real
+// audio routing — those are covered by E2E).
+if (typeof globalThis.MediaStream === 'undefined') {
+  class MediaStreamStub {
+    public readonly id: string;
+    public readonly active: boolean = true;
+    private readonly tracks: unknown[] = [];
+    constructor(tracks?: unknown[]) {
+      this.id = `stub-media-stream-${String(Math.random()).slice(2, 8)}`;
+      if (tracks !== undefined) this.tracks.push(...tracks);
+    }
+    getTracks(): unknown[] {
+      return [...this.tracks];
+    }
+    getAudioTracks(): unknown[] {
+      return [...this.tracks];
+    }
+    getVideoTracks(): unknown[] {
+      return [];
+    }
+    addTrack(track: unknown): void {
+      this.tracks.push(track);
+    }
+    removeTrack(track: unknown): void {
+      const index = this.tracks.indexOf(track);
+      if (index >= 0) this.tracks.splice(index, 1);
+    }
+  }
+  Object.defineProperty(globalThis, 'MediaStream', {
+    value: MediaStreamStub,
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
## Summary

Phase 3 §5.1 音声取得の基盤を追加 (IMPL-300/301/302/303):

- **TabCaptureSourceAdapter** (IMPL-300): `chrome.tabCapture` を `TabCaptureApi` に抽象化し、null stream (tab no longer audible) を `invariantViolationError` で拾う
- **UserMediaSourceAdapter** (IMPL-301): `navigator.mediaDevices.getUserMedia` を `UserMediaApi` に抽象化。`deviceId` 指定時のみ `{ exact: deviceId }` constraint、未指定時は `audio: true` fallback
- **DesktopCaptureSourceAdapter** (IMPL-302): `navigator.mediaDevices.getDisplayMedia` を `DesktopCaptureApi` に抽象化。audio+video 取得で browser picker の成功率を上げる
- **SourceAdapterFactory**: `sourceType` → adapter の routing 層。3 adapter を必須 DI で受け取り、application 層が `sourceType` を知らずに使える
- **AudioPreprocessor** (IMPL-303): `AudioContextLike` で AudioContext の最小 contract を抽象化。`audioContextFactory` / `workletModuleUrl` / `clock` を必須 DI。MVP は AudioContext lifecycle + worklet module ロード + 空 frame channel のみ (実際の PCM フレーム生成は `audio-worklet.js` / E2E で検証)

## Mock 防止設計

- 全 adapter / factory が `createXxx(deps: { xxxApi: XxxApi })` 形式の必須 DI
- production entrypoint は `defaultTabCaptureApi` / `defaultUserMediaApi` / `defaultDesktopCaptureApi` / `defaultAudioContextFactory` を明示的に渡す
- default 引数 (= mock が漏れる経路) は存在しない

## Test infra

- `tests/setup.ts` に `MediaStream` スタブ (jsdom には存在しないため polyfill)
- `tests/helpers/media-stream.ts` に `addFakeTrack` ヘルパ。`as` 禁止下で型ガード経由で `MediaStreamStub` の `tracks` 内部配列へ fake track を挿入

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 545 tests)
- [x] 各 adapter: 正常系 / mismatch source / capture reject / null stream (tab only) / close track stop
- [x] AudioPreprocessor: attach / addModule reject / detach close / no-op on unknown session
- [x] SourceAdapterFactory: 3 sourceType routing

## Out of scope

- 実際の PCM フレーム生成 (`audio-worklet.js` は IMPL-340+ で content script 側に実装)
- §5.2 Translation (IMPL-320 系は PR #21 で完了済み)
- §5.4 Overlay (IMPL-330 ContentScriptOverlayPresenter)
- §5.5 統括 (IMPL-340-344 SessionCommandService / CaptureOrchestrator 等)