### PR TITLE
feat(infrastructure): IMPL-330 ContentScriptOverlayPresenter (DD-108/DD-114)

### DIFF
--- a/packages/extension/src/infrastructure/overlay/content-script-overlay-presenter.test.ts
+++ b/packages/extension/src/infrastructure/overlay/content-script-overlay-presenter.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { createOverlaySettings, type OverlaySettings } from '../../domain/profile/overlay-settings';
+import { parseSegmentIdentifier } from '../../domain/transcript/segment-identifier';
+import { type OverlayRenderModel } from '../../application/ports/overlay-presenter';
+import {
+  createContentScriptOverlayPresenter,
+  type OverlayView,
+  type OverlayViewFactory,
+} from './content-script-overlay-presenter';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+const segmentIdentifier = parseSegmentIdentifier(SEGMENT_ID)._unsafeUnwrap();
+
+const settings: OverlaySettings = createOverlaySettings({
+  positionPreset: 'bottom',
+  opacity: 0.85,
+  maxLines: 2,
+  fontScale: 1,
+  showOriginalText: true,
+  showTranslatedText: true,
+})._unsafeUnwrap();
+
+type MockView = OverlayView & {
+  mount: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  unmount: ReturnType<typeof vi.fn>;
+};
+
+const buildView = (): MockView => ({
+  mount: vi.fn(),
+  update: vi.fn(),
+  unmount: vi.fn(),
+});
+
+const buildFactory = (view: OverlayView): OverlayViewFactory =>
+  vi.fn<OverlayViewFactory>(() => view);
+
+const buildRenderModel = (): OverlayRenderModel => ({
+  sessionIdentifier,
+  lines: [
+    {
+      segmentIdentifier,
+      originalText: 'Hello',
+      translatedText: 'こんにちは',
+      targetLanguage: 'ja',
+      isFinal: true,
+    },
+  ],
+});
+
+describe('createContentScriptOverlayPresenter (IMPL-330, DD-108)', () => {
+  it('mount calls the view factory and mounts the view', async () => {
+    const view = buildView();
+    const factory = buildFactory(view);
+    const presenter = createContentScriptOverlayPresenter({ overlayViewFactory: factory });
+    const result = await presenter.mount(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    expect(factory).toHaveBeenCalledWith(sessionIdentifier);
+    expect(view.mount).toHaveBeenCalledTimes(1);
+  });
+
+  it('mount is rejected when session already has a mounted view', async () => {
+    const view = buildView();
+    const presenter = createContentScriptOverlayPresenter({
+      overlayViewFactory: buildFactory(view),
+    });
+    await presenter.mount(sessionIdentifier);
+    const result = await presenter.mount(sessionIdentifier);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+  });
+
+  it('render pushes the model into the view with settings=null before updateSettings', async () => {
+    const view = buildView();
+    const presenter = createContentScriptOverlayPresenter({
+      overlayViewFactory: buildFactory(view),
+    });
+    await presenter.mount(sessionIdentifier);
+    const model = buildRenderModel();
+    const result = await presenter.render(model);
+    expect(result.isOk()).toBe(true);
+    expect(view.update).toHaveBeenCalledWith(model, null);
+  });
+
+  it('render is rejected when the session has no mounted view', async () => {
+    const view = buildView();
+    const presenter = createContentScriptOverlayPresenter({
+      overlayViewFactory: buildFactory(view),
+    });
+    const result = await presenter.render(buildRenderModel());
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    expect(view.update).not.toHaveBeenCalled();
+  });
+
+  it('updateSettings stores settings; subsequent render passes them through', async () => {
+    const view = buildView();
+    const presenter = createContentScriptOverlayPresenter({
+      overlayViewFactory: buildFactory(view),
+    });
+    await presenter.mount(sessionIdentifier);
+    const updateResult = await presenter.updateSettings(sessionIdentifier, settings);
+    expect(updateResult.isOk()).toBe(true);
+    const model = buildRenderModel();
+    await presenter.render(model);
+    expect(view.update).toHaveBeenLastCalledWith(model, settings);
+  });
+
+  it('updateSettings is rejected when the session has no mounted view', async () => {
+    const view = buildView();
+    const presenter = createContentScriptOverlayPresenter({
+      overlayViewFactory: buildFactory(view),
+    });
+    const result = await presenter.updateSettings(sessionIdentifier, settings);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+  });
+
+  it('unmount calls view.unmount and removes the session', async () => {
+    const view = buildView();
+    const presenter = createContentScriptOverlayPresenter({
+      overlayViewFactory: buildFactory(view),
+    });
+    await presenter.mount(sessionIdentifier);
+    const result = await presenter.unmount(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    expect(view.unmount).toHaveBeenCalledTimes(1);
+
+    const remount = await presenter.mount(sessionIdentifier);
+    expect(remount.isOk()).toBe(true);
+  });
+
+  it('unmount is a no-op when the session was never mounted', async () => {
+    const view = buildView();
+    const presenter = createContentScriptOverlayPresenter({
+      overlayViewFactory: buildFactory(view),
+    });
+    const result = await presenter.unmount(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    expect(view.unmount).not.toHaveBeenCalled();
+  });
+
+  it('mount surfaces factory failure as invariant-violation', async () => {
+    const failing: OverlayViewFactory = () => {
+      throw new Error('shadow host creation failed');
+    };
+    const presenter = createContentScriptOverlayPresenter({ overlayViewFactory: failing });
+    const result = await presenter.mount(sessionIdentifier);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.kind).toBe('invariant-violation');
+      if (result.error.kind === 'invariant-violation') {
+        expect(result.error.details).toContain('shadow host creation failed');
+      }
+    }
+  });
+
+  it('render surfaces view.update failure as invariant-violation', async () => {
+    const view: OverlayView = {
+      mount: vi.fn(),
+      update: vi.fn(() => {
+        throw new Error('react render failed');
+      }),
+      unmount: vi.fn(),
+    };
+    const presenter = createContentScriptOverlayPresenter({
+      overlayViewFactory: buildFactory(view),
+    });
+    await presenter.mount(sessionIdentifier);
+    const result = await presenter.render(buildRenderModel());
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+  });
+});

--- a/packages/extension/src/infrastructure/overlay/content-script-overlay-presenter.ts
+++ b/packages/extension/src/infrastructure/overlay/content-script-overlay-presenter.ts
@@ -1,0 +1,138 @@
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+import { type OverlaySettings } from '../../domain/profile/overlay-settings';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import {
+  type OverlayPresenter,
+  type OverlayRenderModel,
+} from '../../application/ports/overlay-presenter';
+
+/**
+ * セッション毎に実体を持つ view controller。production では Shadow DOM host +
+ * React root を抱える。test では `vi.fn` で mock する。
+ *
+ * `update` は render 時の最新 model と settings を同期的に受け取る。
+ * 内部の描画が失敗した場合は `throw` してよい (presenter 側で
+ * `invariantViolationError` に変換する)。
+ */
+export type OverlayView = Readonly<{
+  mount: () => void;
+  update: (model: OverlayRenderModel, settings: OverlaySettings | null) => void;
+  unmount: () => void;
+}>;
+
+/**
+ * セッション識別子に対し 1 つの `OverlayView` を生成する factory。
+ * production の `defaultOverlayViewFactory` は Shadow DOM host を document.body
+ * に注入し、React root を attach する。test では `vi.fn` mock を注入する。
+ */
+export type OverlayViewFactory = (sessionIdentifier: SessionIdentifier) => OverlayView;
+
+export type ContentScriptOverlayPresenterDependencies = Readonly<{
+  overlayViewFactory: OverlayViewFactory;
+}>;
+
+type SessionEntry = {
+  view: OverlayView;
+  settings: OverlaySettings | null;
+};
+
+/**
+ * IMPL-330 ContentScriptOverlayPresenter (DD-108, DD-114)。
+ *
+ * `OverlayPresenter` ポート実装。セッション毎に `OverlayView` controller を
+ * 生成し、mount / render / updateSettings / unmount を仲介する。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - `overlayViewFactory` は必須 DI (default なし)
+ * - production entrypoint で `defaultOverlayViewFactory` を明示的に渡す
+ *
+ * **設計メモ**:
+ * - Shadow DOM / React rendering は view controller 側に閉じ込める。
+ *   presenter 自体はセッション毎の view map と設定 cache のみを管理する
+ * - `updateSettings` の反映は次の `render` 呼び出し時に行う (内部 cache 更新)
+ * - `render` / `mount` 内での例外は `invariantViolationError` に変換する。
+ *   UseCase 側で `orElse` で握り潰してホットパスを止めない設計 (DD-305 結果整合)
+ */
+export const createContentScriptOverlayPresenter = (
+  deps: ContentScriptOverlayPresenterDependencies,
+): OverlayPresenter => {
+  const sessions = new Map<SessionIdentifier, SessionEntry>();
+
+  return {
+    mount: (sessionIdentifier) => {
+      if (sessions.has(sessionIdentifier)) {
+        return errAsync<void, DomainError>(
+          invariantViolationError({
+            invariant: 'overlay-already-mounted',
+            details: `session ${sessionIdentifier} already has a mounted overlay view`,
+          }),
+        );
+      }
+      return ResultAsync.fromPromise<void, DomainError>(
+        Promise.resolve().then(() => {
+          const view = deps.overlayViewFactory(sessionIdentifier);
+          view.mount();
+          sessions.set(sessionIdentifier, { view, settings: null });
+        }),
+        (cause) =>
+          invariantViolationError({
+            invariant: 'overlay-mount-failed',
+            details: cause instanceof Error ? cause.message : 'unknown error',
+          }),
+      );
+    },
+
+    render: (model) => {
+      const entry = sessions.get(model.sessionIdentifier);
+      if (entry === undefined) {
+        return errAsync<void, DomainError>(
+          invariantViolationError({
+            invariant: 'overlay-not-mounted',
+            details: `session ${model.sessionIdentifier} has no mounted overlay view`,
+          }),
+        );
+      }
+      return ResultAsync.fromPromise<void, DomainError>(
+        Promise.resolve().then(() => {
+          entry.view.update(model, entry.settings);
+        }),
+        (cause) =>
+          invariantViolationError({
+            invariant: 'overlay-render-failed',
+            details: cause instanceof Error ? cause.message : 'unknown error',
+          }),
+      );
+    },
+
+    updateSettings: (sessionIdentifier, settings) => {
+      const entry = sessions.get(sessionIdentifier);
+      if (entry === undefined) {
+        return errAsync<void, DomainError>(
+          invariantViolationError({
+            invariant: 'overlay-not-mounted',
+            details: `session ${sessionIdentifier} has no mounted overlay view`,
+          }),
+        );
+      }
+      sessions.set(sessionIdentifier, { view: entry.view, settings });
+      return okAsync(undefined);
+    },
+
+    unmount: (sessionIdentifier) => {
+      const entry = sessions.get(sessionIdentifier);
+      if (entry === undefined) return okAsync(undefined);
+      return ResultAsync.fromPromise<void, DomainError>(
+        Promise.resolve().then(() => {
+          entry.view.unmount();
+          sessions.delete(sessionIdentifier);
+        }),
+        (cause) =>
+          invariantViolationError({
+            invariant: 'overlay-unmount-failed',
+            details: cause instanceof Error ? cause.message : 'unknown error',
+          }),
+      );
+    },
+  };
+};

--- a/packages/extension/src/infrastructure/overlay/default-overlay-view.test.ts
+++ b/packages/extension/src/infrastructure/overlay/default-overlay-view.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { createOverlaySettings, type OverlaySettings } from '../../domain/profile/overlay-settings';
+import { parseSegmentIdentifier } from '../../domain/transcript/segment-identifier';
+import { type OverlayRenderModel } from '../../application/ports/overlay-presenter';
+import { createDefaultOverlayViewFactory, type OverlayDocumentApi } from './default-overlay-view';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+const segmentIdentifier = parseSegmentIdentifier(SEGMENT_ID)._unsafeUnwrap();
+
+const settings: OverlaySettings = createOverlaySettings({
+  positionPreset: 'bottom',
+  opacity: 0.85,
+  maxLines: 2,
+  fontScale: 1,
+  showOriginalText: true,
+  showTranslatedText: true,
+})._unsafeUnwrap();
+
+const buildModel = (overrides: Partial<OverlayRenderModel> = {}): OverlayRenderModel => ({
+  sessionIdentifier,
+  lines: [
+    {
+      segmentIdentifier,
+      originalText: 'Hello',
+      translatedText: 'こんにちは',
+      targetLanguage: 'ja',
+      isFinal: true,
+    },
+  ],
+  ...overrides,
+});
+
+const buildDocumentApi = () => {
+  const host = document.createElement('div');
+  const shadowRoot = host.attachShadow({ mode: 'open' });
+  const createHost = vi.fn(() => ({ host, shadowRoot }));
+  const removeHost = vi.fn();
+  const api: OverlayDocumentApi = { createHost, removeHost };
+  return { api, host, shadowRoot, createHost, removeHost };
+};
+
+describe('createDefaultOverlayViewFactory (IMPL-330 production helper)', () => {
+  it('mount creates a shadow host and renders an empty root', () => {
+    const { api, shadowRoot, createHost } = buildDocumentApi();
+    const factory = createDefaultOverlayViewFactory({ documentApi: api });
+    const view = factory(sessionIdentifier);
+    view.mount();
+    expect(createHost).toHaveBeenCalledTimes(1);
+    const root = shadowRoot.querySelector('[data-perapera-overlay-root]');
+    expect(root).not.toBeNull();
+  });
+
+  it('update writes original and translated lines into the shadow root', () => {
+    const { api, shadowRoot } = buildDocumentApi();
+    const factory = createDefaultOverlayViewFactory({ documentApi: api });
+    const view = factory(sessionIdentifier);
+    view.mount();
+    view.update(buildModel(), settings);
+    const text = shadowRoot.textContent ?? '';
+    expect(text).toContain('Hello');
+    expect(text).toContain('こんにちは');
+  });
+
+  it('update is a no-op when called before mount', () => {
+    const { api } = buildDocumentApi();
+    const factory = createDefaultOverlayViewFactory({ documentApi: api });
+    const view = factory(sessionIdentifier);
+    expect(() => {
+      view.update(buildModel(), settings);
+    }).not.toThrow();
+  });
+
+  it('update applies opacity and fontScale from settings to the root container', () => {
+    const { api, shadowRoot } = buildDocumentApi();
+    const factory = createDefaultOverlayViewFactory({ documentApi: api });
+    const view = factory(sessionIdentifier);
+    view.mount();
+    const custom = createOverlaySettings({
+      positionPreset: 'top',
+      opacity: 0.5,
+      maxLines: 3,
+      fontScale: 1.5,
+      showOriginalText: true,
+      showTranslatedText: true,
+    })._unsafeUnwrap();
+    view.update(buildModel(), custom);
+    const root = shadowRoot.querySelector('[data-perapera-overlay-root]');
+    expect(root).not.toBeNull();
+    if (root instanceof HTMLElement) {
+      expect(root.style.opacity).toBe('0.5');
+      expect(root.style.getPropertyValue('--perapera-font-scale')).toBe('1.5');
+    }
+  });
+
+  it('update renders without settings (settings=null): defaults apply', () => {
+    const { api, shadowRoot } = buildDocumentApi();
+    const factory = createDefaultOverlayViewFactory({ documentApi: api });
+    const view = factory(sessionIdentifier);
+    view.mount();
+    view.update(buildModel(), null);
+    const text = shadowRoot.textContent ?? '';
+    expect(text).toContain('Hello');
+  });
+
+  it('unmount removes the host and prevents further updates', () => {
+    const { api, host, removeHost } = buildDocumentApi();
+    const factory = createDefaultOverlayViewFactory({ documentApi: api });
+    const view = factory(sessionIdentifier);
+    view.mount();
+    view.unmount();
+    expect(removeHost).toHaveBeenCalledWith(host);
+    // Subsequent update should not throw
+    expect(() => {
+      view.update(buildModel(), settings);
+    }).not.toThrow();
+  });
+
+  it('unmount is safe to call multiple times', () => {
+    const { api } = buildDocumentApi();
+    const factory = createDefaultOverlayViewFactory({ documentApi: api });
+    const view = factory(sessionIdentifier);
+    view.mount();
+    view.unmount();
+    expect(() => {
+      view.unmount();
+    }).not.toThrow();
+  });
+});

--- a/packages/extension/src/infrastructure/overlay/default-overlay-view.ts
+++ b/packages/extension/src/infrastructure/overlay/default-overlay-view.ts
@@ -1,0 +1,146 @@
+import { type OverlaySettings } from '../../domain/profile/overlay-settings';
+import { type OverlayRenderModel } from '../../application/ports/overlay-presenter';
+import { type OverlayView, type OverlayViewFactory } from './content-script-overlay-presenter';
+
+/**
+ * DOM 操作を presenter から分離するための薄い contract。
+ * production では `document` をそのまま使う default 実装、test では
+ * jsdom 上で host を作る mock を注入する。
+ */
+export type OverlayDocumentApi = {
+  createHost: () => { host: HTMLElement; shadowRoot: ShadowRoot };
+  removeHost: (host: HTMLElement) => void;
+};
+
+/**
+ * Production `OverlayDocumentApi` 実装 (mock ではない)。
+ * content script の `document` に絶対配置の Shadow host を追加する。
+ *
+ * - `position: fixed` で viewport 基準の overlay
+ * - `pointer-events: none` でページ操作を妨げない
+ * - `z-index: 2147483647` で最前面 (chrome 拡張の慣例値)
+ * - `all: initial` でページ CSS 継承を遮断
+ */
+export const defaultOverlayDocumentApi: OverlayDocumentApi = {
+  createHost: () => {
+    const host = document.createElement('div');
+    host.setAttribute('data-perapera-overlay', '');
+    host.style.cssText = [
+      'all: initial',
+      'position: fixed',
+      'left: 0',
+      'right: 0',
+      'bottom: 0',
+      'pointer-events: none',
+      'z-index: 2147483647',
+    ].join(';');
+    document.body.append(host);
+    const shadowRoot = host.attachShadow({ mode: 'open' });
+    return { host, shadowRoot };
+  },
+  removeHost: (host) => {
+    host.remove();
+  },
+};
+
+export type DefaultOverlayViewFactoryDependencies = Readonly<{
+  documentApi: OverlayDocumentApi;
+}>;
+
+const BASE_STYLE = `
+:host { color-scheme: light dark; }
+.perapera-overlay-container {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-size: calc(16px * var(--perapera-font-scale, 1));
+  line-height: 1.4;
+  color: white;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+  background: rgba(0, 0, 0, 0.5);
+  padding: 0.5em 1em;
+  margin: 1em;
+  border-radius: 0.25em;
+  max-width: 90vw;
+  pointer-events: auto;
+}
+.perapera-overlay-line { margin: 0.2em 0; }
+.perapera-overlay-original { opacity: 0.7; }
+.perapera-overlay-translated { font-weight: 500; }
+`;
+
+const renderLines = (root: HTMLElement, model: OverlayRenderModel): void => {
+  root.replaceChildren();
+  for (const line of model.lines) {
+    const lineEl = document.createElement('div');
+    lineEl.className = 'perapera-overlay-line';
+    lineEl.setAttribute('data-segment-identifier', line.segmentIdentifier);
+    if (line.originalText !== null) {
+      const original = document.createElement('span');
+      original.className = 'perapera-overlay-original';
+      original.textContent = line.originalText;
+      lineEl.append(original);
+    }
+    if (line.translatedText !== null) {
+      if (line.originalText !== null) lineEl.append(document.createElement('br'));
+      const translated = document.createElement('span');
+      translated.className = 'perapera-overlay-translated';
+      translated.textContent = line.translatedText;
+      lineEl.append(translated);
+    }
+    root.append(lineEl);
+  }
+};
+
+const applySettings = (root: HTMLElement, settings: OverlaySettings | null): void => {
+  if (settings === null) {
+    root.style.removeProperty('opacity');
+    root.style.removeProperty('--perapera-font-scale');
+    return;
+  }
+  root.style.opacity = String(settings.opacity);
+  root.style.setProperty('--perapera-font-scale', String(settings.fontScale));
+};
+
+/**
+ * IMPL-330 production `OverlayViewFactory`。Shadow DOM 直接操作で overlay を
+ * 描画する。React は bundle size を抑えるため採用せず、MVP の線量であれば
+ * DOM API で十分。複雑化したら React 化を再評価する。
+ *
+ * - mount: Shadow host + base `<style>` + root `<div>` を生成
+ * - update: root `<div>` に lines を再描画、settings に応じて opacity /
+ *   font scale を変更
+ * - unmount: host を DOM から取り除く
+ */
+export const createDefaultOverlayViewFactory = (
+  deps: DefaultOverlayViewFactoryDependencies,
+): OverlayViewFactory => {
+  return (_sessionIdentifier): OverlayView => {
+    let hostElement: HTMLElement | null = null;
+    let rootElement: HTMLElement | null = null;
+
+    return {
+      mount: () => {
+        const { host, shadowRoot } = deps.documentApi.createHost();
+        hostElement = host;
+        const style = document.createElement('style');
+        style.textContent = BASE_STYLE;
+        const root = document.createElement('div');
+        root.className = 'perapera-overlay-container';
+        root.setAttribute('data-perapera-overlay-root', '');
+        shadowRoot.append(style, root);
+        rootElement = root;
+      },
+      update: (model, settings) => {
+        if (rootElement === null) return;
+        applySettings(rootElement, settings);
+        renderLines(rootElement, model);
+      },
+      unmount: () => {
+        if (hostElement !== null) {
+          deps.documentApi.removeHost(hostElement);
+          hostElement = null;
+        }
+        rootElement = null;
+      },
+    };
+  };
+};

--- a/packages/extension/src/infrastructure/overlay/index.ts
+++ b/packages/extension/src/infrastructure/overlay/index.ts
@@ -1,0 +1,12 @@
+export {
+  createContentScriptOverlayPresenter,
+  type ContentScriptOverlayPresenterDependencies,
+  type OverlayView,
+  type OverlayViewFactory,
+} from './content-script-overlay-presenter';
+export {
+  createDefaultOverlayViewFactory,
+  defaultOverlayDocumentApi,
+  type DefaultOverlayViewFactoryDependencies,
+  type OverlayDocumentApi,
+} from './default-overlay-view';


### PR DESCRIPTION
## Summary

Phase 3 §5.4 表示。`OverlayPresenter` ポート実装と production 用 `OverlayViewFactory` を追加。Shadow DOM + 直接 DOM 操作で翻訳オーバーレイを描画する。

## ContentScriptOverlayPresenter (presenter 層)

- `OverlayView` を抽象 factory 経由で DI (`overlayViewFactory`)。presenter 自身はセッション毎の view map と settings cache のみを管理し、描画詳細を隔離
- `mount` / `render` / `updateSettings` / `unmount` の 4 operation を実装
- `updateSettings` は内部 cache を更新し、次の `render` で反映 (view 側の onSettings イベントを避けて単純化)
- `mount` / `render` 内の例外は `invariantViolationError` に変換。UseCase 側の `orElse` で握り潰してホットパスを止めない (DD-305 結果整合)

## DefaultOverlayViewFactory (production helper)

- Shadow DOM host (`all: initial; position: fixed; z-index: 2147483647`) を `document.body` に注入し、ページ CSS 継承を遮断
- Base `<style>` と root `<div>` を shadowRoot に配置
- `update` で `replaceChildren` + span append による線量描画。React は bundle size を抑えるため採用せず、MVP の線量であれば DOM API で十分
- `opacity` / `fontScale` は CSS custom property (`--perapera-font-scale`) で反映
- `unmount` で host を DOM から削除、内部 ref を null 化

## Mock 防止設計

- `overlayViewFactory` / `documentApi` は全て必須 DI (default なし)
- production entrypoint で `defaultOverlayDocumentApi` と `createDefaultOverlayViewFactory` を明示的に渡す

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 562 tests)
- [x] `content-script-overlay-presenter.test.ts` (10 cases): mount 二重 / render 未 mount / updateSettings 反映 / unmount 後再 mount / factory 例外 / view.update 例外
- [x] `default-overlay-view.test.ts` (7 cases): createHost 呼び出し / line 描画 / mount 前 update no-op / opacity+fontScale 反映 / settings=null / unmount 二重

## Out of scope

- React 採用 (MVP は DOM API で線量描画、複雑化したら再評価)
- §5.5 統括 (IMPL-340-344 SessionCommandService / CaptureOrchestrator / SessionRegistry / TranscriptAssembler / ExportService) — 次の PR で