### PR TITLE
feat(application): IMPL-342/343 SessionRegistry + TranscriptAssembler

### DIFF
--- a/packages/extension/src/application/services/index.ts
+++ b/packages/extension/src/application/services/index.ts
@@ -1,0 +1,6 @@
+export { createSessionRegistry, type SessionRegistry } from './session-registry';
+export {
+  createTranscriptAssembler,
+  type TranscriptAssembler,
+  type TranscriptAssemblerEvent,
+} from './transcript-assembler';

--- a/packages/extension/src/application/services/session-registry.test.ts
+++ b/packages/extension/src/application/services/session-registry.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSourceSession,
+  startSourceSession,
+  stopSourceSession,
+  transitionSourceSessionState,
+  type SourceSession,
+} from '../../domain/session/source-session';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { createLanguagePair, type LanguagePair } from '../../domain/session/language-pair';
+import { createSessionRegistry } from './session-registry';
+
+const ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const identifier1: SessionIdentifier = parseSessionIdentifier(ID_1)._unsafeUnwrap();
+
+const LANGUAGE_PAIR: LanguagePair = createLanguagePair({
+  source: 'en-US',
+  target: 'ja-JP',
+})._unsafeUnwrap();
+
+const buildSession = (sessionIdentifier: string, state?: SourceSession['state']): SourceSession => {
+  const session = createSourceSession({
+    sessionIdentifier,
+    sourceIdentifier: SOURCE_ID,
+    sourceType: 'microphone',
+    languagePair: LANGUAGE_PAIR,
+    startedAt: '2026-04-21T00:00:00.000Z',
+  })._unsafeUnwrap();
+  if (state === undefined || state === 'idle') return session;
+  if (state === 'stopped') {
+    return startSourceSession(session)
+      .andThen((s) => transitionSourceSessionState(s, 'connecting'))
+      .andThen((s) => transitionSourceSessionState(s, 'capturing'))
+      .andThen((s) => stopSourceSession(s, { stoppedAt: '2026-04-21T00:01:00.000Z' }))
+      ._unsafeUnwrap();
+  }
+  const started = startSourceSession(session)._unsafeUnwrap();
+  if (state === 'requesting_permission') return started;
+  return transitionSourceSessionState(started, state)._unsafeUnwrap();
+};
+
+describe('createSessionRegistry (IMPL-342)', () => {
+  it('find returns undefined for unknown sessionIdentifier', () => {
+    const registry = createSessionRegistry();
+    expect(registry.find(identifier1)).toBeUndefined();
+  });
+
+  it('save stores a session retrievable by identifier', () => {
+    const registry = createSessionRegistry();
+    const session = buildSession(ID_1);
+    registry.save(session);
+    expect(registry.find(identifier1)).toEqual(session);
+  });
+
+  it('save overwrites the session for the same identifier', () => {
+    const registry = createSessionRegistry();
+    const initial = buildSession(ID_1);
+    registry.save(initial);
+    const next = buildSession(ID_1, 'connecting');
+    registry.save(next);
+    expect(registry.find(identifier1)?.state).toBe('connecting');
+  });
+
+  it('delete removes the session', () => {
+    const registry = createSessionRegistry();
+    registry.save(buildSession(ID_1));
+    registry.delete(identifier1);
+    expect(registry.find(identifier1)).toBeUndefined();
+  });
+
+  it('delete is a no-op for unknown identifiers', () => {
+    const registry = createSessionRegistry();
+    expect(() => {
+      registry.delete(identifier1);
+    }).not.toThrow();
+  });
+
+  it('findActive returns only non-stopped sessions', () => {
+    const registry = createSessionRegistry();
+    const idle = buildSession(ID_1, 'idle');
+    const stopped = buildSession(ID_2, 'stopped');
+    registry.save(idle);
+    registry.save(stopped);
+    const active = registry.findActive();
+    expect(active).toHaveLength(1);
+    expect(active[0]?.sessionIdentifier).toBe(identifier1);
+  });
+
+  it('listAll returns every registered session regardless of state', () => {
+    const registry = createSessionRegistry();
+    registry.save(buildSession(ID_1, 'idle'));
+    registry.save(buildSession(ID_2, 'stopped'));
+    expect(registry.listAll()).toHaveLength(2);
+  });
+
+  it('clear removes every session', () => {
+    const registry = createSessionRegistry();
+    registry.save(buildSession(ID_1));
+    registry.save(buildSession(ID_2));
+    registry.clear();
+    expect(registry.listAll()).toHaveLength(0);
+  });
+});

--- a/packages/extension/src/application/services/session-registry.ts
+++ b/packages/extension/src/application/services/session-registry.ts
@@ -1,0 +1,52 @@
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type SourceSession } from '../../domain/session/source-session';
+import { isActiveSession } from '../../domain/specifications/concurrent-session-limit-specification';
+
+/**
+ * IMPL-342 SessionRegistry (detailed-design §2.2)。
+ *
+ * ソースセッションの **メモリ上の正本** (`正本` = authoritative copy)。
+ * Service Worker のライフタイム内でアクティブセッションを即時参照する
+ * ための in-memory 層。IndexedDB (`ExtensionSessionRepository` 実装) は
+ * 永続化層で、registry は write-through の sync 層として機能する。
+ *
+ * 設計上の位置付け (infrastructure.md §5.1):
+ * - セッション単位のメモリ整合: 本 registry を正とする
+ * - ストレージへの遅延永続化: IndexedDB に追記保存する
+ *
+ * 用途:
+ * - `findActive`: Concurrency 制限の事前判定 (`MAX_CONCURRENT_ACTIVE_SESSIONS`)
+ * - `find`: RelayEvent 受信時の対象セッション参照
+ * - `save` / `delete`: 状態遷移の即時反映
+ */
+export type SessionRegistry = Readonly<{
+  find: (sessionIdentifier: SessionIdentifier) => SourceSession | undefined;
+  save: (session: SourceSession) => void;
+  delete: (sessionIdentifier: SessionIdentifier) => void;
+  findActive: () => readonly SourceSession[];
+  listAll: () => readonly SourceSession[];
+  clear: () => void;
+}>;
+
+/**
+ * `SessionRegistry` の factory。内部は `Map<SessionIdentifier, SourceSession>`。
+ * Service Worker 再起動で消失する性質は許容 (永続化は IndexedDB 側が担う)。
+ */
+export const createSessionRegistry = (): SessionRegistry => {
+  const sessions = new Map<SessionIdentifier, SourceSession>();
+
+  return {
+    find: (sessionIdentifier) => sessions.get(sessionIdentifier),
+    save: (session) => {
+      sessions.set(session.sessionIdentifier, session);
+    },
+    delete: (sessionIdentifier) => {
+      sessions.delete(sessionIdentifier);
+    },
+    findActive: () => [...sessions.values()].filter((session) => isActiveSession(session)),
+    listAll: () => [...sessions.values()],
+    clear: () => {
+      sessions.clear();
+    },
+  };
+};

--- a/packages/extension/src/application/services/transcript-assembler.test.ts
+++ b/packages/extension/src/application/services/transcript-assembler.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createTranscriptStream,
+  getSegment,
+  getTranslation,
+} from '../../domain/transcript/transcript-stream';
+import { createTimestampRange } from '../../domain/transcript/timestamp-range';
+import { createTranscriptAssembler } from './transcript-assembler';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const TRANSLATION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
+
+const emptyStream = () => createTranscriptStream({ sessionIdentifier: SESSION_ID })._unsafeUnwrap();
+const range = () => createTimestampRange({ startMs: 0, endMs: 1000 })._unsafeUnwrap();
+
+describe('createTranscriptAssembler (IMPL-343)', () => {
+  it('apply with partial event appends a new partial segment', () => {
+    const assembler = createTranscriptAssembler();
+    const result = assembler.apply(emptyStream(), {
+      type: 'partial',
+      segmentIdentifier: SEGMENT_ID,
+      revision: 1,
+      text: 'hello',
+      timeRange: range(),
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const segment = getSegment(result.value, SEGMENT_ID);
+      expect(segment).not.toBeUndefined();
+      expect(segment?.text).toBe('hello');
+      expect(segment?.isFinal).toBe(false);
+    }
+  });
+
+  it('apply with partial event updates an existing partial segment when revision is higher', () => {
+    const assembler = createTranscriptAssembler();
+    const first = assembler
+      .apply(emptyStream(), {
+        type: 'partial',
+        segmentIdentifier: SEGMENT_ID,
+        revision: 1,
+        text: 'he',
+        timeRange: range(),
+      })
+      ._unsafeUnwrap();
+    const second = assembler.apply(first, {
+      type: 'partial',
+      segmentIdentifier: SEGMENT_ID,
+      revision: 2,
+      text: 'hello',
+      timeRange: range(),
+    });
+    expect(second.isOk()).toBe(true);
+    if (second.isOk()) {
+      expect(getSegment(second.value, SEGMENT_ID)?.text).toBe('hello');
+    }
+  });
+
+  it('apply with final event without prior partial requires text and timeRange', () => {
+    const assembler = createTranscriptAssembler();
+    const result = assembler.apply(emptyStream(), {
+      type: 'final',
+      segmentIdentifier: SEGMENT_ID,
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+  });
+
+  it('apply with final event after partial marks the segment as final', () => {
+    const assembler = createTranscriptAssembler();
+    const partial = assembler
+      .apply(emptyStream(), {
+        type: 'partial',
+        segmentIdentifier: SEGMENT_ID,
+        revision: 1,
+        text: 'hello',
+        timeRange: range(),
+      })
+      ._unsafeUnwrap();
+    const finalResult = assembler.apply(partial, {
+      type: 'final',
+      segmentIdentifier: SEGMENT_ID,
+    });
+    expect(finalResult.isOk()).toBe(true);
+    if (finalResult.isOk()) {
+      expect(getSegment(finalResult.value, SEGMENT_ID)?.isFinal).toBe(true);
+    }
+  });
+
+  it('apply with translation event attaches translation to finalized segment', () => {
+    const assembler = createTranscriptAssembler();
+    const finalized = assembler
+      .apply(emptyStream(), {
+        type: 'partial',
+        segmentIdentifier: SEGMENT_ID,
+        revision: 1,
+        text: 'hello',
+        timeRange: range(),
+      })
+      .andThen((s) =>
+        assembler.apply(s, {
+          type: 'final',
+          segmentIdentifier: SEGMENT_ID,
+        }),
+      )
+      ._unsafeUnwrap();
+    const translated = assembler.apply(finalized, {
+      type: 'translation',
+      translationIdentifier: TRANSLATION_ID,
+      segmentIdentifier: SEGMENT_ID,
+      targetLanguage: 'ja',
+      text: 'こんにちは',
+    });
+    expect(translated.isOk()).toBe(true);
+    if (translated.isOk()) {
+      const translation = getTranslation(translated.value, SEGMENT_ID);
+      expect(translation).not.toBeUndefined();
+      if (translation?.status === 'completed') {
+        expect(translation.text).toBe('こんにちは');
+      }
+    }
+  });
+
+  it('apply with translation event before finalization returns invariant-violation', () => {
+    const assembler = createTranscriptAssembler();
+    const partial = assembler
+      .apply(emptyStream(), {
+        type: 'partial',
+        segmentIdentifier: SEGMENT_ID,
+        revision: 1,
+        text: 'hello',
+        timeRange: range(),
+      })
+      ._unsafeUnwrap();
+    const translated = assembler.apply(partial, {
+      type: 'translation',
+      translationIdentifier: TRANSLATION_ID,
+      segmentIdentifier: SEGMENT_ID,
+      targetLanguage: 'ja',
+      text: 'こんにちは',
+    });
+    expect(translated.isErr()).toBe(true);
+    if (translated.isErr()) expect(translated.error.kind).toBe('invariant-violation');
+  });
+});

--- a/packages/extension/src/application/services/transcript-assembler.ts
+++ b/packages/extension/src/application/services/transcript-assembler.ts
@@ -1,0 +1,82 @@
+import { type Result } from 'neverthrow';
+import { type DomainError } from '../../domain/shared/errors';
+import { type TimestampRange } from '../../domain/transcript/timestamp-range';
+import {
+  appendPartialTranscriptSegment,
+  attachTranslationToSegment,
+  finalizeSegment,
+  type TranscriptStream,
+} from '../../domain/transcript/transcript-stream';
+
+/**
+ * TranscriptAssembler が処理する `TranscriptEvent` discriminated union。
+ * Relay API から受信した字幕 / 翻訳イベント (api-specification §6.3) を
+ * application 層の形式に正規化したもの。
+ */
+export type TranscriptAssemblerEvent =
+  | Readonly<{
+      type: 'partial';
+      segmentIdentifier: string;
+      revision: number;
+      text: string;
+      timeRange: TimestampRange;
+    }>
+  | Readonly<{
+      type: 'final';
+      segmentIdentifier: string;
+      text?: string;
+      timeRange?: TimestampRange;
+    }>
+  | Readonly<{
+      type: 'translation';
+      translationIdentifier: string;
+      segmentIdentifier: string;
+      targetLanguage: string;
+      text: string;
+    }>;
+
+/**
+ * IMPL-343 TranscriptAssembler (detailed-design §2.2)。
+ *
+ * Relay からの字幕 / 翻訳イベントを `TranscriptStream` 集約の immutable 更新に
+ * 適用する薄い coordinator。ドメインの集約操作関数
+ * (`appendPartialTranscriptSegment` / `finalizeSegment` /
+ * `attachTranslationToSegment`) を event.type で分岐して呼び分けるのみ。
+ *
+ * 純粋関数なので DI なし。複数 session 間で共有しても副作用なし。
+ */
+export type TranscriptAssembler = Readonly<{
+  apply: (
+    stream: TranscriptStream,
+    event: TranscriptAssemblerEvent,
+  ) => Result<TranscriptStream, DomainError>;
+}>;
+
+export const createTranscriptAssembler = (): TranscriptAssembler => ({
+  apply: (stream, event) => {
+    switch (event.type) {
+      case 'partial':
+        return appendPartialTranscriptSegment(stream, {
+          segmentIdentifier: event.segmentIdentifier,
+          revision: event.revision,
+          text: event.text,
+          timeRange: event.timeRange,
+        });
+      case 'final': {
+        const params: Parameters<typeof finalizeSegment>[1] = {
+          segmentIdentifier: event.segmentIdentifier,
+        };
+        if (event.text !== undefined) params.text = event.text;
+        if (event.timeRange !== undefined) params.timeRange = event.timeRange;
+        return finalizeSegment(stream, params);
+      }
+      case 'translation':
+        return attachTranslationToSegment(stream, {
+          translationIdentifier: event.translationIdentifier,
+          segmentIdentifier: event.segmentIdentifier,
+          targetLanguage: event.targetLanguage,
+          text: event.text,
+        });
+    }
+  },
+});


### PR DESCRIPTION
## Summary

Phase 3 §5.5 統括 の前半。メモリ上のセッション正本と字幕 assembler を追加。UseCase 実装の依存先として利用可能な状態にする (IMPL-340 SessionCommandService でこれらを配線する予定)。

## SessionRegistry (IMPL-342)

- Service Worker 内 lifetime の**メモリ正本** (`infrastructure.md` §5.1)。`Map<SessionIdentifier, SourceSession>` をラップし、`find` / `save` / `delete` / `findActive` / `listAll` / `clear` を提供
- `findActive` は `isActiveSession` spec (`stopped` 以外) で filter
- 永続化は IndexedDB (`ExtensionSessionRepository` 実装) 側が担う write-through 想定。registry 消失は Service Worker 再起動時に許容

## TranscriptAssembler (IMPL-343)

- `TranscriptAssemblerEvent` discriminated union (`partial` / `final` / `translation`)
- `event.type` で分岐し、domain の集約操作関数 (`appendPartialTranscriptSegment` / `finalizeSegment` / `attachTranslationToSegment`) を呼び分ける薄い coordinator
- 純粋関数で DI 不要

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 576 tests)
- [x] `session-registry.test.ts` (8 cases): find/save/delete/findActive/listAll/clear の網羅
- [x] `transcript-assembler.test.ts` (6 cases): partial 追加 / 部分更新 / final without partial (invariant-violation) / final after partial / translation 正常系 / translation before finalization (invariant-violation)

## Out of scope

- IMPL-340 SessionCommandService (本 registry/assembler を配線する facade) — 後続 PR
- IMPL-341 CaptureOrchestrator (SourceAdapterFactory + AudioPreprocessor を束ねる) — 後続 PR
- IMPL-344 ExportService (ExportSessionResultUseCase の facade) — 後続 PR