### PR TITLE
feat(application): IMPL-341/344 CaptureOrchestrator + ExportService

### DIFF
--- a/packages/extension/src/application/services/capture-orchestrator.test.ts
+++ b/packages/extension/src/application/services/capture-orchestrator.test.ts
@@ -1,0 +1,165 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { invariantViolationError } from '../../domain/shared/errors';
+import { type AudioFrameChannel, type AudioPreprocessor } from '../ports/audio-preprocessor';
+import {
+  type SourceAdapter,
+  type SourceAdapterFactory,
+  type StartSourceCommand,
+} from '../ports/source-adapter';
+import { createCaptureOrchestrator } from './capture-orchestrator';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const buildCommand = (): StartSourceCommand => ({
+  sourceType: 'microphone',
+  sessionIdentifier,
+  deviceId: 'default',
+});
+
+const buildFrameChannel = (): AudioFrameChannel & { close: ReturnType<typeof vi.fn> } => ({
+  frames: {
+    [Symbol.asyncIterator]: () => ({
+      next: () => Promise.resolve({ done: true as const, value: undefined }),
+    }),
+  },
+  close: vi.fn(),
+});
+
+const buildAdapter = (): SourceAdapter & {
+  open: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+} => {
+  const stream = new MediaStream();
+  const open = vi.fn(() => okAsync<MediaStream, never>(stream));
+  const close = vi.fn(() => okAsync<void, never>(undefined));
+  return { open, close };
+};
+
+const buildFactory = (
+  adapter: SourceAdapter,
+): SourceAdapterFactory & {
+  create: ReturnType<typeof vi.fn>;
+} => {
+  const create = vi.fn(() => adapter);
+  return { create };
+};
+
+const buildPreprocessor = (
+  channel: AudioFrameChannel,
+): AudioPreprocessor & {
+  attach: ReturnType<typeof vi.fn>;
+  detach: ReturnType<typeof vi.fn>;
+} => ({
+  attach: vi.fn(() => okAsync<AudioFrameChannel, never>(channel)),
+  detach: vi.fn(() => okAsync<void, never>(undefined)),
+});
+
+describe('createCaptureOrchestrator (IMPL-341)', () => {
+  it('connect opens the adapter and attaches preprocessor, returning ActiveCapture', async () => {
+    const adapter = buildAdapter();
+    const factory = buildFactory(adapter);
+    const channel = buildFrameChannel();
+    const preprocessor = buildPreprocessor(channel);
+    const orchestrator = createCaptureOrchestrator({
+      sourceAdapterFactory: factory,
+      audioPreprocessor: preprocessor,
+    });
+    const result = await orchestrator.connect(buildCommand());
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessionIdentifier).toBe(sessionIdentifier);
+      expect(result.value.frameChannel).toBe(channel);
+    }
+    expect(factory.create).toHaveBeenCalledWith('microphone');
+    expect(adapter.open).toHaveBeenCalledTimes(1);
+    expect(preprocessor.attach).toHaveBeenCalledTimes(1);
+  });
+
+  it('connect surfaces adapter open failure', async () => {
+    const adapter: SourceAdapter = {
+      open: () =>
+        errAsync(invariantViolationError({ invariant: 'source-open-failed', details: 'boom' })),
+      close: () => okAsync<void, never>(undefined),
+    };
+    const orchestrator = createCaptureOrchestrator({
+      sourceAdapterFactory: buildFactory(adapter),
+      audioPreprocessor: buildPreprocessor(buildFrameChannel()),
+    });
+    const result = await orchestrator.connect(buildCommand());
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('connect surfaces preprocessor attach failure', async () => {
+    const adapter = buildAdapter();
+    const factory = buildFactory(adapter);
+    const preprocessor: AudioPreprocessor = {
+      attach: () =>
+        errAsync(
+          invariantViolationError({
+            invariant: 'audio-context-unavailable',
+            details: 'no AudioContext',
+          }),
+        ),
+      detach: () => okAsync<void, never>(undefined),
+    };
+    const orchestrator = createCaptureOrchestrator({
+      sourceAdapterFactory: factory,
+      audioPreprocessor: preprocessor,
+    });
+    const result = await orchestrator.connect(buildCommand());
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('disconnect closes the frame channel and the adapter', async () => {
+    const adapter = buildAdapter();
+    const factory = buildFactory(adapter);
+    const channel = buildFrameChannel();
+    const preprocessor = buildPreprocessor(channel);
+    const orchestrator = createCaptureOrchestrator({
+      sourceAdapterFactory: factory,
+      audioPreprocessor: preprocessor,
+    });
+    await orchestrator.connect(buildCommand());
+    const result = await orchestrator.disconnect(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    expect(channel.close).toHaveBeenCalledTimes(1);
+    expect(preprocessor.detach).toHaveBeenCalledWith(sessionIdentifier);
+    expect(adapter.close).toHaveBeenCalledWith(sessionIdentifier);
+  });
+
+  it('disconnect is a no-op for an unknown session', async () => {
+    const adapter = buildAdapter();
+    const preprocessor = buildPreprocessor(buildFrameChannel());
+    const orchestrator = createCaptureOrchestrator({
+      sourceAdapterFactory: buildFactory(adapter),
+      audioPreprocessor: preprocessor,
+    });
+    const result = await orchestrator.disconnect(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    expect(preprocessor.detach).not.toHaveBeenCalled();
+    expect(adapter.close).not.toHaveBeenCalled();
+  });
+
+  it('disconnect after a failed connect is still a no-op', async () => {
+    const adapter: SourceAdapter = {
+      open: () =>
+        errAsync(invariantViolationError({ invariant: 'source-open-failed', details: 'boom' })),
+      close: vi.fn(() => okAsync<void, never>(undefined)),
+    };
+    const preprocessor = buildPreprocessor(buildFrameChannel());
+    const orchestrator = createCaptureOrchestrator({
+      sourceAdapterFactory: buildFactory(adapter),
+      audioPreprocessor: preprocessor,
+    });
+    await orchestrator.connect(buildCommand());
+    const result = await orchestrator.disconnect(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    expect(preprocessor.detach).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/src/application/services/capture-orchestrator.ts
+++ b/packages/extension/src/application/services/capture-orchestrator.ts
@@ -1,0 +1,78 @@
+import { okAsync, type ResultAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type SourceType } from '../../domain/session/source-type';
+import { type DomainError } from '../../domain/shared/errors';
+import { type AudioFrameChannel, type AudioPreprocessor } from '../ports/audio-preprocessor';
+import { type SourceAdapterFactory, type StartSourceCommand } from '../ports/source-adapter';
+
+/**
+ * Active な音声キャプチャ 1 本の実体。
+ * - `stream`: Source Adapter で開いた `MediaStream`
+ * - `frameChannel`: AudioPreprocessor で attach した PCM フレーム配信 channel
+ * - `sourceType`: disconnect 時に SourceAdapter を再取得するため保持
+ */
+export type ActiveCapture = Readonly<{
+  sessionIdentifier: SessionIdentifier;
+  sourceType: SourceType;
+  stream: MediaStream;
+  frameChannel: AudioFrameChannel;
+}>;
+
+export type CaptureOrchestratorDependencies = Readonly<{
+  sourceAdapterFactory: SourceAdapterFactory;
+  audioPreprocessor: AudioPreprocessor;
+}>;
+
+/**
+ * IMPL-341 CaptureOrchestrator (detailed-design §2.2)。
+ *
+ * `SourceAdapter` と `AudioPreprocessor` を束ねる application service。
+ * `connect(command)` でソース接続 → 音声前処理 attach を一括で行い、
+ * `ActiveCapture` を返す。`disconnect(sessionIdentifier)` で逆順に解放する。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - `sourceAdapterFactory` / `audioPreprocessor` は必須 DI (default なし)
+ * - production entrypoint で対応する infrastructure adapter を明示的に渡す
+ *
+ * 注: pause / resume は MVP の scope 外。Relay gateway 側のセッション
+ * 状態変更で実現する (AudioContext suspend は AudioPreprocessor の
+ * port interface に現時点では存在しない)。
+ */
+export type CaptureOrchestrator = Readonly<{
+  connect: (command: StartSourceCommand) => ResultAsync<ActiveCapture, DomainError>;
+  disconnect: (sessionIdentifier: SessionIdentifier) => ResultAsync<void, DomainError>;
+}>;
+
+export const createCaptureOrchestrator = (
+  deps: CaptureOrchestratorDependencies,
+): CaptureOrchestrator => {
+  const active = new Map<SessionIdentifier, ActiveCapture>();
+
+  return {
+    connect: (command) => {
+      const adapter = deps.sourceAdapterFactory.create(command.sourceType);
+      return adapter.open(command).andThen((stream) =>
+        deps.audioPreprocessor.attach(stream, command.sessionIdentifier).map((frameChannel) => {
+          const capture: ActiveCapture = {
+            sessionIdentifier: command.sessionIdentifier,
+            sourceType: command.sourceType,
+            stream,
+            frameChannel,
+          };
+          active.set(command.sessionIdentifier, capture);
+          return capture;
+        }),
+      );
+    },
+    disconnect: (sessionIdentifier) => {
+      const capture = active.get(sessionIdentifier);
+      if (capture === undefined) return okAsync<void, DomainError>(undefined);
+      active.delete(sessionIdentifier);
+      capture.frameChannel.close();
+      const adapter = deps.sourceAdapterFactory.create(capture.sourceType);
+      return deps.audioPreprocessor
+        .detach(sessionIdentifier)
+        .andThen(() => adapter.close(sessionIdentifier));
+    },
+  };
+};

--- a/packages/extension/src/application/services/export-service.test.ts
+++ b/packages/extension/src/application/services/export-service.test.ts
@@ -1,0 +1,49 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type ExportSessionResultInput,
+  type ExportSessionResultOutput,
+} from '../dto/export-session-result-dto';
+import { sessionNotFoundAppError } from '../errors/application-errors';
+import { type ExportSessionResultUseCase } from '../use-cases/export-session-result-use-case';
+import { createExportService } from './export-service';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+
+const buildInput = (): ExportSessionResultInput => ({
+  sessionId: SESSION_ID,
+  format: 'txt',
+  includeOriginal: true,
+  includeTranslation: true,
+});
+
+const buildOutput = (): ExportSessionResultOutput => ({
+  exportId: '01HZX8Y1R8M7D3Q2P4T5V6W7B1',
+  format: 'txt',
+  bytes: 42,
+});
+
+describe('createExportService (IMPL-344)', () => {
+  it('export delegates to the ExportSessionResultUseCase and returns the output', async () => {
+    const useCase = vi.fn<ExportSessionResultUseCase>(() => okAsync(buildOutput()));
+    const service = createExportService({ exportSessionResultUseCase: useCase });
+    const result = await service.export(buildInput());
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.exportId).toBe('01HZX8Y1R8M7D3Q2P4T5V6W7B1');
+    }
+    expect(useCase).toHaveBeenCalledWith(buildInput());
+  });
+
+  it('export propagates useCase failures', async () => {
+    const appError = sessionNotFoundAppError({
+      identifier: SESSION_ID,
+      message: 'session not found',
+    });
+    const useCase: ExportSessionResultUseCase = () => errAsync(appError);
+    const service = createExportService({ exportSessionResultUseCase: useCase });
+    const result = await service.export(buildInput());
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.code).toBe('SESSION_NOT_FOUND');
+  });
+});

--- a/packages/extension/src/application/services/export-service.ts
+++ b/packages/extension/src/application/services/export-service.ts
@@ -1,0 +1,36 @@
+import { type ResultAsync } from 'neverthrow';
+import {
+  type ExportSessionResultInput,
+  type ExportSessionResultOutput,
+} from '../dto/export-session-result-dto';
+import { type ApplicationError } from '../errors/application-errors';
+import { type ExportSessionResultUseCase } from '../use-cases/export-session-result-use-case';
+
+/**
+ * IMPL-344 ExportService (detailed-design §2.2)。
+ *
+ * `ExportSessionResultUseCase` を presentation 層 (SidePanelController) に
+ * 公開する薄い facade。class diagram 上で独立した service として存在する
+ * ため、直接 UseCase を注入するより名前付き service を間に挟むことで
+ * 依存方向が明確になる。
+ *
+ * 用途:
+ * - SidePanelController は `exportService.export(command)` を呼ぶだけで済む
+ * - UseCase の実装詳細 (repository / assembly service) は隠蔽される
+ *
+ * 本 service 自身にロジックを持たせず、上位で UseCase を差し替える際の
+ * 配線点 (seam) として機能する。
+ */
+export type ExportService = Readonly<{
+  export: (
+    input: ExportSessionResultInput,
+  ) => ResultAsync<ExportSessionResultOutput, ApplicationError>;
+}>;
+
+export type ExportServiceDependencies = Readonly<{
+  exportSessionResultUseCase: ExportSessionResultUseCase;
+}>;
+
+export const createExportService = (deps: ExportServiceDependencies): ExportService => ({
+  export: (input) => deps.exportSessionResultUseCase(input),
+});

--- a/packages/extension/src/application/services/index.ts
+++ b/packages/extension/src/application/services/index.ts
@@ -1,3 +1,14 @@
+export {
+  createCaptureOrchestrator,
+  type ActiveCapture,
+  type CaptureOrchestrator,
+  type CaptureOrchestratorDependencies,
+} from './capture-orchestrator';
+export {
+  createExportService,
+  type ExportService,
+  type ExportServiceDependencies,
+} from './export-service';
 export { createSessionRegistry, type SessionRegistry } from './session-registry';
 export {
   createTranscriptAssembler,


### PR DESCRIPTION
## Summary

Phase 3 §5.5 統括 の中盤。音声キャプチャの束ね役と Export 用 facade を追加。

## CaptureOrchestrator (IMPL-341)

- `SourceAdapterFactory` と `AudioPreprocessor` を束ねる application service
- `connect(command)`: SourceType に応じた `adapter.open` → `AudioPreprocessor.attach` → `ActiveCapture` を返す
- `disconnect(sessionIdentifier)`: `frameChannel.close` → `audioPreprocessor.detach` → `adapter.close` の逆順で解放
- `ActiveCapture` に `sourceType` も保持 (disconnect で同じ adapter を再取得するため)
- `pause` / `resume` は MVP の scope 外 (AudioContext suspend は port に存在しない)

## ExportService (IMPL-344)

- `ExportSessionResultUseCase` を presentation 層に公開する薄い facade
- 将来 UseCase の実装を差し替える際の seam

## Mock 防止設計

- `sourceAdapterFactory` / `audioPreprocessor` / `exportSessionResultUseCase` は全て必須 DI

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 584 tests)
- [x] `capture-orchestrator.test.ts` (6 cases): connect 正常系 / adapter open 失敗 / preprocessor attach 失敗 / disconnect tracks+adapter / 未接続 session / 失敗後 disconnect
- [x] `export-service.test.ts` (2 cases): UseCase へ delegate / 失敗を伝播

## Out of scope

- IMPL-340 SessionCommandService (§5.5 最終段の facade、本 PR の registry/assembler/orchestrator を配線) — 後続 PR で Phase 3 completion