### PR TITLE
feat(application): IMPL-340 SessionCommandService — Phase 3 §5.5 完了

### DIFF
--- a/packages/extension/src/application/services/index.ts
+++ b/packages/extension/src/application/services/index.ts
@@ -9,6 +9,11 @@ export {
   type ExportService,
   type ExportServiceDependencies,
 } from './export-service';
+export {
+  createSessionCommandService,
+  type SessionCommandService,
+  type SessionCommandServiceDependencies,
+} from './session-command-service';
 export { createSessionRegistry, type SessionRegistry } from './session-registry';
 export {
   createTranscriptAssembler,

--- a/packages/extension/src/application/services/session-command-service.test.ts
+++ b/packages/extension/src/application/services/session-command-service.test.ts
@@ -1,0 +1,226 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import { parseSessionIdentifier } from '../../domain/session/session-identifier';
+import { type HandleTranscriptFinalOutput } from '../dto/handle-transcript-final-dto';
+import { type HandleTranscriptPartialOutput } from '../dto/handle-transcript-partial-dto';
+import {
+  type StartSourceSessionInput,
+  type StartSourceSessionOutput,
+} from '../dto/start-source-session-dto';
+import {
+  type StopSourceSessionInput,
+  type StopSourceSessionOutput,
+} from '../dto/stop-source-session-dto';
+import {
+  type UpdateSourceSettingsInput,
+  type UpdateSourceSettingsOutput,
+} from '../dto/update-source-settings-dto';
+import { internalAppError, sessionNotFoundAppError } from '../errors/application-errors';
+import { type RelayEvent } from '../ports/relay-gateway';
+import { type HandleTranscriptFinalUseCase } from '../use-cases/handle-transcript-final-use-case';
+import { type HandleTranscriptPartialUseCase } from '../use-cases/handle-transcript-partial-use-case';
+import { type StartSourceSessionUseCase } from '../use-cases/start-source-session-use-case';
+import { type StopSourceSessionUseCase } from '../use-cases/stop-source-session-use-case';
+import { type UpdateSourceSettingsUseCase } from '../use-cases/update-source-settings-use-case';
+import { createSessionCommandService } from './session-command-service';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const sessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const TRANSLATION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
+
+const clock = () => 1_700_000_000_000;
+
+const startInput: StartSourceSessionInput = {
+  sourceType: 'microphone',
+  displayName: 'Mic',
+  autoDetectLanguage: false,
+  targetLanguage: 'ja-JP',
+  overlayTarget: { kind: 'extension-monitor' },
+};
+const stopInput: StopSourceSessionInput = { sessionId: SESSION_ID };
+const updateInput: UpdateSourceSettingsInput = { sessionId: SESSION_ID };
+
+type Mocks = {
+  startSourceSessionUseCase: ReturnType<typeof vi.fn<StartSourceSessionUseCase>>;
+  stopSourceSessionUseCase: ReturnType<typeof vi.fn<StopSourceSessionUseCase>>;
+  updateSourceSettingsUseCase: ReturnType<typeof vi.fn<UpdateSourceSettingsUseCase>>;
+  handleTranscriptPartialUseCase: ReturnType<typeof vi.fn<HandleTranscriptPartialUseCase>>;
+  handleTranscriptFinalUseCase: ReturnType<typeof vi.fn<HandleTranscriptFinalUseCase>>;
+};
+
+const buildMocks = (): Mocks => ({
+  startSourceSessionUseCase: vi.fn<StartSourceSessionUseCase>(() =>
+    okAsync<StartSourceSessionOutput, never>({
+      sessionId: SESSION_ID,
+      state: 'connecting',
+      startedAt: '2026-04-21T00:00:00.000Z',
+    }),
+  ),
+  stopSourceSessionUseCase: vi.fn<StopSourceSessionUseCase>(() =>
+    okAsync<StopSourceSessionOutput, never>({
+      sessionId: SESSION_ID,
+      state: 'stopped',
+      stoppedAt: '2026-04-21T00:01:00.000Z',
+    }),
+  ),
+  updateSourceSettingsUseCase: vi.fn<UpdateSourceSettingsUseCase>(() =>
+    okAsync<UpdateSourceSettingsOutput, never>({
+      sessionId: SESSION_ID,
+      appliedAt: '2026-04-21T00:00:30.000Z',
+    }),
+  ),
+  handleTranscriptPartialUseCase: vi.fn<HandleTranscriptPartialUseCase>(() =>
+    okAsync<HandleTranscriptPartialOutput, never>({
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      revision: 1,
+      renderModel: {
+        sessionIdentifier,
+        lines: [],
+      },
+    }),
+  ),
+  handleTranscriptFinalUseCase: vi.fn<HandleTranscriptFinalUseCase>(() =>
+    okAsync<HandleTranscriptFinalOutput, never>({
+      sessionId: SESSION_ID,
+      segmentId: SEGMENT_ID,
+      translationStatus: 'pending',
+      renderModel: {
+        sessionIdentifier,
+        lines: [],
+      },
+    }),
+  ),
+});
+
+describe('createSessionCommandService (IMPL-340)', () => {
+  it('startSource delegates to StartSourceSessionUseCase', async () => {
+    const mocks = buildMocks();
+    const service = createSessionCommandService({ ...mocks, clock });
+    const result = await service.startSource(startInput);
+    expect(result.isOk()).toBe(true);
+    expect(mocks.startSourceSessionUseCase).toHaveBeenCalledWith(startInput);
+  });
+
+  it('stopSource delegates to StopSourceSessionUseCase', async () => {
+    const mocks = buildMocks();
+    const service = createSessionCommandService({ ...mocks, clock });
+    const result = await service.stopSource(stopInput);
+    expect(result.isOk()).toBe(true);
+    expect(mocks.stopSourceSessionUseCase).toHaveBeenCalledWith(stopInput);
+  });
+
+  it('applySourceSettings delegates to UpdateSourceSettingsUseCase', async () => {
+    const mocks = buildMocks();
+    const service = createSessionCommandService({ ...mocks, clock });
+    const result = await service.applySourceSettings(updateInput);
+    expect(result.isOk()).toBe(true);
+    expect(mocks.updateSourceSettingsUseCase).toHaveBeenCalledWith(updateInput);
+  });
+
+  it('startSource propagates UseCase failures', async () => {
+    const mocks = buildMocks();
+    mocks.startSourceSessionUseCase.mockReturnValueOnce(
+      errAsync(internalAppError({ message: 'boom' })),
+    );
+    const service = createSessionCommandService({ ...mocks, clock });
+    const result = await service.startSource(startInput);
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('handleRelayEvent routes transcript.partial to HandleTranscriptPartialUseCase', async () => {
+    const mocks = buildMocks();
+    const service = createSessionCommandService({ ...mocks, clock });
+    const event: RelayEvent = {
+      type: 'transcript.partial',
+      sessionIdentifier,
+      segmentIdentifier: SEGMENT_ID,
+      revision: 1,
+      text: 'hello',
+    };
+    const result = await service.handleRelayEvent(event);
+    expect(result.isOk()).toBe(true);
+    expect(mocks.handleTranscriptPartialUseCase).toHaveBeenCalledTimes(1);
+    const call = mocks.handleTranscriptPartialUseCase.mock.calls[0]?.[0];
+    expect(call?.sessionId).toBe(SESSION_ID);
+    expect(call?.segmentId).toBe(SEGMENT_ID);
+    expect(call?.text).toBe('hello');
+  });
+
+  it('handleRelayEvent routes transcript.final to HandleTranscriptFinalUseCase (without translation)', async () => {
+    const mocks = buildMocks();
+    const service = createSessionCommandService({ ...mocks, clock });
+    const event: RelayEvent = {
+      type: 'transcript.final',
+      sessionIdentifier,
+      segmentIdentifier: SEGMENT_ID,
+      text: 'hello',
+      finalizedAt: '2026-04-21T00:00:15.000Z',
+    };
+    const result = await service.handleRelayEvent(event);
+    expect(result.isOk()).toBe(true);
+    expect(mocks.handleTranscriptFinalUseCase).toHaveBeenCalledTimes(1);
+    const call = mocks.handleTranscriptFinalUseCase.mock.calls[0]?.[0];
+    expect(call?.translation).toBeUndefined();
+  });
+
+  it('handleRelayEvent routes translation.final to HandleTranscriptFinalUseCase with translation payload', async () => {
+    const mocks = buildMocks();
+    const service = createSessionCommandService({ ...mocks, clock });
+    const event: RelayEvent = {
+      type: 'translation.final',
+      sessionIdentifier,
+      segmentIdentifier: SEGMENT_ID,
+      translationIdentifier: TRANSLATION_ID,
+      targetLanguage: 'ja',
+      text: 'こんにちは',
+    };
+    const result = await service.handleRelayEvent(event);
+    expect(result.isOk()).toBe(true);
+    expect(mocks.handleTranscriptFinalUseCase).toHaveBeenCalledTimes(1);
+    const call = mocks.handleTranscriptFinalUseCase.mock.calls[0]?.[0];
+    expect(call?.translation?.status).toBe('completed');
+    expect(call?.translation?.text).toBe('こんにちは');
+  });
+
+  it('handleRelayEvent returns ok for non-transcript events (no-op)', async () => {
+    const mocks = buildMocks();
+    const service = createSessionCommandService({ ...mocks, clock });
+    const events: RelayEvent[] = [
+      { type: 'session.ready', sessionIdentifier, streamToken: 'tok' },
+      { type: 'session.state.changed', sessionIdentifier, state: 'capturing' },
+      {
+        type: 'session.error',
+        sessionIdentifier,
+        code: 'STT_ERROR',
+        message: 'boom',
+        retryable: true,
+        fatal: false,
+      },
+    ];
+    for (const event of events) {
+      const result = await service.handleRelayEvent(event);
+      expect(result.isOk()).toBe(true);
+    }
+    expect(mocks.handleTranscriptPartialUseCase).not.toHaveBeenCalled();
+    expect(mocks.handleTranscriptFinalUseCase).not.toHaveBeenCalled();
+  });
+
+  it('handleRelayEvent surfaces UseCase failures', async () => {
+    const mocks = buildMocks();
+    mocks.handleTranscriptFinalUseCase.mockReturnValueOnce(
+      errAsync(sessionNotFoundAppError({ identifier: SESSION_ID, message: 'no' })),
+    );
+    const service = createSessionCommandService({ ...mocks, clock });
+    const event: RelayEvent = {
+      type: 'transcript.final',
+      sessionIdentifier,
+      segmentIdentifier: SEGMENT_ID,
+      text: 'hello',
+      finalizedAt: '2026-04-21T00:00:15.000Z',
+    };
+    const result = await service.handleRelayEvent(event);
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/extension/src/application/services/session-command-service.ts
+++ b/packages/extension/src/application/services/session-command-service.ts
@@ -1,0 +1,154 @@
+import { okAsync, type ResultAsync } from 'neverthrow';
+import {
+  type HandleTranscriptFinalInput,
+  type HandleTranscriptFinalOutput,
+} from '../dto/handle-transcript-final-dto';
+import {
+  type HandleTranscriptPartialInput,
+  type HandleTranscriptPartialOutput,
+} from '../dto/handle-transcript-partial-dto';
+import {
+  type StartSourceSessionInput,
+  type StartSourceSessionOutput,
+} from '../dto/start-source-session-dto';
+import {
+  type StopSourceSessionInput,
+  type StopSourceSessionOutput,
+} from '../dto/stop-source-session-dto';
+import {
+  type UpdateSourceSettingsInput,
+  type UpdateSourceSettingsOutput,
+} from '../dto/update-source-settings-dto';
+import { type ApplicationError } from '../errors/application-errors';
+import { type RelayEvent } from '../ports/relay-gateway';
+import { type HandleTranscriptFinalUseCase } from '../use-cases/handle-transcript-final-use-case';
+import { type HandleTranscriptPartialUseCase } from '../use-cases/handle-transcript-partial-use-case';
+import { type StartSourceSessionUseCase } from '../use-cases/start-source-session-use-case';
+import { type StopSourceSessionUseCase } from '../use-cases/stop-source-session-use-case';
+import { type UpdateSourceSettingsUseCase } from '../use-cases/update-source-settings-use-case';
+
+/**
+ * IMPL-340 SessionCommandService (detailed-design §2.2 中核)。
+ *
+ * Popup / SidePanel controller へ公開する **application-level facade**。
+ * 複数の UseCase を 1 つの service にまとめ、controller が個別 UseCase を
+ * 知らなくて済むようにする。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - 5 UseCase と clock は全て必須 DI (default なし)
+ * - production entrypoint で createStartSourceSessionUseCase 等の factory
+ *   呼び出しを経由して明示的に配線する
+ *
+ * **handleRelayEvent の方針**:
+ * - `transcript.partial` → HandleTranscriptPartialUseCase (時刻は clock() から合成)
+ * - `transcript.final` → HandleTranscriptFinalUseCase (translation なし)
+ * - `translation.final` → HandleTranscriptFinalUseCase (translation 付き)
+ * - `session.ready` / `session.state.changed` / `session.error` は現状 no-op。
+ *   これらは `SessionRegistry` や controller 側の UI 更新でハンドリング想定
+ *
+ * 注: `transcript.partial` / `final` の `timeRange` は RelayEvent に含まれない
+ * ため `clock()` を起点に 100ms 幅で合成する。将来 Relay API が時刻を含む
+ * ように更新されたら差し替える。
+ */
+export type SessionCommandService = Readonly<{
+  startSource: (
+    input: StartSourceSessionInput,
+  ) => ResultAsync<StartSourceSessionOutput, ApplicationError>;
+  stopSource: (
+    input: StopSourceSessionInput,
+  ) => ResultAsync<StopSourceSessionOutput, ApplicationError>;
+  applySourceSettings: (
+    input: UpdateSourceSettingsInput,
+  ) => ResultAsync<UpdateSourceSettingsOutput, ApplicationError>;
+  handleRelayEvent: (event: RelayEvent) => ResultAsync<void, ApplicationError>;
+}>;
+
+export type SessionCommandServiceDependencies = Readonly<{
+  startSourceSessionUseCase: StartSourceSessionUseCase;
+  stopSourceSessionUseCase: StopSourceSessionUseCase;
+  updateSourceSettingsUseCase: UpdateSourceSettingsUseCase;
+  handleTranscriptPartialUseCase: HandleTranscriptPartialUseCase;
+  handleTranscriptFinalUseCase: HandleTranscriptFinalUseCase;
+  clock: () => number;
+}>;
+
+const FRAME_WINDOW_MS = 100;
+
+const toPartialInput = (
+  event: Extract<RelayEvent, { type: 'transcript.partial' }>,
+  nowMs: number,
+): HandleTranscriptPartialInput => ({
+  sessionId: event.sessionIdentifier,
+  segmentId: event.segmentIdentifier,
+  revision: event.revision,
+  text: event.text,
+  timeRange: {
+    startMs: nowMs - FRAME_WINDOW_MS,
+    endMs: nowMs,
+  },
+});
+
+const toFinalInput = (
+  event: Extract<RelayEvent, { type: 'transcript.final' }>,
+  nowMs: number,
+): HandleTranscriptFinalInput => ({
+  sessionId: event.sessionIdentifier,
+  segmentId: event.segmentIdentifier,
+  text: event.text,
+  timeRange: {
+    startMs: nowMs - FRAME_WINDOW_MS,
+    endMs: nowMs,
+  },
+});
+
+const toTranslationFinalInput = (
+  event: Extract<RelayEvent, { type: 'translation.final' }>,
+  nowMs: number,
+): HandleTranscriptFinalInput => ({
+  sessionId: event.sessionIdentifier,
+  segmentId: event.segmentIdentifier,
+  text: '',
+  timeRange: {
+    startMs: nowMs - FRAME_WINDOW_MS,
+    endMs: nowMs,
+  },
+  translation: {
+    targetLanguage: event.targetLanguage,
+    text: event.text,
+    status: 'completed',
+  },
+});
+
+export const createSessionCommandService = (
+  deps: SessionCommandServiceDependencies,
+): SessionCommandService => ({
+  startSource: (input) => deps.startSourceSessionUseCase(input),
+  stopSource: (input) => deps.stopSourceSessionUseCase(input),
+  applySourceSettings: (input) => deps.updateSourceSettingsUseCase(input),
+  handleRelayEvent: (event) => {
+    switch (event.type) {
+      case 'transcript.partial': {
+        const input = toPartialInput(event, deps.clock());
+        return deps
+          .handleTranscriptPartialUseCase(input)
+          .map((_output: HandleTranscriptPartialOutput): void => undefined);
+      }
+      case 'transcript.final': {
+        const input = toFinalInput(event, deps.clock());
+        return deps
+          .handleTranscriptFinalUseCase(input)
+          .map((_output: HandleTranscriptFinalOutput): void => undefined);
+      }
+      case 'translation.final': {
+        const input = toTranslationFinalInput(event, deps.clock());
+        return deps
+          .handleTranscriptFinalUseCase(input)
+          .map((_output: HandleTranscriptFinalOutput): void => undefined);
+      }
+      case 'session.ready':
+      case 'session.state.changed':
+      case 'session.error':
+        return okAsync<void, ApplicationError>(undefined);
+    }
+  },
+});


### PR DESCRIPTION
## Summary

Phase 3 §5.5 統括 の締め。全 UseCase を束ねる application-level facade。Popup / SidePanel controller が個別 UseCase を知らずに service 1 点でセッション制御を行えるようにする。

## SessionCommandService (IMPL-340)

- `startSource` / `stopSource` / `applySourceSettings`: 対応 UseCase へ直接 delegate
- `handleRelayEvent`: RelayEvent discriminated union を dispatch
  - `transcript.partial` → `HandleTranscriptPartialUseCase`
  - `transcript.final` → `HandleTranscriptFinalUseCase` (translation なし)
  - `translation.final` → `HandleTranscriptFinalUseCase` (translation 付き)
  - `session.ready` / `session.state.changed` / `session.error` → no-op (`SessionRegistry` / controller 側の UI 更新で扱う想定)

## timeRange 合成

RelayEvent の `transcript.partial` / `final` には `timeRange` が含まれないため `clock()` を起点に 100ms 幅で合成する。Relay API が将来時刻を含むように更新されたら差し替える。

## Mock 防止設計

- 5 UseCase と `clock` は全て必須 DI (default なし)
- production entrypoint で `create*UseCase` を呼んで明示配線する

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 593 tests)
- [x] `session-command-service.test.ts` (9 cases): delegate 3 種 / 失敗伝播 / handleRelayEvent 5 event type / transcript.final に translation がないこと / translation.final が translation 付きで UseCase を呼ぶこと

## Phase 3 completion

これで Phase 3 (infrastructure 層 + application 統括) 全体完了:
- §5.1 音声取得 (IMPL-300-303) ✅
- §5.2 Relay gateway (IMPL-310-312) ✅
- §5.3 Storage (IMPL-320-322) ✅
- §5.4 Overlay (IMPL-330) ✅
- §5.5 統括 (IMPL-340-344) ✅

次は Phase 4 Relay API (packages/relay-api/) または Phase 5 presentation 層配線。