### PR TITLE
feat(relay-api): IMPL-400 RelaySession aggregate + identifiers + state machine

### DIFF
--- a/packages/relay-api/src/domain/session/relay-session-state.test.ts
+++ b/packages/relay-api/src/domain/session/relay-session-state.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { parseRelaySessionState, RELAY_SESSION_STATES } from './relay-session-state';
+
+describe('parseRelaySessionState', () => {
+  it.each(RELAY_SESSION_STATES)('accepts %s', (state) => {
+    const result = parseRelaySessionState(state);
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects unknown values', () => {
+    const result = parseRelaySessionState('unknown-state');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('rejects non-string values', () => {
+    expect(parseRelaySessionState(0).isErr()).toBe(true);
+    expect(parseRelaySessionState(null).isErr()).toBe(true);
+  });
+});

--- a/packages/relay-api/src/domain/session/relay-session-state.ts
+++ b/packages/relay-api/src/domain/session/relay-session-state.ts
@@ -1,0 +1,31 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors';
+
+/**
+ * Relay Session の状態 (IMPL-400)。
+ *
+ * 拡張側 `SourceSession` よりシンプル:
+ * - `created`: `POST /sessions` 成功直後。まだ WebSocket 接続なし
+ * - `streaming`: WebSocket 接続が確立し、audio.frame を受信中
+ * - `ended`: クライアントが `stop` を送信、または `expiresAt` 到達
+ * - `error`: プロバイダエラー (STT/翻訳) / 認証失敗 / レート制限超過
+ */
+export const RELAY_SESSION_STATES = ['created', 'streaming', 'ended', 'error'] as const;
+
+const schema = z.enum(RELAY_SESSION_STATES);
+
+export type RelaySessionState = z.infer<typeof schema>;
+
+export const parseRelaySessionState = (value: unknown): Result<RelaySessionState, DomainError> => {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'RelaySessionState',
+        message: `expected one of [${RELAY_SESSION_STATES.join(', ')}]`,
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/relay-api/src/domain/session/relay-session.test.ts
+++ b/packages/relay-api/src/domain/session/relay-session.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createRelaySession,
+  endSession,
+  markSessionError,
+  startStreaming,
+  type CreateRelaySessionParams,
+} from './relay-session';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const TOKEN_ID = 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+
+const baseParams = (
+  overrides: Partial<CreateRelaySessionParams> = {},
+): CreateRelaySessionParams => ({
+  sessionIdentifier: SESSION_ID,
+  streamTokenIdentifier: TOKEN_ID,
+  sourceType: 'tab',
+  displayName: 'YouTube Live',
+  sourceLanguage: 'en-US',
+  autoDetectLanguage: false,
+  targetLanguage: 'ja-JP',
+  overlayTarget: { kind: 'tab', tabId: 42 },
+  client: { extensionVersion: '0.1.0', protocolVersion: '1.0' },
+  createdAt: '2026-04-21T00:00:00.000Z',
+  expiresAt: '2026-04-21T01:00:00.000Z',
+  ...overrides,
+});
+
+describe('createRelaySession', () => {
+  it('creates a session in created state', () => {
+    const result = createRelaySession(baseParams());
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.state).toBe('created');
+      expect(result.value.sourceType).toBe('tab');
+      expect(result.value.overlayTarget.kind).toBe('tab');
+    }
+  });
+
+  it('allows sourceLanguage=null when autoDetectLanguage is true', () => {
+    const result = createRelaySession(
+      baseParams({ sourceLanguage: null, autoDetectLanguage: true }),
+    );
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects sourceLanguage=null when autoDetectLanguage is false', () => {
+    const result = createRelaySession(
+      baseParams({ sourceLanguage: null, autoDetectLanguage: false }),
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+  });
+
+  it('rejects invalid sourceType', () => {
+    const result = createRelaySession(baseParams({ sourceType: 'webcam' }));
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects empty displayName', () => {
+    const result = createRelaySession(baseParams({ displayName: '   ' }));
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects invalid sourceLanguage', () => {
+    const result = createRelaySession(baseParams({ sourceLanguage: 'not-a-tag' }));
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects invalid targetLanguage', () => {
+    const result = createRelaySession(baseParams({ targetLanguage: 'xx-zz' }));
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects overlayTarget with invalid kind', () => {
+    const result = createRelaySession(baseParams({ overlayTarget: { kind: 'popup' } }));
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects expiresAt equal to createdAt', () => {
+    const result = createRelaySession(
+      baseParams({ createdAt: '2026-04-21T00:00:00.000Z', expiresAt: '2026-04-21T00:00:00.000Z' }),
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+  });
+
+  it('rejects expiresAt before createdAt', () => {
+    const result = createRelaySession(
+      baseParams({ createdAt: '2026-04-21T00:00:00.000Z', expiresAt: '2026-04-20T00:00:00.000Z' }),
+    );
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects non-ISO 8601 createdAt', () => {
+    const result = createRelaySession(baseParams({ createdAt: 'yesterday' }));
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('accepts extension-monitor overlayTarget', () => {
+    const result = createRelaySession(
+      baseParams({ overlayTarget: { kind: 'extension-monitor', pageId: 'monitor-01' } }),
+    );
+    expect(result.isOk()).toBe(true);
+  });
+});
+
+describe('state transitions', () => {
+  const built = createRelaySession(baseParams())._unsafeUnwrap();
+
+  it('startStreaming moves from created → streaming', () => {
+    const result = startStreaming(built);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value.state).toBe('streaming');
+  });
+
+  it('endSession moves from created → ended', () => {
+    const result = endSession(built);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value.state).toBe('ended');
+  });
+
+  it('markSessionError moves from created → error', () => {
+    const result = markSessionError(built);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value.state).toBe('error');
+  });
+
+  it('endSession is rejected from ended state', () => {
+    const ended = endSession(built)._unsafeUnwrap();
+    const result = endSession(ended);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('session-state-transition');
+  });
+
+  it('startStreaming is rejected from ended state', () => {
+    const ended = endSession(built)._unsafeUnwrap();
+    const result = startStreaming(ended);
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('markSessionError is rejected from error state', () => {
+    const erroredSession = markSessionError(built)._unsafeUnwrap();
+    const result = markSessionError(erroredSession);
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/relay-api/src/domain/session/relay-session.ts
+++ b/packages/relay-api/src/domain/session/relay-session.ts
@@ -1,0 +1,220 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import {
+  invariantViolationError,
+  sessionStateTransitionError,
+  validationError,
+  type DomainError,
+} from '../shared/errors';
+import { parseSessionIdentifier, type SessionIdentifier } from './session-identifier';
+import { parseStreamTokenIdentifier, type StreamTokenIdentifier } from './stream-token-identifier';
+import { type RelaySessionState } from './relay-session-state';
+
+/**
+ * `POST /sessions` の入力から生成される Relay 側の Session 集約。
+ *
+ * - 状態機械: created → streaming → ended / error
+ *   (error / ended は終端)
+ * - stream token は発行時に紐付け、expiresAt で失効
+ * - overlayTarget / client 情報はクライアント側で利用するため保持 (ログ・
+ *   デバッグ用途)
+ */
+
+const sourceTypeSchema = z.enum(['tab', 'microphone', 'desktop']);
+const languageTagSchema = z.string().regex(/^[a-z]{2,3}(?:-[A-Z]{2})?$/, 'invalid BCP-47 tag');
+const iso8601Schema = z.string().datetime();
+
+export type RelaySessionSourceType = z.infer<typeof sourceTypeSchema>;
+
+export type RelaySessionOverlayTarget =
+  | Readonly<{ kind: 'tab'; tabId: number }>
+  | Readonly<{ kind: 'extension-monitor'; pageId: string }>;
+
+export type RelaySessionClient = Readonly<{
+  extensionVersion: string;
+  protocolVersion: string;
+}>;
+
+export type RelaySession = Readonly<{
+  sessionIdentifier: SessionIdentifier;
+  streamTokenIdentifier: StreamTokenIdentifier;
+  state: RelaySessionState;
+  sourceType: RelaySessionSourceType;
+  displayName: string;
+  sourceLanguage: string | null;
+  autoDetectLanguage: boolean;
+  targetLanguage: string;
+  overlayTarget: RelaySessionOverlayTarget;
+  client: RelaySessionClient;
+  createdAt: string;
+  expiresAt: string;
+}>;
+
+export type CreateRelaySessionParams = {
+  sessionIdentifier: string;
+  streamTokenIdentifier: string;
+  sourceType: string;
+  displayName: string;
+  sourceLanguage: string | null;
+  autoDetectLanguage: boolean;
+  targetLanguage: string;
+  overlayTarget: unknown;
+  client: { extensionVersion: string; protocolVersion: string };
+  createdAt: string;
+  expiresAt: string;
+};
+
+const overlayTargetTabSchema = z.object({
+  kind: z.literal('tab'),
+  tabId: z.number().int().positive(),
+});
+
+const overlayTargetMonitorSchema = z.object({
+  kind: z.literal('extension-monitor'),
+  pageId: z.string().min(1),
+});
+
+const overlayTargetSchema = z.union([overlayTargetTabSchema, overlayTargetMonitorSchema]);
+
+const parseOverlayTarget = (value: unknown): Result<RelaySessionOverlayTarget, DomainError> => {
+  const result = overlayTargetSchema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'RelaySession.overlayTarget',
+        message: 'must be {kind:tab,tabId} or {kind:extension-monitor,pageId}',
+      }),
+    );
+  }
+  return ok(result.data);
+};
+
+const validateTimestamp = (field: string, value: string): Result<string, DomainError> => {
+  const result = iso8601Schema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field,
+        message: 'must be ISO 8601 datetime',
+      }),
+    );
+  }
+  return ok(result.data);
+};
+
+export const createRelaySession = (
+  params: CreateRelaySessionParams,
+): Result<RelaySession, DomainError> =>
+  parseSessionIdentifier(params.sessionIdentifier).andThen((sessionIdentifier) =>
+    parseStreamTokenIdentifier(params.streamTokenIdentifier).andThen((streamTokenIdentifier) => {
+      const sourceTypeResult = sourceTypeSchema.safeParse(params.sourceType);
+      if (!sourceTypeResult.success) {
+        return err(
+          validationError({
+            field: 'RelaySession.sourceType',
+            message: 'must be tab / microphone / desktop',
+          }),
+        );
+      }
+      if (params.displayName.trim().length === 0) {
+        return err(
+          validationError({
+            field: 'RelaySession.displayName',
+            message: 'must be non-empty',
+          }),
+        );
+      }
+      if (params.sourceLanguage !== null) {
+        const lang = languageTagSchema.safeParse(params.sourceLanguage);
+        if (!lang.success) {
+          return err(
+            validationError({
+              field: 'RelaySession.sourceLanguage',
+              message: 'must be a BCP-47 tag or null',
+            }),
+          );
+        }
+      }
+      if (!params.autoDetectLanguage && params.sourceLanguage === null) {
+        return err(
+          invariantViolationError({
+            invariant: 'source-language-required-when-auto-detect-off',
+            details: 'sourceLanguage must be set when autoDetectLanguage is false',
+          }),
+        );
+      }
+      const targetLangResult = languageTagSchema.safeParse(params.targetLanguage);
+      if (!targetLangResult.success) {
+        return err(
+          validationError({
+            field: 'RelaySession.targetLanguage',
+            message: 'must be a BCP-47 tag',
+          }),
+        );
+      }
+      return parseOverlayTarget(params.overlayTarget).andThen((overlayTarget) =>
+        validateTimestamp('RelaySession.createdAt', params.createdAt).andThen((createdAt) =>
+          validateTimestamp('RelaySession.expiresAt', params.expiresAt).andThen((expiresAt) => {
+            if (new Date(expiresAt).getTime() <= new Date(createdAt).getTime()) {
+              return err(
+                invariantViolationError({
+                  invariant: 'expires-at-must-be-after-created-at',
+                  details: `expiresAt=${expiresAt} must be later than createdAt=${createdAt}`,
+                }),
+              );
+            }
+            return ok<RelaySession, DomainError>({
+              sessionIdentifier,
+              streamTokenIdentifier,
+              state: 'created',
+              sourceType: sourceTypeResult.data,
+              displayName: params.displayName,
+              sourceLanguage: params.sourceLanguage,
+              autoDetectLanguage: params.autoDetectLanguage,
+              targetLanguage: targetLangResult.data,
+              overlayTarget,
+              client: {
+                extensionVersion: params.client.extensionVersion,
+                protocolVersion: params.client.protocolVersion,
+              },
+              createdAt,
+              expiresAt,
+            });
+          }),
+        ),
+      );
+    }),
+  );
+
+const ALLOWED_TRANSITIONS: Readonly<Record<RelaySessionState, readonly RelaySessionState[]>> = {
+  created: ['streaming', 'ended', 'error'],
+  streaming: ['ended', 'error'],
+  ended: [],
+  error: [],
+};
+
+const transitionGuard = (
+  session: RelaySession,
+  target: RelaySessionState,
+  reason: string,
+): Result<RelaySession, DomainError> => {
+  if (!ALLOWED_TRANSITIONS[session.state].includes(target)) {
+    return err(
+      sessionStateTransitionError({
+        from: session.state,
+        to: target,
+        reason,
+      }),
+    );
+  }
+  return ok({ ...session, state: target });
+};
+
+export const startStreaming = (session: RelaySession): Result<RelaySession, DomainError> =>
+  transitionGuard(session, 'streaming', 'streaming is only allowed from created');
+
+export const endSession = (session: RelaySession): Result<RelaySession, DomainError> =>
+  transitionGuard(session, 'ended', 'end is not allowed from terminal states');
+
+export const markSessionError = (session: RelaySession): Result<RelaySession, DomainError> =>
+  transitionGuard(session, 'error', 'error is not allowed from terminal states');

--- a/packages/relay-api/src/domain/session/session-identifier.test.ts
+++ b/packages/relay-api/src/domain/session/session-identifier.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { parseSessionIdentifier } from './session-identifier';
+
+describe('parseSessionIdentifier', () => {
+  it('accepts a valid ULID', () => {
+    const result = parseSessionIdentifier('01HZX8Y1R8M7D3Q2P4T5V6W7A1');
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('accepts lowercase ULIDs', () => {
+    const result = parseSessionIdentifier('01hzx8y1r8m7d3q2p4t5v6w7a1');
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects non-ULID strings', () => {
+    const result = parseSessionIdentifier('not-a-ulid');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('rejects strings shorter than 26 chars', () => {
+    const result = parseSessionIdentifier('01HZX8Y1R8');
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects non-string values', () => {
+    const result = parseSessionIdentifier(123);
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/relay-api/src/domain/session/session-identifier.ts
+++ b/packages/relay-api/src/domain/session/session-identifier.ts
@@ -1,0 +1,31 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors';
+
+/**
+ * Relay Session の識別子 (SessionIdentifier)。
+ *
+ * - ULID 形式 (ULID spec) を採用。小文字 / 大文字両方許容し、拡張側との
+ *   相互運用性を確保 (拡張も ULID).
+ * - `brand<'RelaySessionIdentifier'>()` で nominal typing (`as` 禁止下で
+ *   識別子の入れ違いを防ぐ)
+ */
+const sessionIdentifierSchema = z
+  .string()
+  .regex(/^[0-9A-HJKMNP-TV-Z]{26}$/i, 'must be a ULID')
+  .brand<'RelaySessionIdentifier'>();
+
+export type SessionIdentifier = z.infer<typeof sessionIdentifierSchema>;
+
+export const parseSessionIdentifier = (value: unknown): Result<SessionIdentifier, DomainError> => {
+  const result = sessionIdentifierSchema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'SessionIdentifier',
+        message: 'must be a ULID (26 crockford base32 chars)',
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/relay-api/src/domain/session/stream-token-identifier.test.ts
+++ b/packages/relay-api/src/domain/session/stream-token-identifier.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { parseStreamTokenIdentifier } from './stream-token-identifier';
+
+describe('parseStreamTokenIdentifier', () => {
+  it('accepts strm_<ULID> form', () => {
+    const result = parseStreamTokenIdentifier('strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1');
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects identifiers without prefix', () => {
+    const result = parseStreamTokenIdentifier('01HZX8Y1R8M7D3Q2P4T5V6W7A1');
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects identifiers with wrong prefix', () => {
+    const result = parseStreamTokenIdentifier('sess_01HZX8Y1R8M7D3Q2P4T5V6W7A1');
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects non-string values', () => {
+    const result = parseStreamTokenIdentifier(null);
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/relay-api/src/domain/session/stream-token-identifier.ts
+++ b/packages/relay-api/src/domain/session/stream-token-identifier.ts
@@ -1,0 +1,32 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors';
+
+/**
+ * WebSocket 接続用の短命トークン識別子 (StreamTokenIdentifier)。
+ *
+ * - `strm_` プレフィクス + ULID 形式 (api-specification §4.2)
+ * - 実際の JWT 文字列とは別に、jti 相当の識別子として使用する
+ * - `brand<'StreamTokenIdentifier'>()` で nominal typing
+ */
+const streamTokenIdentifierSchema = z
+  .string()
+  .regex(/^strm_[0-9A-HJKMNP-TV-Z]{26}$/i, 'must be in the form strm_<ULID>')
+  .brand<'StreamTokenIdentifier'>();
+
+export type StreamTokenIdentifier = z.infer<typeof streamTokenIdentifierSchema>;
+
+export const parseStreamTokenIdentifier = (
+  value: unknown,
+): Result<StreamTokenIdentifier, DomainError> => {
+  const result = streamTokenIdentifierSchema.safeParse(value);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'StreamTokenIdentifier',
+        message: 'must be in the form strm_<ULID>',
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/relay-api/src/domain/shared/errors.test.ts
+++ b/packages/relay-api/src/domain/shared/errors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  invariantViolationError,
+  notFoundError,
+  sessionStateTransitionError,
+  validationError,
+} from './errors';
+
+describe('domain error factory functions', () => {
+  it('sessionStateTransitionError builds a tagged error', () => {
+    const err = sessionStateTransitionError({
+      from: 'created',
+      to: 'ended',
+      reason: 'cannot skip streaming',
+    });
+    expect(err).toEqual({
+      kind: 'session-state-transition',
+      from: 'created',
+      to: 'ended',
+      reason: 'cannot skip streaming',
+    });
+  });
+
+  it('invariantViolationError builds a tagged error', () => {
+    const err = invariantViolationError({
+      invariant: 'stream-token-expired',
+      details: 'token expired before connect',
+    });
+    expect(err.kind).toBe('invariant-violation');
+    expect(err.invariant).toBe('stream-token-expired');
+  });
+
+  it('validationError builds a tagged error', () => {
+    const err = validationError({ field: 'sourceType', message: 'must be one of ...' });
+    expect(err.kind).toBe('validation');
+  });
+
+  it('notFoundError builds a tagged error', () => {
+    const err = notFoundError({ resourceType: 'Session', identifier: 'sess_xxx' });
+    expect(err.kind).toBe('not-found');
+  });
+});

--- a/packages/relay-api/src/domain/shared/errors.ts
+++ b/packages/relay-api/src/domain/shared/errors.ts
@@ -1,0 +1,62 @@
+/**
+ * Relay API ドメイン層の共通エラー型。
+ *
+ * 拡張側 (`packages/extension/src/domain/shared/errors.ts`) と同じ
+ * discriminated union + factory 関数パターンで、内容は Relay API の文脈に
+ * 合わせる。両 workspace で個別定義する方針 (IMPL-004)。
+ *
+ * **初期 4 種** (必要に応じて拡張):
+ * - `session-state-transition`: 許可されない状態遷移
+ * - `invariant-violation`: 集約 / Value Object の不変条件違反
+ * - `validation`: 外部入力の形式不正 (Zod 検証失敗等)
+ * - `not-found`: エンティティが見つからない
+ */
+
+export type SessionStateTransitionError = Readonly<{
+  kind: 'session-state-transition';
+  from: string;
+  to: string;
+  reason: string;
+}>;
+
+export type InvariantViolationError = Readonly<{
+  kind: 'invariant-violation';
+  invariant: string;
+  details: string;
+}>;
+
+export type ValidationError = Readonly<{
+  kind: 'validation';
+  field: string;
+  message: string;
+}>;
+
+export type NotFoundError = Readonly<{
+  kind: 'not-found';
+  resourceType: string;
+  identifier: string;
+}>;
+
+export type DomainError =
+  | SessionStateTransitionError
+  | InvariantViolationError
+  | ValidationError
+  | NotFoundError;
+
+export const sessionStateTransitionError = (
+  params: Omit<SessionStateTransitionError, 'kind'>,
+): SessionStateTransitionError => ({ kind: 'session-state-transition', ...params });
+
+export const invariantViolationError = (
+  params: Omit<InvariantViolationError, 'kind'>,
+): InvariantViolationError => ({ kind: 'invariant-violation', ...params });
+
+export const validationError = (params: Omit<ValidationError, 'kind'>): ValidationError => ({
+  kind: 'validation',
+  ...params,
+});
+
+export const notFoundError = (params: Omit<NotFoundError, 'kind'>): NotFoundError => ({
+  kind: 'not-found',
+  ...params,
+});


### PR DESCRIPTION
## Summary

Phase 4 §6.1 の最初の一歩。Relay 側の Session 集約と値オブジェクトを追加。拡張側の SourceSession とは別に、Relay API context で扱う簡潔な state machine (`created` → `streaming` → `ended` / `error`) を持つ。

## Domain shared errors

- discriminated union + factory 関数 (`session-state-transition` / `invariant-violation` / `validation` / `not-found`)
- 拡張側と同パターンで個別定義 (IMPL-004)

## Value objects

- `SessionIdentifier`: ULID、`brand<'RelaySessionIdentifier'>` で拡張側 `SessionIdentifier` と型レベルで区別
- `StreamTokenIdentifier`: `strm_<ULID>` 形式 (api-specification §4.2)、JWT の `jti` 相当
- `RelaySessionState`: `created` / `streaming` / `ended` / `error`

## RelaySession aggregate

- `POST /sessions` リクエストから生成 (api-spec §4.2)
- `sourceType` / `displayName` / `language` / `overlayTarget` / `client` を検証
- `autoDetectLanguage=false` なら `sourceLanguage` 必須 (invariant)
- `expiresAt > createdAt` (invariant)
- `overlayTarget` は `tab` / `extension-monitor` の discriminated union
- 状態遷移: `startStreaming` / `endSession` / `markSessionError` (ended / error は終端)

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 38 Relay API tests + 593 extension tests)
- [x] 38 cases: 値オブジェクト 15、state enum 6、aggregate 17 (正常系 / 各 invariant / 状態遷移の拒否)

## Out of scope (Phase 4 後続)

- IMPL-401 `IssueStreamTokenUseCase` (JWT 発行)
- IMPL-411 `POST /sessions` HTTP route
- IMPL-420-423 WebSocket (relay / heartbeat)
- IMPL-430-434 認証・rate limit・security headers
- IMPL-440-446 ACL (STT / Translation providers)