### PR TITLE
feat(relay-api): IMPL-401 IssueStreamTokenUseCase + JwtSigner / SessionRepository ports

### DIFF
--- a/packages/relay-api/src/application/dto/issue-stream-token-dto.test.ts
+++ b/packages/relay-api/src/application/dto/issue-stream-token-dto.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { parseIssueStreamTokenInput } from './issue-stream-token-dto';
+
+const baseInput = (overrides: Record<string, unknown> = {}) => ({
+  sourceType: 'tab',
+  displayName: 'YouTube Live',
+  sourceLanguage: 'en-US',
+  autoDetectLanguage: false,
+  targetLanguage: 'ja-JP',
+  overlayTarget: { kind: 'tab', tabId: 42 },
+  client: { extensionVersion: '0.1.0', protocolVersion: '1.0' },
+  ...overrides,
+});
+
+describe('parseIssueStreamTokenInput', () => {
+  it('accepts a valid tab input', () => {
+    const result = parseIssueStreamTokenInput(baseInput());
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('accepts extension-monitor overlayTarget', () => {
+    const result = parseIssueStreamTokenInput(
+      baseInput({ overlayTarget: { kind: 'extension-monitor', pageId: 'monitor-1' } }),
+    );
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('accepts sourceLanguage=null', () => {
+    const result = parseIssueStreamTokenInput(
+      baseInput({ sourceLanguage: null, autoDetectLanguage: true }),
+    );
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects unknown sourceType', () => {
+    const result = parseIssueStreamTokenInput(baseInput({ sourceType: 'webcam' }));
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('rejects empty displayName', () => {
+    const result = parseIssueStreamTokenInput(baseInput({ displayName: '' }));
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects overlayTarget kind=tab without tabId', () => {
+    const result = parseIssueStreamTokenInput(baseInput({ overlayTarget: { kind: 'tab' } }));
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects client without extensionVersion', () => {
+    const result = parseIssueStreamTokenInput(baseInput({ client: { protocolVersion: '1.0' } }));
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects non-boolean autoDetectLanguage', () => {
+    const result = parseIssueStreamTokenInput(baseInput({ autoDetectLanguage: 'yes' }));
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/relay-api/src/application/dto/issue-stream-token-dto.ts
+++ b/packages/relay-api/src/application/dto/issue-stream-token-dto.ts
@@ -1,0 +1,74 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../../domain/shared/errors';
+
+/**
+ * POST /sessions 入力 DTO (api-specification §4.2)。
+ *
+ * HTTP layer で Zod 検証を通したあと、本 DTO の形式に正規化して UseCase へ
+ * 渡す。overlayTarget は discriminated union として維持する。
+ */
+
+const overlayTargetSchema = z.union([
+  z.object({ kind: z.literal('tab'), tabId: z.number().int().positive() }),
+  z.object({ kind: z.literal('extension-monitor'), pageId: z.string().min(1) }),
+]);
+
+const issueStreamTokenInputSchema = z.object({
+  sourceType: z.enum(['tab', 'microphone', 'desktop']),
+  displayName: z.string().min(1),
+  sourceLanguage: z.string().nullable(),
+  autoDetectLanguage: z.boolean(),
+  targetLanguage: z.string(),
+  overlayTarget: overlayTargetSchema,
+  client: z.object({
+    extensionVersion: z.string().min(1),
+    protocolVersion: z.string().min(1),
+  }),
+});
+
+export type IssueStreamTokenInput = z.infer<typeof issueStreamTokenInputSchema>;
+
+export const parseIssueStreamTokenInput = (
+  raw: unknown,
+): Result<IssueStreamTokenInput, DomainError> => {
+  const result = issueStreamTokenInputSchema.safeParse(raw);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'IssueStreamTokenInput',
+        message: result.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};
+
+/**
+ * POST /sessions 応答 DTO (api-specification §4.2 成功レスポンス)。
+ *
+ * - `streamToken`: 署名済み JWT 文字列 (WebSocket `Authorization: Bearer` で使用)
+ * - `audio` / `limits` は API 仕様に従う固定値 (UseCase 内で合成)
+ */
+export type IssueStreamTokenAudio = Readonly<{
+  encoding: 'pcm_s16le';
+  sampleRateHz: 16000;
+  channels: 1;
+  frameDurationMs: 100;
+  transport: 'json-base64';
+}>;
+
+export type IssueStreamTokenLimits = Readonly<{
+  maxConcurrentSessions: number;
+  maxFrameRatePerSecond: number;
+}>;
+
+export type IssueStreamTokenOutput = Readonly<{
+  sessionId: string;
+  streamToken: string;
+  relayUrl: string;
+  expiresAt: string;
+  heartbeatIntervalSec: number;
+  audio: IssueStreamTokenAudio;
+  limits: IssueStreamTokenLimits;
+}>;

--- a/packages/relay-api/src/application/ports/jwt-signer.test.ts
+++ b/packages/relay-api/src/application/ports/jwt-signer.test.ts
@@ -1,0 +1,39 @@
+import { okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { type DomainError } from '../../domain/shared/errors';
+import { type JwtSigner, type JwtSignerPayload } from './jwt-signer';
+
+describe('JwtSigner port contract', () => {
+  it('can be implemented with a mock that returns a JWT string', async () => {
+    const signer: JwtSigner = {
+      sign: (payload: JwtSignerPayload) =>
+        okAsync<string, DomainError>(`JWT.${payload.jti}.${payload.sub}`),
+    };
+    const result = await signer.sign({
+      jti: 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+      sub: '01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+      expiresAtEpochSec: 1_700_000_000,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toContain('strm_');
+    }
+  });
+
+  it('passes extraClaims through to the implementation', async () => {
+    const received: JwtSignerPayload[] = [];
+    const signer: JwtSigner = {
+      sign: (payload) => {
+        received.push(payload);
+        return okAsync<string, DomainError>('jwt');
+      },
+    };
+    await signer.sign({
+      jti: 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+      sub: '01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+      expiresAtEpochSec: 1_700_000_000,
+      extraClaims: { ext: 'v1' },
+    });
+    expect(received[0]?.extraClaims?.['ext']).toBe('v1');
+  });
+});

--- a/packages/relay-api/src/application/ports/jwt-signer.ts
+++ b/packages/relay-api/src/application/ports/jwt-signer.ts
@@ -1,0 +1,30 @@
+import { type ResultAsync } from 'neverthrow';
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * WebSocket stream token 用の JWT 署名ポート (IMPL-431)。
+ *
+ * Relay API は短命 (TTL 5〜30 分を想定) の JWT を発行し、WebSocket 接続時に
+ * `Authorization: Bearer <jwt>` で検証する。本 port は `jose` を用いた
+ * 実装 (infrastructure 層) へのアクセスを抽象化する。
+ *
+ * **payload の扱い**:
+ * - `jti`: `StreamTokenIdentifier` (`strm_<ULID>`)
+ * - `sub`: `SessionIdentifier` (`<ULID>`)
+ * - `exp`: token 失効 UNIX epoch 秒
+ * - その他のフィールド (iss / aud) は実装側で付加
+ */
+export type JwtSignerPayload = Readonly<{
+  jti: string;
+  sub: string;
+  expiresAtEpochSec: number;
+  extraClaims?: Readonly<Record<string, string | number | boolean>>;
+}>;
+
+/**
+ * JwtSigner port。`sign(payload)` で JWT 文字列を返す。
+ * 検証は別 port (`JwtVerifier`) に分ける想定 (WebSocket 側で利用)。
+ */
+export type JwtSigner = Readonly<{
+  sign: (payload: JwtSignerPayload) => ResultAsync<string, DomainError>;
+}>;

--- a/packages/relay-api/src/application/ports/session-repository.test.ts
+++ b/packages/relay-api/src/application/ports/session-repository.test.ts
@@ -1,0 +1,55 @@
+import { okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import {
+  createRelaySession,
+  type CreateRelaySessionParams,
+} from '../../domain/session/relay-session';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { type DomainError } from '../../domain/shared/errors';
+import { type RelaySessionRepository } from './session-repository';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const buildSession = () =>
+  createRelaySession({
+    sessionIdentifier: SESSION_ID,
+    streamTokenIdentifier: 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+    sourceType: 'tab',
+    displayName: 'Tab',
+    sourceLanguage: 'en-US',
+    autoDetectLanguage: false,
+    targetLanguage: 'ja-JP',
+    overlayTarget: { kind: 'tab', tabId: 1 },
+    client: { extensionVersion: '0.1.0', protocolVersion: '1.0' },
+    createdAt: '2026-04-21T00:00:00.000Z',
+    expiresAt: '2026-04-21T01:00:00.000Z',
+  } satisfies CreateRelaySessionParams)._unsafeUnwrap();
+
+describe('RelaySessionRepository port contract', () => {
+  it('can be implemented with okAsync for all operations', async () => {
+    const session = buildSession();
+    const repo: RelaySessionRepository = {
+      save: () => okAsync<void, DomainError>(undefined),
+      find: () => okAsync<typeof session | null, DomainError>(session),
+      delete: () => okAsync<void, DomainError>(undefined),
+    };
+    expect((await repo.save(session)).isOk()).toBe(true);
+    expect((await repo.find(sessionIdentifier)).isOk()).toBe(true);
+    expect((await repo.delete(sessionIdentifier)).isOk()).toBe(true);
+  });
+
+  it('find returns null for missing sessions', async () => {
+    const repo: RelaySessionRepository = {
+      save: () => okAsync<void, DomainError>(undefined),
+      find: () => okAsync<null, DomainError>(null),
+      delete: () => okAsync<void, DomainError>(undefined),
+    };
+    const result = await repo.find(sessionIdentifier);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBeNull();
+  });
+});

--- a/packages/relay-api/src/application/ports/session-repository.ts
+++ b/packages/relay-api/src/application/ports/session-repository.ts
@@ -1,0 +1,22 @@
+import { type ResultAsync } from 'neverthrow';
+import { type RelaySession } from '../../domain/session/relay-session';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * Relay Session repository port (IMPL-400 派生)。
+ *
+ * 対応: infrastructure 層の in-memory / Redis / DB いずれでも実装可能。MVP は
+ * in-memory を想定 (Cloud Run 単一インスタンス前提)。スケール後は Redis 等で
+ * 共有化する (infrastructure.md §5.1 "メモリ正本")。
+ *
+ * ライフサイクル:
+ * - `save`: `POST /sessions` 成功時、state 遷移時
+ * - `find`: `GET /sessions/:id`、WebSocket 接続時の認可チェック
+ * - `delete`: expiresAt 経過時 (cleanup task)
+ */
+export type RelaySessionRepository = Readonly<{
+  save: (session: RelaySession) => ResultAsync<void, DomainError>;
+  find: (sessionIdentifier: SessionIdentifier) => ResultAsync<RelaySession | null, DomainError>;
+  delete: (sessionIdentifier: SessionIdentifier) => ResultAsync<void, DomainError>;
+}>;

--- a/packages/relay-api/src/application/use-cases/issue-stream-token-use-case.test.ts
+++ b/packages/relay-api/src/application/use-cases/issue-stream-token-use-case.test.ts
@@ -1,0 +1,147 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import { type RelaySession } from '../../domain/session/relay-session';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { type IssueStreamTokenInput } from '../dto/issue-stream-token-dto';
+import { type JwtSigner } from '../ports/jwt-signer';
+import { type RelaySessionRepository } from '../ports/session-repository';
+import {
+  createIssueStreamTokenUseCase,
+  type IssueStreamTokenDependencies,
+} from './issue-stream-token-use-case';
+
+const CREATED_AT = '2026-04-21T00:00:00.000Z';
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const TOKEN_ID = 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+const JWT_STRING = 'eyJhbGciOiJIUzI1NiJ9.xxx.yyy';
+const RELAY_URL = 'wss://relay.example.com/api/v1/relay';
+
+const buildInput = (overrides: Partial<IssueStreamTokenInput> = {}): IssueStreamTokenInput => ({
+  sourceType: 'tab',
+  displayName: 'YouTube Live',
+  sourceLanguage: 'en-US',
+  autoDetectLanguage: false,
+  targetLanguage: 'ja-JP',
+  overlayTarget: { kind: 'tab', tabId: 42 },
+  client: { extensionVersion: '0.1.0', protocolVersion: '1.0' },
+  ...overrides,
+});
+
+const buildDeps = (
+  overrides: Partial<IssueStreamTokenDependencies> = {},
+): IssueStreamTokenDependencies & {
+  jwtSigner: { sign: ReturnType<typeof vi.fn<JwtSigner['sign']>> };
+  sessionRepository: {
+    save: ReturnType<typeof vi.fn<RelaySessionRepository['save']>>;
+    find: ReturnType<typeof vi.fn<RelaySessionRepository['find']>>;
+    delete: ReturnType<typeof vi.fn<RelaySessionRepository['delete']>>;
+  };
+} => {
+  const jwtSigner = {
+    sign: vi.fn<JwtSigner['sign']>(() => okAsync<string, DomainError>(JWT_STRING)),
+  };
+  const sessionRepository = {
+    save: vi.fn<RelaySessionRepository['save']>(() => okAsync<void, DomainError>(undefined)),
+    find: vi.fn<RelaySessionRepository['find']>(() =>
+      okAsync<RelaySession | null, DomainError>(null),
+    ),
+    delete: vi.fn<RelaySessionRepository['delete']>(() => okAsync<void, DomainError>(undefined)),
+  };
+  const base: IssueStreamTokenDependencies = {
+    jwtSigner,
+    sessionRepository,
+    clock: () => CREATED_AT,
+    sessionIdFactory: () => SESSION_ID,
+    streamTokenIdFactory: () => TOKEN_ID,
+    relayUrl: RELAY_URL,
+    tokenTtlSec: 1800,
+    heartbeatIntervalSec: 15,
+    maxConcurrentSessions: 3,
+    maxFrameRatePerSecond: 10,
+  };
+  return { ...base, ...overrides, jwtSigner, sessionRepository };
+};
+
+describe('createIssueStreamTokenUseCase (IMPL-401)', () => {
+  it('returns sessionId + JWT + expiresAt and saves the session', async () => {
+    const deps = buildDeps();
+    const useCase = createIssueStreamTokenUseCase(deps);
+    const result = await useCase(buildInput());
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessionId).toBe(SESSION_ID);
+      expect(result.value.streamToken).toBe(JWT_STRING);
+      expect(result.value.relayUrl).toBe(RELAY_URL);
+      expect(result.value.expiresAt).toBe('2026-04-21T00:30:00.000Z');
+      expect(result.value.heartbeatIntervalSec).toBe(15);
+      expect(result.value.audio.sampleRateHz).toBe(16000);
+      expect(result.value.limits.maxConcurrentSessions).toBe(3);
+    }
+    expect(deps.jwtSigner.sign).toHaveBeenCalledTimes(1);
+    expect(deps.sessionRepository.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('signs the JWT with jti, sub, and expiresAtEpochSec', async () => {
+    const deps = buildDeps();
+    const useCase = createIssueStreamTokenUseCase(deps);
+    await useCase(buildInput());
+    const payload = deps.jwtSigner.sign.mock.calls[0]?.[0];
+    expect(payload?.jti).toBe(TOKEN_ID);
+    expect(payload?.sub).toBe(SESSION_ID);
+    expect(payload?.expiresAtEpochSec).toBe(
+      Math.floor(new Date('2026-04-21T00:30:00.000Z').getTime() / 1000),
+    );
+  });
+
+  it('rejects invalid input (missing displayName)', async () => {
+    const deps = buildDeps();
+    const useCase = createIssueStreamTokenUseCase(deps);
+    const result = await useCase({
+      ...buildInput(),
+      displayName: '',
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+    expect(deps.jwtSigner.sign).not.toHaveBeenCalled();
+    expect(deps.sessionRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects autoDetectLanguage=false with sourceLanguage=null', async () => {
+    const deps = buildDeps();
+    const useCase = createIssueStreamTokenUseCase(deps);
+    const result = await useCase(buildInput({ autoDetectLanguage: false, sourceLanguage: null }));
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    expect(deps.sessionRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('surfaces jwtSigner failure without saving', async () => {
+    const deps = buildDeps();
+    deps.jwtSigner.sign.mockReturnValueOnce(
+      errAsync<string, DomainError>(
+        invariantViolationError({ invariant: 'jwt-signing-failed', details: 'boom' }),
+      ),
+    );
+    const useCase = createIssueStreamTokenUseCase(deps);
+    const result = await useCase(buildInput());
+    expect(result.isErr()).toBe(true);
+    expect(deps.sessionRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('surfaces sessionRepository failure', async () => {
+    const deps = buildDeps();
+    deps.sessionRepository.save.mockReturnValueOnce(
+      errAsync<void, DomainError>(
+        invariantViolationError({ invariant: 'repo-write-failed', details: 'boom' }),
+      ),
+    );
+    const useCase = createIssueStreamTokenUseCase(deps);
+    const result = await useCase(buildInput());
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('throws synchronously if tokenTtlSec is non-positive', () => {
+    const deps = buildDeps({ tokenTtlSec: 0 });
+    expect(() => createIssueStreamTokenUseCase(deps)).toThrow(/tokenTtlSec must be positive/);
+  });
+});

--- a/packages/relay-api/src/application/use-cases/issue-stream-token-use-case.ts
+++ b/packages/relay-api/src/application/use-cases/issue-stream-token-use-case.ts
@@ -1,0 +1,110 @@
+import { type ResultAsync } from 'neverthrow';
+import { createRelaySession } from '../../domain/session/relay-session';
+import { type DomainError } from '../../domain/shared/errors';
+import {
+  parseIssueStreamTokenInput,
+  type IssueStreamTokenInput,
+  type IssueStreamTokenOutput,
+} from '../dto/issue-stream-token-dto';
+import { type JwtSigner } from '../ports/jwt-signer';
+import { type RelaySessionRepository } from '../ports/session-repository';
+
+/**
+ * IMPL-401 IssueStreamTokenUseCase (api-specification §4.2)。
+ *
+ * `POST /sessions` の application logic:
+ * 1. 入力 DTO を Zod で検証
+ * 2. sessionId / streamTokenId を factory から生成 (ULID)
+ * 3. clock() から createdAt を取得し expiresAt = createdAt + tokenTtlSec を合成
+ * 4. RelaySession aggregate を生成 (domain invariants の検証)
+ * 5. JwtSigner で短命 JWT を署名 (jti=streamTokenId, sub=sessionId, exp=...)
+ * 6. RelaySessionRepository へ save
+ * 7. Output に JWT / relayUrl / 固定 audio パラメータ / 制限値を含めて返却
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - jwtSigner / sessionRepository / clock / sessionIdFactory /
+ *   streamTokenIdFactory / relayUrl / tokenTtlSec は全て必須 DI
+ * - production entrypoint で jose 署名 / in-memory repo / ulid() / 環境変数
+ *   を明示的に渡す
+ */
+export type IssueStreamTokenDependencies = Readonly<{
+  jwtSigner: JwtSigner;
+  sessionRepository: RelaySessionRepository;
+  clock: () => string;
+  sessionIdFactory: () => string;
+  streamTokenIdFactory: () => string;
+  relayUrl: string;
+  tokenTtlSec: number;
+  heartbeatIntervalSec: number;
+  maxConcurrentSessions: number;
+  maxFrameRatePerSecond: number;
+}>;
+
+export type IssueStreamTokenUseCase = (
+  input: IssueStreamTokenInput,
+) => ResultAsync<IssueStreamTokenOutput, DomainError>;
+
+const addSecondsIso = (isoDate: string, seconds: number): string => {
+  const ms = new Date(isoDate).getTime();
+  return new Date(ms + seconds * 1000).toISOString();
+};
+
+const toEpochSec = (isoDate: string): number => Math.floor(new Date(isoDate).getTime() / 1000);
+
+export const createIssueStreamTokenUseCase = (
+  deps: IssueStreamTokenDependencies,
+): IssueStreamTokenUseCase => {
+  if (deps.tokenTtlSec <= 0) {
+    throw new Error('tokenTtlSec must be positive');
+  }
+  return (rawInput) =>
+    parseIssueStreamTokenInput(rawInput).asyncAndThen((input) => {
+      const createdAt = deps.clock();
+      const expiresAt = addSecondsIso(createdAt, deps.tokenTtlSec);
+      const sessionId = deps.sessionIdFactory();
+      const streamTokenId = deps.streamTokenIdFactory();
+
+      return createRelaySession({
+        sessionIdentifier: sessionId,
+        streamTokenIdentifier: streamTokenId,
+        sourceType: input.sourceType,
+        displayName: input.displayName,
+        sourceLanguage: input.sourceLanguage,
+        autoDetectLanguage: input.autoDetectLanguage,
+        targetLanguage: input.targetLanguage,
+        overlayTarget: input.overlayTarget,
+        client: input.client,
+        createdAt,
+        expiresAt,
+      }).asyncAndThen((session) =>
+        deps.jwtSigner
+          .sign({
+            jti: session.streamTokenIdentifier,
+            sub: session.sessionIdentifier,
+            expiresAtEpochSec: toEpochSec(session.expiresAt),
+          })
+          .andThen((jwt) =>
+            deps.sessionRepository.save(session).map(
+              (): IssueStreamTokenOutput => ({
+                sessionId: session.sessionIdentifier,
+                streamToken: jwt,
+                relayUrl: deps.relayUrl,
+                expiresAt: session.expiresAt,
+                heartbeatIntervalSec: deps.heartbeatIntervalSec,
+                audio: {
+                  encoding: 'pcm_s16le',
+                  sampleRateHz: 16000,
+                  channels: 1,
+                  frameDurationMs: 100,
+                  transport: 'json-base64',
+                },
+                limits: {
+                  maxConcurrentSessions: deps.maxConcurrentSessions,
+                  maxFrameRatePerSecond: deps.maxFrameRatePerSecond,
+                },
+              }),
+            ),
+          ),
+      );
+    });
+};


### PR DESCRIPTION
## Summary

Phase 4 §6.1 の UseCase。`POST /sessions` の application logic を実装し、JWT stream token の発行経路を組み立てる。

## Ports

- **JwtSigner**: payload (`jti` / `sub` / `expiresAtEpochSec` + extra) を受け取り JWT 文字列を返す抽象。infrastructure 側で `jose` を使った実装を後続で追加
- **RelaySessionRepository**: `save` / `find` / `delete`。MVP は in-memory 想定 (Cloud Run 単一インスタンス前提)

## DTO

- **IssueStreamTokenInput**: POST /sessions ボディを Zod 検証 (`sourceType` / `displayName` / `languages` / `overlayTarget` (`tab` or `extension-monitor`) / `client`)
- **IssueStreamTokenOutput**: api-specification §4.2 の成功レスポンスに合わせ `sessionId` / `streamToken` (JWT) / `relayUrl` / `expiresAt` / `heartbeatIntervalSec` / `audio` (pcm_s16le 16kHz mono 100ms json-base64) / `limits` を返す

## UseCase (createIssueStreamTokenUseCase)

1. parse input
2. `sessionIdFactory` / `streamTokenIdFactory` で ULID を合成
3. `clock()` からの `createdAt` + `tokenTtlSec` で `expiresAt` を合成
4. `createRelaySession` で domain invariants 検証
5. `jwtSigner.sign({jti, sub, expiresAtEpochSec})` で JWT 署名
6. `sessionRepository.save` でメモリ保存
7. Output を組み立てて返す

## Mock 防止設計

- `jwtSigner` / `sessionRepository` / `clock` / `sessionIdFactory` / `streamTokenIdFactory` / `relayUrl` / `tokenTtlSec` / `heartbeatIntervalSec` / `maxConcurrentSessions` / `maxFrameRatePerSecond` は全て必須 DI
- `tokenTtlSec <= 0` は factory 呼び出し時 `throw` (fail-fast)

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 57 relay-api tests + 593 extension tests)
- [x] `jwt-signer.test.ts` (2 cases): port contract
- [x] `session-repository.test.ts` (2 cases): port contract
- [x] `issue-stream-token-dto.test.ts` (8 cases): 正常系 / 未知 sourceType / empty displayName / overlayTarget 不足 / client 不足 / non-boolean autoDetectLanguage
- [x] `issue-stream-token-use-case.test.ts` (7 cases): 正常系 / JWT 署名 payload / 入力不正 / autoDetect 不整合 / jwtSigner 失敗時 save しない / repo 失敗 / tokenTtlSec=0 での fail-fast

## Out of scope (後続 PR)

- IMPL-431 実 JWT 署名 (jose HS256 or RS256) / 検証 port
- IMPL-411 POST /sessions HTTP route (本 UseCase を配線)
- IMPL-412 GET /sessions/:id route
- in-memory `RelaySessionRepository` 実装