### PR TITLE
feat(relay-api): IMPL-431 jose JwtSigner + in-memory RelaySessionRepository

### DIFF
--- a/packages/relay-api/src/infrastructure/auth/jose-jwt-signer.test.ts
+++ b/packages/relay-api/src/infrastructure/auth/jose-jwt-signer.test.ts
@@ -1,0 +1,85 @@
+import { jwtVerify } from 'jose';
+import { describe, expect, it } from 'vitest';
+import { createJoseJwtSigner } from './jose-jwt-signer';
+
+const SECRET_32 = new TextEncoder().encode('test-secret-32-bytes-padding!!123456');
+const ISSUER = 'https://relay.example.com';
+const AUDIENCE = 'perapera-extension';
+
+describe('createJoseJwtSigner', () => {
+  it('throws synchronously when the secretKey is shorter than 32 bytes', () => {
+    const shortKey = new TextEncoder().encode('too-short');
+    expect(() =>
+      createJoseJwtSigner({ secretKey: shortKey, issuer: ISSUER, audience: AUDIENCE }),
+    ).toThrow(/at least 32 bytes/);
+  });
+
+  it('returns a signed JWT whose payload contains jti / sub / iss / aud / exp', async () => {
+    const signer = createJoseJwtSigner({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    const result = await signer.sign({
+      jti: 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+      sub: '01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+      expiresAtEpochSec: exp,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const { payload } = await jwtVerify(result.value, SECRET_32, {
+        issuer: ISSUER,
+        audience: AUDIENCE,
+      });
+      expect(payload.jti).toBe('strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1');
+      expect(payload.sub).toBe('01HZX8Y1R8M7D3Q2P4T5V6W7A2');
+      expect(payload.exp).toBe(exp);
+      expect(payload.iss).toBe(ISSUER);
+      expect(payload.aud).toBe(AUDIENCE);
+    }
+  });
+
+  it('includes extraClaims in the signed payload', async () => {
+    const signer = createJoseJwtSigner({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    const result = await signer.sign({
+      jti: 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+      sub: '01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+      expiresAtEpochSec: exp,
+      extraClaims: { pv: '1.0' },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const { payload } = await jwtVerify(result.value, SECRET_32, {
+        issuer: ISSUER,
+        audience: AUDIENCE,
+      });
+      expect(payload['pv']).toBe('1.0');
+    }
+  });
+
+  it('rejects verification when using a different secretKey', async () => {
+    const signer = createJoseJwtSigner({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const result = await signer.sign({
+      jti: 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+      sub: '01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+      expiresAtEpochSec: Math.floor(Date.now() / 1000) + 600,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const wrongKey = new TextEncoder().encode('wrong-secret-32-bytes-padding!123456');
+      await expect(
+        jwtVerify(result.value, wrongKey, { issuer: ISSUER, audience: AUDIENCE }),
+      ).rejects.toThrow();
+    }
+  });
+});

--- a/packages/relay-api/src/infrastructure/auth/jose-jwt-signer.ts
+++ b/packages/relay-api/src/infrastructure/auth/jose-jwt-signer.ts
@@ -1,0 +1,48 @@
+import { ResultAsync } from 'neverthrow';
+import { SignJWT } from 'jose';
+import { type JwtSigner, type JwtSignerPayload } from '../../application/ports/jwt-signer';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+
+/**
+ * `JwtSigner` の jose 実装 (IMPL-431 の一部)。
+ *
+ * HS256 (HMAC-SHA256) で WebSocket stream token 用の短命 JWT を署名する。
+ * 秘密鍵は Cloud Run 環境変数 (`STREAM_TOKEN_SECRET`) 等から注入する想定。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - `secretKey` / `issuer` / `audience` は必須 DI (default なし)
+ * - production entrypoint で `new TextEncoder().encode(process.env.STREAM_TOKEN_SECRET)` を明示的に渡す
+ *
+ * 注: RS256 / ES256 への移行は後続 issue。鍵ローテーションも同様。
+ */
+export type JoseJwtSignerDependencies = Readonly<{
+  secretKey: Uint8Array;
+  issuer: string;
+  audience: string;
+}>;
+
+export const createJoseJwtSigner = (deps: JoseJwtSignerDependencies): JwtSigner => {
+  if (deps.secretKey.byteLength < 32) {
+    throw new Error('JoseJwtSigner: HS256 secretKey must be at least 32 bytes (256-bit)');
+  }
+  return {
+    sign: (payload: JwtSignerPayload) => {
+      const extra = payload.extraClaims ?? {};
+      const token = new SignJWT(extra)
+        .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+        .setJti(payload.jti)
+        .setSubject(payload.sub)
+        .setIssuer(deps.issuer)
+        .setAudience(deps.audience)
+        .setIssuedAt()
+        .setExpirationTime(payload.expiresAtEpochSec)
+        .sign(deps.secretKey);
+      return ResultAsync.fromPromise<string, DomainError>(token, (cause) =>
+        invariantViolationError({
+          invariant: 'jwt-signing-failed',
+          details: cause instanceof Error ? cause.message : 'unknown signing error',
+        }),
+      );
+    },
+  };
+};

--- a/packages/relay-api/src/infrastructure/session/in-memory-relay-session-repository.test.ts
+++ b/packages/relay-api/src/infrastructure/session/in-memory-relay-session-repository.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { createRelaySession } from '../../domain/session/relay-session';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { createInMemoryRelaySessionRepository } from './in-memory-relay-session-repository';
+
+const ID_A = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const ID_B = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+
+const buildSession = (sessionId: string) =>
+  createRelaySession({
+    sessionIdentifier: sessionId,
+    streamTokenIdentifier: 'strm_' + sessionId,
+    sourceType: 'tab',
+    displayName: 'Tab',
+    sourceLanguage: 'en-US',
+    autoDetectLanguage: false,
+    targetLanguage: 'ja-JP',
+    overlayTarget: { kind: 'tab', tabId: 1 },
+    client: { extensionVersion: '0.1.0', protocolVersion: '1.0' },
+    createdAt: '2026-04-21T00:00:00.000Z',
+    expiresAt: '2026-04-21T01:00:00.000Z',
+  })._unsafeUnwrap();
+
+describe('createInMemoryRelaySessionRepository', () => {
+  const identifierA: SessionIdentifier = parseSessionIdentifier(ID_A)._unsafeUnwrap();
+  const identifierB: SessionIdentifier = parseSessionIdentifier(ID_B)._unsafeUnwrap();
+
+  it('save then find returns the stored session', async () => {
+    const repo = createInMemoryRelaySessionRepository();
+    const session = buildSession(ID_A);
+    await repo.save(session);
+    const result = await repo.find(identifierA);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toEqual(session);
+  });
+
+  it('find returns null for unknown identifiers', async () => {
+    const repo = createInMemoryRelaySessionRepository();
+    const result = await repo.find(identifierA);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBeNull();
+  });
+
+  it('save overwrites an existing session for the same identifier', async () => {
+    const repo = createInMemoryRelaySessionRepository();
+    const first = buildSession(ID_A);
+    await repo.save(first);
+    const next = { ...first, displayName: 'Renamed' };
+    await repo.save(next);
+    const result = await repo.find(identifierA);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value?.displayName).toBe('Renamed');
+  });
+
+  it('delete removes the session', async () => {
+    const repo = createInMemoryRelaySessionRepository();
+    await repo.save(buildSession(ID_A));
+    await repo.delete(identifierA);
+    const result = await repo.find(identifierA);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBeNull();
+  });
+
+  it('isolates sessions by identifier', async () => {
+    const repo = createInMemoryRelaySessionRepository();
+    await repo.save(buildSession(ID_A));
+    await repo.save(buildSession(ID_B));
+    const a = await repo.find(identifierA);
+    const b = await repo.find(identifierB);
+    expect(a.isOk() && a.value !== null).toBe(true);
+    expect(b.isOk() && b.value !== null).toBe(true);
+  });
+});

--- a/packages/relay-api/src/infrastructure/session/in-memory-relay-session-repository.ts
+++ b/packages/relay-api/src/infrastructure/session/in-memory-relay-session-repository.ts
@@ -1,0 +1,34 @@
+import { okAsync, type ResultAsync } from 'neverthrow';
+import { type RelaySessionRepository } from '../../application/ports/session-repository';
+import { type RelaySession } from '../../domain/session/relay-session';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * `RelaySessionRepository` の in-memory 実装 (MVP)。
+ *
+ * Cloud Run 単一インスタンス前提の簡易実装。プロセス再起動で消失する。
+ * スケール (複数インスタンス) 時は Redis 等の共有ストアへ差し替える。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - 内部 Map は module-private。外部から観測できない (test は port 経由)
+ * - production entrypoint で `createInMemoryRelaySessionRepository()` を明示
+ *   的に呼び出して service に注入する
+ */
+export const createInMemoryRelaySessionRepository = (): RelaySessionRepository => {
+  const store = new Map<SessionIdentifier, RelaySession>();
+  return {
+    save: (session: RelaySession): ResultAsync<void, DomainError> => {
+      store.set(session.sessionIdentifier, session);
+      return okAsync<void, DomainError>(undefined);
+    },
+    find: (sessionIdentifier: SessionIdentifier) => {
+      const session = store.get(sessionIdentifier);
+      return okAsync<RelaySession | null, DomainError>(session ?? null);
+    },
+    delete: (sessionIdentifier: SessionIdentifier) => {
+      store.delete(sessionIdentifier);
+      return okAsync<void, DomainError>(undefined);
+    },
+  };
+};


### PR DESCRIPTION
## Summary

Phase 4 §6.1 の infrastructure 実装。`IssueStreamTokenUseCase` (IMPL-401) に必要な `JwtSigner` / `SessionRepository` の production 実装を提供する。

## createJoseJwtSigner (infrastructure/auth/)

- `jose` `SignJWT` で **HS256** 署名
- `jti` / `sub` / `iss` / `aud` / `iat` / `exp` + `extraClaims` を標準 JWT claims として設定
- `secretKey` が 32 bytes 未満 (HS256 の 256-bit 要件未満) は factory で `throw` (fail-fast)。production は環境変数 `STREAM_TOKEN_SECRET` 等から注入する想定
- 失敗時は `invariantViolationError({ invariant: 'jwt-signing-failed' })`

## createInMemoryRelaySessionRepository (infrastructure/session/)

- `Map<SessionIdentifier, RelaySession>` を保持するシンプル実装
- Cloud Run 単一インスタンス前提 (MVP)。スケール時は Redis 等の共有ストアへ差し替え可能に port 経由

## Mock 防止設計

- 両 factory とも production 利用時に必須 DI (`secretKey` / `issuer` / `audience` 等)
- jose は公式ライブラリで mock ではない

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 66 relay-api tests + 593 extension tests)
- [x] `jose-jwt-signer.test.ts` (4 cases): 短鍵 throw / sign + jwtVerify 往復 / extraClaims 反映 / 鍵違いで verify 失敗
- [x] `in-memory-relay-session-repository.test.ts` (5 cases): save+find / 未知 identifier は null / 上書き / delete / 独立 identifier

## Out of scope (後続 PR)

- IMPL-411 POST /sessions HTTP route (本 infrastructure を UseCase 経由で配線)
- IMPL-412 GET /sessions/:id route
- JwtVerifier port + 実装 (WebSocket 側で stream token 検証に利用)
- RS256 / 鍵ローテーション (HS256 → 非対称署名への移行)