### PR TITLE
feat(relay-api): IMPL-431 JwtVerifier port + jose implementation

### DIFF
--- a/packages/relay-api/src/application/ports/jwt-verifier.test.ts
+++ b/packages/relay-api/src/application/ports/jwt-verifier.test.ts
@@ -1,0 +1,35 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { type JwtVerifiedPayload, type JwtVerifier } from './jwt-verifier';
+
+describe('JwtVerifier port contract', () => {
+  it('can be implemented with a mock that returns a verified payload', async () => {
+    const verifier: JwtVerifier = {
+      verify: (token: string) => {
+        if (token === 'valid.jwt') {
+          return okAsync<JwtVerifiedPayload, DomainError>({
+            jti: 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+            sub: '01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+            expiresAtEpochSec: 1_700_000_000,
+            issuedAtEpochSec: 1_699_999_400,
+            claims: { sourceType: 'tab' },
+          });
+        }
+        return errAsync<JwtVerifiedPayload, DomainError>(
+          invariantViolationError({
+            invariant: 'jwt-verification-failed',
+            details: 'invalid token',
+          }),
+        );
+      },
+    };
+
+    const ok = await verifier.verify('valid.jwt');
+    expect(ok.isOk()).toBe(true);
+    if (ok.isOk()) expect(ok.value.claims['sourceType']).toBe('tab');
+
+    const bad = await verifier.verify('bad.jwt');
+    expect(bad.isErr()).toBe(true);
+  });
+});

--- a/packages/relay-api/src/application/ports/jwt-verifier.ts
+++ b/packages/relay-api/src/application/ports/jwt-verifier.ts
@@ -1,0 +1,35 @@
+import { type ResultAsync } from 'neverthrow';
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * JwtVerifier が返す復号済みペイロード (IMPL-431 WebSocket 側)。
+ *
+ * - `jti` / `sub` / `expiresAtEpochSec` / `issuedAtEpochSec`: 標準 claims
+ * - `claims`: signer が `extraClaims` に入れた session メタ (sourceType 等)
+ *   だけを抽出したもの。`iss` / `aud` / `jti` / `sub` / `exp` / `iat` は含まない
+ */
+export type JwtVerifiedPayload = Readonly<{
+  jti: string;
+  sub: string;
+  expiresAtEpochSec: number;
+  issuedAtEpochSec: number;
+  claims: Readonly<Record<string, unknown>>;
+}>;
+
+/**
+ * WebSocket stream token 用の JWT 検証ポート。
+ *
+ * 対応する Signer: `application/ports/jwt-signer.ts`
+ *
+ * 失敗ケース (いずれも `invariantViolationError`):
+ * - 署名不正 / 鍵違い
+ * - 有効期限切れ (exp 超過)
+ * - issuer / audience 不一致
+ * - 必須 claim (jti / sub / exp / iat) が欠落
+ * - トークン形式異常
+ *
+ * WebSocket handler は result.isErr で接続を拒否する。
+ */
+export type JwtVerifier = Readonly<{
+  verify: (token: string) => ResultAsync<JwtVerifiedPayload, DomainError>;
+}>;

--- a/packages/relay-api/src/infrastructure/auth/jose-jwt-verifier.test.ts
+++ b/packages/relay-api/src/infrastructure/auth/jose-jwt-verifier.test.ts
@@ -1,0 +1,204 @@
+import { SignJWT } from 'jose';
+import { describe, expect, it } from 'vitest';
+import { createJoseJwtSigner } from './jose-jwt-signer';
+import { createJoseJwtVerifier } from './jose-jwt-verifier';
+
+const SECRET_32 = new TextEncoder().encode('test-secret-32-bytes-padding!!123456');
+const ISSUER = 'https://relay.example.com';
+const AUDIENCE = 'perapera-extension';
+
+const futureEpochSec = () => Math.floor(Date.now() / 1000) + 600;
+
+describe('createJoseJwtVerifier', () => {
+  it('throws synchronously when the secretKey is shorter than 32 bytes', () => {
+    const shortKey = new TextEncoder().encode('too-short');
+    expect(() =>
+      createJoseJwtVerifier({ secretKey: shortKey, issuer: ISSUER, audience: AUDIENCE }),
+    ).toThrow(/at least 32 bytes/);
+  });
+
+  it('verifies a token signed by createJoseJwtSigner and returns jti / sub / exp / iat / claims', async () => {
+    const signer = createJoseJwtSigner({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const verifier = createJoseJwtVerifier({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const exp = futureEpochSec();
+    const signed = await signer.sign({
+      jti: 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+      sub: '01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+      expiresAtEpochSec: exp,
+      extraClaims: {
+        sourceType: 'tab',
+        displayName: 'YouTube Live',
+        overlayTarget: { kind: 'tab', tabId: 42 },
+      },
+    });
+    expect(signed.isOk()).toBe(true);
+    if (!signed.isOk()) return;
+
+    const verified = await verifier.verify(signed.value);
+    expect(verified.isOk()).toBe(true);
+    if (verified.isOk()) {
+      expect(verified.value.jti).toBe('strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1');
+      expect(verified.value.sub).toBe('01HZX8Y1R8M7D3Q2P4T5V6W7A2');
+      expect(verified.value.expiresAtEpochSec).toBe(exp);
+      expect(verified.value.claims['sourceType']).toBe('tab');
+      expect(verified.value.claims['displayName']).toBe('YouTube Live');
+      expect(verified.value.claims['overlayTarget']).toEqual({ kind: 'tab', tabId: 42 });
+    }
+  });
+
+  it('excludes standard claims (iss / aud / jti / sub / exp / iat) from the custom claims bag', async () => {
+    const signer = createJoseJwtSigner({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const verifier = createJoseJwtVerifier({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const signed = (
+      await signer.sign({
+        jti: 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+        sub: '01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+        expiresAtEpochSec: futureEpochSec(),
+        extraClaims: { foo: 'bar' },
+      })
+    )._unsafeUnwrap();
+
+    const verified = await verifier.verify(signed);
+    if (verified.isOk()) {
+      expect(verified.value.claims).toEqual({ foo: 'bar' });
+      expect(verified.value.claims['iss']).toBeUndefined();
+      expect(verified.value.claims['aud']).toBeUndefined();
+      expect(verified.value.claims['jti']).toBeUndefined();
+    }
+  });
+
+  it('rejects tokens signed with a different secretKey', async () => {
+    const verifier = createJoseJwtVerifier({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const wrongKey = new TextEncoder().encode('different-secret-32-bytes-pad!!123456');
+    const signedWithWrong = await new SignJWT({})
+      .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+      .setJti('strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1')
+      .setSubject('01HZX8Y1R8M7D3Q2P4T5V6W7A2')
+      .setIssuer(ISSUER)
+      .setAudience(AUDIENCE)
+      .setIssuedAt()
+      .setExpirationTime(futureEpochSec())
+      .sign(wrongKey);
+    const result = await verifier.verify(signedWithWrong);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+  });
+
+  it('rejects tokens with mismatched issuer', async () => {
+    const signer = createJoseJwtSigner({
+      secretKey: SECRET_32,
+      issuer: 'https://other.example.com',
+      audience: AUDIENCE,
+    });
+    const verifier = createJoseJwtVerifier({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const signed = (
+      await signer.sign({
+        jti: 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+        sub: '01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+        expiresAtEpochSec: futureEpochSec(),
+      })
+    )._unsafeUnwrap();
+    const result = await verifier.verify(signed);
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects tokens with mismatched audience', async () => {
+    const signer = createJoseJwtSigner({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: 'other-audience',
+    });
+    const verifier = createJoseJwtVerifier({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const signed = (
+      await signer.sign({
+        jti: 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+        sub: '01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+        expiresAtEpochSec: futureEpochSec(),
+      })
+    )._unsafeUnwrap();
+    const result = await verifier.verify(signed);
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects expired tokens', async () => {
+    const verifier = createJoseJwtVerifier({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const pastEpochSec = Math.floor(Date.now() / 1000) - 3600;
+    const expired = await new SignJWT({})
+      .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+      .setJti('strm_01HZX8Y1R8M7D3Q2P4T5V6W7A1')
+      .setSubject('01HZX8Y1R8M7D3Q2P4T5V6W7A2')
+      .setIssuer(ISSUER)
+      .setAudience(AUDIENCE)
+      .setIssuedAt(pastEpochSec - 600)
+      .setExpirationTime(pastEpochSec)
+      .sign(SECRET_32);
+    const result = await verifier.verify(expired);
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects malformed tokens', async () => {
+    const verifier = createJoseJwtVerifier({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const result = await verifier.verify('not-a-jwt');
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects tokens missing jti (standard claim type violation)', async () => {
+    const verifier = createJoseJwtVerifier({
+      secretKey: SECRET_32,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const signedWithoutJti = await new SignJWT({})
+      .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+      .setSubject('01HZX8Y1R8M7D3Q2P4T5V6W7A2')
+      .setIssuer(ISSUER)
+      .setAudience(AUDIENCE)
+      .setIssuedAt()
+      .setExpirationTime(futureEpochSec())
+      .sign(SECRET_32);
+    const result = await verifier.verify(signedWithoutJti);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.kind).toBe('invariant-violation');
+      if (result.error.kind === 'invariant-violation') {
+        expect(result.error.invariant).toBe('jwt-missing-jti');
+      }
+    }
+  });
+});

--- a/packages/relay-api/src/infrastructure/auth/jose-jwt-verifier.ts
+++ b/packages/relay-api/src/infrastructure/auth/jose-jwt-verifier.ts
@@ -1,0 +1,106 @@
+import { ResultAsync, err, ok, type Result } from 'neverthrow';
+import { jwtVerify, type JWTPayload } from 'jose';
+import { type JwtVerifiedPayload, type JwtVerifier } from '../../application/ports/jwt-verifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+
+/**
+ * `JwtVerifier` の jose 実装 (IMPL-431 WebSocket 側)。
+ *
+ * HS256 で署名された stream token を検証する。対応する signer は
+ * `createJoseJwtSigner`。両者は同一の `secretKey` / `issuer` / `audience` を
+ * 共有する必要がある (production では同じ環境変数から注入する)。
+ *
+ * 検証内容 (jose `jwtVerify` が自動で行う項目):
+ * - 署名検証 (HS256 HMAC)
+ * - `iss` が期待値と一致
+ * - `aud` が期待値と一致
+ * - `exp` が現在時刻を超過していない
+ *
+ * 本実装で追加の検証:
+ * - `jti` / `sub` / `exp` / `iat` の型 (string / number) を確認し、欠落時は
+ *   `invariantViolationError` で弾く (JWT 標準 claims の type 違反)
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - `secretKey` / `issuer` / `audience` は必須 DI
+ * - production entrypoint で signer と同じ値を渡す
+ */
+export type JoseJwtVerifierDependencies = Readonly<{
+  secretKey: Uint8Array;
+  issuer: string;
+  audience: string;
+}>;
+
+const STANDARD_CLAIM_KEYS = new Set(['iss', 'aud', 'jti', 'sub', 'exp', 'iat', 'nbf']);
+
+const extractCustomClaims = (payload: JWTPayload): Record<string, unknown> => {
+  const custom: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(payload)) {
+    if (!STANDARD_CLAIM_KEYS.has(key)) {
+      custom[key] = value;
+    }
+  }
+  return custom;
+};
+
+const narrowPayload = (payload: JWTPayload): Result<JwtVerifiedPayload, DomainError> => {
+  if (typeof payload.jti !== 'string' || payload.jti.length === 0) {
+    return err(
+      invariantViolationError({
+        invariant: 'jwt-missing-jti',
+        details: 'verified payload must contain a non-empty jti',
+      }),
+    );
+  }
+  if (typeof payload.sub !== 'string' || payload.sub.length === 0) {
+    return err(
+      invariantViolationError({
+        invariant: 'jwt-missing-sub',
+        details: 'verified payload must contain a non-empty sub',
+      }),
+    );
+  }
+  if (typeof payload.exp !== 'number') {
+    return err(
+      invariantViolationError({
+        invariant: 'jwt-missing-exp',
+        details: 'verified payload must contain a numeric exp',
+      }),
+    );
+  }
+  if (typeof payload.iat !== 'number') {
+    return err(
+      invariantViolationError({
+        invariant: 'jwt-missing-iat',
+        details: 'verified payload must contain a numeric iat',
+      }),
+    );
+  }
+  return ok<JwtVerifiedPayload, DomainError>({
+    jti: payload.jti,
+    sub: payload.sub,
+    expiresAtEpochSec: payload.exp,
+    issuedAtEpochSec: payload.iat,
+    claims: extractCustomClaims(payload),
+  });
+};
+
+export const createJoseJwtVerifier = (deps: JoseJwtVerifierDependencies): JwtVerifier => {
+  if (deps.secretKey.byteLength < 32) {
+    throw new Error('JoseJwtVerifier: HS256 secretKey must be at least 32 bytes (256-bit)');
+  }
+  return {
+    verify: (token: string) => {
+      return ResultAsync.fromPromise(
+        jwtVerify(token, deps.secretKey, {
+          issuer: deps.issuer,
+          audience: deps.audience,
+        }),
+        (cause) =>
+          invariantViolationError({
+            invariant: 'jwt-verification-failed',
+            details: cause instanceof Error ? cause.message : 'unknown verification error',
+          }),
+      ).andThen(({ payload }) => narrowPayload(payload));
+    },
+  };
+};


### PR DESCRIPTION
## Summary

Stateless 設計 (PR #30) を受けて、WebSocket 側で stream token を検証する対の verifier を追加。signer と verifier は同じ `secret` / `issuer` / `audience` を共有し、jose HS256 で署名と検証を往復する。

## JwtVerifier port (application/ports/jwt-verifier.ts)

- `verify(token) → ResultAsync<JwtVerifiedPayload, DomainError>`
- `JwtVerifiedPayload`: `jti` / `sub` / `expiresAtEpochSec` / `issuedAtEpochSec` + `claims` (標準 JWT claims を除いた `extraClaims` 相当)

## createJoseJwtVerifier (infrastructure/auth/jose-jwt-verifier.ts)

- `jose jwtVerify` で HS256 署名 / `iss` / `aud` / `exp` を自動検証
- 標準 claims (`jti` / `sub` / `exp` / `iat`) の型を narrow チェック。欠落は `invariantViolationError({ invariant: 'jwt-missing-<claim>' })` で弾く
- custom claims は `iss` / `aud` / `jti` / `sub` / `exp` / `iat` / `nbf` を除外した key で `claims` bag に格納
- `secretKey < 32 bytes` は factory で `throw` (signer と同じ fail-fast)

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 77 relay-api tests + 593 extension tests)
- [x] `jwt-verifier.test.ts` (1 case): port contract mock
- [x] `jose-jwt-verifier.test.ts` (9 cases): 短鍵 throw / signer との E2E 往復 / 標準 claims 除外 / 鍵違い / issuer 不一致 / audience 不一致 / expired / malformed / jti 欠落

## Out of scope (後続)

- IMPL-430 HTTP access token Bearer 検証 (POST /sessions の preHandler)
- IMPL-420 WebSocket /relay 接続時の stream token 検証 (本 verifier を配線)
- IMPL-432 rate limit / IMPL-433 CORS / IMPL-434 helmet