### PR TITLE
feat(relay-api): IMPL-420 WebSocket /relay connection + stream token verify

### DIFF
--- a/packages/relay-api/src/presentation/http/routes/sessions.test.ts
+++ b/packages/relay-api/src/presentation/http/routes/sessions.test.ts
@@ -1,5 +1,6 @@
 import { errAsync, okAsync } from 'neverthrow';
 import { describe, expect, it, vi } from 'vitest';
+import { type JwtVerifier } from '../../../application/ports/jwt-verifier';
 import { type IssueStreamTokenOutput } from '../../../application/dto/issue-stream-token-dto';
 import { type IssueStreamTokenUseCase } from '../../../application/use-cases/issue-stream-token-use-case';
 import {
@@ -8,6 +9,20 @@ import {
   type DomainError,
 } from '../../../domain/shared/errors';
 import { buildApp } from '../server';
+
+const noopVerifier: JwtVerifier = {
+  verify: () =>
+    okAsync({
+      jti: 'strm_xxx',
+      sub: '01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+      expiresAtEpochSec: Math.floor(Date.now() / 1000) + 600,
+      issuedAtEpochSec: Math.floor(Date.now() / 1000),
+      claims: {},
+    }),
+};
+
+const buildTestApp = (issueStreamTokenUseCase: IssueStreamTokenUseCase) =>
+  buildApp({ issueStreamTokenUseCase, jwtVerifier: noopVerifier });
 
 const successOutput: IssueStreamTokenOutput = {
   sessionId: '01HZX8Y1R8M7D3Q2P4T5V6W7A1',
@@ -43,7 +58,7 @@ describe('POST /sessions route (IMPL-411, stateless)', () => {
     const useCase: IssueStreamTokenUseCase = vi.fn(() =>
       okAsync<IssueStreamTokenOutput, DomainError>(successOutput),
     );
-    const app = buildApp({ issueStreamTokenUseCase: useCase });
+    const app = buildTestApp(useCase);
     try {
       const response = await app.inject({
         method: 'POST',
@@ -64,7 +79,7 @@ describe('POST /sessions route (IMPL-411, stateless)', () => {
   it('returns requestId in meta with req_ prefix', async () => {
     const useCase: IssueStreamTokenUseCase = () =>
       okAsync<IssueStreamTokenOutput, DomainError>(successOutput);
-    const app = buildApp({ issueStreamTokenUseCase: useCase });
+    const app = buildTestApp(useCase);
     try {
       const response = await app.inject({
         method: 'POST',
@@ -92,7 +107,7 @@ describe('POST /sessions route (IMPL-411, stateless)', () => {
       errAsync<IssueStreamTokenOutput, DomainError>(
         validationError({ field: 'displayName', message: 'must be non-empty' }),
       );
-    const app = buildApp({ issueStreamTokenUseCase: useCase });
+    const app = buildTestApp(useCase);
     try {
       const response = await app.inject({
         method: 'POST',
@@ -112,7 +127,7 @@ describe('POST /sessions route (IMPL-411, stateless)', () => {
       errAsync<IssueStreamTokenOutput, DomainError>(
         invariantViolationError({ invariant: 'x', details: 'y' }),
       );
-    const app = buildApp({ issueStreamTokenUseCase: useCase });
+    const app = buildTestApp(useCase);
     try {
       const response = await app.inject({
         method: 'POST',

--- a/packages/relay-api/src/presentation/http/server.ts
+++ b/packages/relay-api/src/presentation/http/server.ts
@@ -1,16 +1,21 @@
+import fastifyWebsocket from '@fastify/websocket';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { ulid } from 'ulid';
+import { type JwtVerifier } from '../../application/ports/jwt-verifier';
 import {
   createIssueStreamTokenUseCase,
   type IssueStreamTokenUseCase,
 } from '../../application/use-cases/issue-stream-token-use-case';
 import { createJoseJwtSigner } from '../../infrastructure/auth/jose-jwt-signer';
+import { createJoseJwtVerifier } from '../../infrastructure/auth/jose-jwt-verifier';
 import { loggerOptions } from '../../infrastructure/logging/logger';
+import { registerRelayRoute } from '../ws/relay-route';
 import { registerHealthRoute } from './routes/health';
 import { registerSessionsRoute } from './routes/sessions';
 
 export type AppDependencies = Readonly<{
   issueStreamTokenUseCase: IssueStreamTokenUseCase;
+  jwtVerifier: JwtVerifier;
 }>;
 
 export function buildApp(deps: AppDependencies): FastifyInstance {
@@ -21,8 +26,17 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
     genReqId: () => `req_${ulid()}`,
   });
 
+  // @fastify/websocket は onRoute hook で `{ websocket: true }` 経路を変換する。
+  // hook は plugin load 後にしか有効にならないため、WebSocket route は本 plugin
+  // 登録の "後" に load されるネスト plugin 内で宣言する必要がある。
+  void app.register(fastifyWebsocket);
+
   registerHealthRoute(app);
   registerSessionsRoute(app, { issueStreamTokenUseCase: deps.issueStreamTokenUseCase });
+  void app.register((instance, _opts, done) => {
+    registerRelayRoute(instance, { jwtVerifier: deps.jwtVerifier });
+    done();
+  });
 
   return app;
 }
@@ -52,11 +66,9 @@ const buildProductionDependencies = (): AppDependencies => {
   const relayUrl = process.env['RELAY_PUBLIC_URL'] ?? 'wss://relay.local/api/v1/relay';
   const ttlSec = Number.parseInt(process.env['STREAM_TOKEN_TTL_SEC'] ?? '1800', 10);
 
-  const jwtSigner = createJoseJwtSigner({
-    secretKey: new TextEncoder().encode(secret),
-    issuer,
-    audience,
-  });
+  const secretKey = new TextEncoder().encode(secret);
+  const jwtSigner = createJoseJwtSigner({ secretKey, issuer, audience });
+  const jwtVerifier = createJoseJwtVerifier({ secretKey, issuer, audience });
 
   const issueStreamTokenUseCase = createIssueStreamTokenUseCase({
     jwtSigner,
@@ -70,7 +82,7 @@ const buildProductionDependencies = (): AppDependencies => {
     maxFrameRatePerSecond: 10,
   });
 
-  return { issueStreamTokenUseCase };
+  return { issueStreamTokenUseCase, jwtVerifier };
 };
 
 async function start(): Promise<void> {

--- a/packages/relay-api/src/presentation/ws/relay-auth.test.ts
+++ b/packages/relay-api/src/presentation/ws/relay-auth.test.ts
@@ -1,0 +1,160 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { type JwtVerifiedPayload, type JwtVerifier } from '../../application/ports/jwt-verifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { authorizeRelayUpgrade } from './relay-auth';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const TOKEN_ID = 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+
+const validPayload: JwtVerifiedPayload = {
+  jti: TOKEN_ID,
+  sub: SESSION_ID,
+  expiresAtEpochSec: Math.floor(Date.now() / 1000) + 600,
+  issuedAtEpochSec: Math.floor(Date.now() / 1000) - 10,
+  claims: { sourceType: 'tab' },
+};
+
+const okVerifier: JwtVerifier = {
+  verify: () => okAsync<JwtVerifiedPayload, DomainError>(validPayload),
+};
+
+const failingVerifier: JwtVerifier = {
+  verify: () =>
+    errAsync<JwtVerifiedPayload, DomainError>(
+      invariantViolationError({ invariant: 'jwt-verification-failed', details: 'boom' }),
+    ),
+};
+
+describe('authorizeRelayUpgrade', () => {
+  it('succeeds when Authorization is valid, sessionId matches sub, and protocolVersion is supported', async () => {
+    const result = await authorizeRelayUpgrade(
+      {
+        authorizationHeader: 'Bearer valid.jwt.string',
+        sessionIdQuery: SESSION_ID,
+        protocolVersionQuery: '1.0',
+      },
+      okVerifier,
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessionId).toBe(SESSION_ID);
+      expect(result.value.protocolVersion).toBe('1.0');
+      expect(result.value.tokenPayload.jti).toBe(TOKEN_ID);
+    }
+  });
+
+  it('rejects when Authorization header is missing', async () => {
+    const result = await authorizeRelayUpgrade(
+      {
+        authorizationHeader: undefined,
+        sessionIdQuery: SESSION_ID,
+        protocolVersionQuery: '1.0',
+      },
+      okVerifier,
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('relay-missing-authorization');
+    }
+  });
+
+  it('rejects when Authorization header does not use Bearer scheme', async () => {
+    const result = await authorizeRelayUpgrade(
+      {
+        authorizationHeader: 'Basic abc',
+        sessionIdQuery: SESSION_ID,
+        protocolVersionQuery: '1.0',
+      },
+      okVerifier,
+    );
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects when Bearer token is empty', async () => {
+    const result = await authorizeRelayUpgrade(
+      {
+        authorizationHeader: 'Bearer ',
+        sessionIdQuery: SESSION_ID,
+        protocolVersionQuery: '1.0',
+      },
+      okVerifier,
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('relay-empty-authorization');
+    }
+  });
+
+  it('surfaces JwtVerifier failure as invariant-violation', async () => {
+    const result = await authorizeRelayUpgrade(
+      {
+        authorizationHeader: 'Bearer expired.jwt',
+        sessionIdQuery: SESSION_ID,
+        protocolVersionQuery: '1.0',
+      },
+      failingVerifier,
+    );
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects when protocolVersion is missing', async () => {
+    const result = await authorizeRelayUpgrade(
+      {
+        authorizationHeader: 'Bearer valid.jwt',
+        sessionIdQuery: SESSION_ID,
+        protocolVersionQuery: undefined,
+      },
+      okVerifier,
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('relay-missing-protocol-version');
+    }
+  });
+
+  it('rejects when protocolVersion is unsupported', async () => {
+    const result = await authorizeRelayUpgrade(
+      {
+        authorizationHeader: 'Bearer valid.jwt',
+        sessionIdQuery: SESSION_ID,
+        protocolVersionQuery: '2.0',
+      },
+      okVerifier,
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('relay-unsupported-protocol-version');
+    }
+  });
+
+  it('rejects when sessionId query is missing', async () => {
+    const result = await authorizeRelayUpgrade(
+      {
+        authorizationHeader: 'Bearer valid.jwt',
+        sessionIdQuery: undefined,
+        protocolVersionQuery: '1.0',
+      },
+      okVerifier,
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('relay-missing-session-id');
+    }
+  });
+
+  it('rejects when sessionId query does not match token sub', async () => {
+    const result = await authorizeRelayUpgrade(
+      {
+        authorizationHeader: 'Bearer valid.jwt',
+        sessionIdQuery: 'different-session-id',
+        protocolVersionQuery: '1.0',
+      },
+      okVerifier,
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('relay-session-id-mismatch');
+    }
+  });
+});

--- a/packages/relay-api/src/presentation/ws/relay-auth.ts
+++ b/packages/relay-api/src/presentation/ws/relay-auth.ts
@@ -1,0 +1,119 @@
+import { err, ok, type Result } from 'neverthrow';
+import { type ResultAsync } from 'neverthrow';
+import { type JwtVerifiedPayload, type JwtVerifier } from '../../application/ports/jwt-verifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+
+/**
+ * WebSocket `/relay` 接続の認可・検証ロジック (IMPL-420 抽象部)。
+ *
+ * pure function として `@fastify/websocket` 層から分離する。preValidation hook
+ * から呼び出し、失敗時は 401 で upgrade を拒否する。
+ *
+ * 検証項目 (api-specification §6.1):
+ * 1. `Authorization: Bearer <stream_token>` ヘッダが存在する
+ * 2. stream token が JwtVerifier で verify される
+ * 3. クエリの `sessionId` が JWT の `sub` と一致する
+ * 4. クエリの `protocolVersion` が既知バージョン ('1.0') と一致する
+ */
+export type ExtractAuthInput = Readonly<{
+  authorizationHeader: string | undefined;
+  sessionIdQuery: string | undefined;
+  protocolVersionQuery: string | undefined;
+}>;
+
+export const SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = ['1.0'] as const;
+
+const BEARER_PREFIX = 'Bearer ';
+
+const extractBearerToken = (header: string | undefined): Result<string, DomainError> => {
+  if (!header?.startsWith(BEARER_PREFIX)) {
+    return err(
+      invariantViolationError({
+        invariant: 'relay-missing-authorization',
+        details: 'Authorization header with Bearer scheme is required',
+      }),
+    );
+  }
+  const token = header.slice(BEARER_PREFIX.length).trim();
+  if (token.length === 0) {
+    return err(
+      invariantViolationError({
+        invariant: 'relay-empty-authorization',
+        details: 'Bearer token is empty',
+      }),
+    );
+  }
+  return ok(token);
+};
+
+const validateProtocolVersion = (version: string | undefined): Result<string, DomainError> => {
+  if (version === undefined) {
+    return err(
+      invariantViolationError({
+        invariant: 'relay-missing-protocol-version',
+        details: 'protocolVersion query parameter is required',
+      }),
+    );
+  }
+  if (!SUPPORTED_PROTOCOL_VERSIONS.includes(version)) {
+    return err(
+      invariantViolationError({
+        invariant: 'relay-unsupported-protocol-version',
+        details: `protocolVersion=${version} is not supported (expected one of ${SUPPORTED_PROTOCOL_VERSIONS.join(',')})`,
+      }),
+    );
+  }
+  return ok(version);
+};
+
+const validateSessionIdMatch = (
+  sessionIdQuery: string | undefined,
+  tokenSub: string,
+): Result<string, DomainError> => {
+  if (sessionIdQuery === undefined || sessionIdQuery.length === 0) {
+    return err(
+      invariantViolationError({
+        invariant: 'relay-missing-session-id',
+        details: 'sessionId query parameter is required',
+      }),
+    );
+  }
+  if (sessionIdQuery !== tokenSub) {
+    return err(
+      invariantViolationError({
+        invariant: 'relay-session-id-mismatch',
+        details: `sessionId query (${sessionIdQuery}) does not match token sub (${tokenSub})`,
+      }),
+    );
+  }
+  return ok(sessionIdQuery);
+};
+
+export type RelayAuthorizedContext = Readonly<{
+  sessionId: string;
+  protocolVersion: string;
+  tokenPayload: JwtVerifiedPayload;
+}>;
+
+/**
+ * WebSocket upgrade 前の認可チェック。成功時は `RelayAuthorizedContext` を返し、
+ * 失敗時は `DomainError`。呼び出し側は `error-mapper` で HTTP ステータスに
+ * 変換する (`invariant-violation` → 401 が望ましい)。
+ */
+export const authorizeRelayUpgrade = (
+  input: ExtractAuthInput,
+  verifier: JwtVerifier,
+): ResultAsync<RelayAuthorizedContext, DomainError> =>
+  extractBearerToken(input.authorizationHeader)
+    .asyncAndThen((token) => verifier.verify(token))
+    .andThen((tokenPayload) =>
+      validateProtocolVersion(input.protocolVersionQuery).andThen((protocolVersion) =>
+        validateSessionIdMatch(input.sessionIdQuery, tokenPayload.sub).map(
+          (sessionId): RelayAuthorizedContext => ({
+            sessionId,
+            protocolVersion,
+            tokenPayload,
+          }),
+        ),
+      ),
+    );

--- a/packages/relay-api/src/presentation/ws/relay-route.test.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.test.ts
@@ -1,0 +1,171 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import WebSocket from 'ws';
+import { type FastifyInstance } from 'fastify';
+import { type JwtVerifiedPayload, type JwtVerifier } from '../../application/ports/jwt-verifier';
+import { type IssueStreamTokenUseCase } from '../../application/use-cases/issue-stream-token-use-case';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { buildApp } from '../http/server';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const OTHER_SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7XX';
+
+const okVerifier: JwtVerifier = {
+  verify: () =>
+    okAsync<JwtVerifiedPayload, DomainError>({
+      jti: 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+      sub: SESSION_ID,
+      expiresAtEpochSec: Math.floor(Date.now() / 1000) + 600,
+      issuedAtEpochSec: Math.floor(Date.now() / 1000),
+      claims: { sourceType: 'tab' },
+    }),
+};
+
+const failingVerifier: JwtVerifier = {
+  verify: () =>
+    errAsync<JwtVerifiedPayload, DomainError>(
+      invariantViolationError({ invariant: 'jwt-verification-failed', details: 'expired' }),
+    ),
+};
+
+const noopUseCase: IssueStreamTokenUseCase = () =>
+  okAsync({
+    sessionId: SESSION_ID,
+    streamToken: 'jwt',
+    relayUrl: 'wss://test/relay',
+    expiresAt: '2026-04-21T01:00:00.000Z',
+    heartbeatIntervalSec: 15,
+    audio: {
+      encoding: 'pcm_s16le',
+      sampleRateHz: 16000,
+      channels: 1,
+      frameDurationMs: 100,
+      transport: 'json-base64',
+    },
+    limits: { maxConcurrentSessions: 3, maxFrameRatePerSecond: 10 },
+  });
+
+type AppHarness = Readonly<{
+  app: FastifyInstance;
+  port: number;
+}>;
+
+const startApp = async (verifier: JwtVerifier): Promise<AppHarness> => {
+  const app = buildApp({ issueStreamTokenUseCase: noopUseCase, jwtVerifier: verifier });
+  await app.listen({ port: 0, host: '127.0.0.1' });
+  const address = app.server.address();
+  const port = typeof address === 'object' && address !== null ? address.port : 0;
+  return { app, port };
+};
+
+const relayUrl = (
+  harness: AppHarness,
+  query = `sessionId=${SESSION_ID}&protocolVersion=1.0`,
+): string => `ws://127.0.0.1:${harness.port}/relay?${query}`;
+
+const connectWithAuth = (url: string, token: string | null): WebSocket =>
+  new WebSocket(
+    url,
+    token === null ? undefined : { headers: { authorization: `Bearer ${token}` } },
+  );
+
+const awaitFirstMessage = (ws: WebSocket): Promise<string> =>
+  new Promise((resolve, reject) => {
+    ws.once('message', (data) => {
+      const buf = Array.isArray(data)
+        ? Buffer.concat(data)
+        : Buffer.isBuffer(data)
+          ? data
+          : Buffer.from(data);
+      resolve(buf.toString('utf8'));
+    });
+    ws.once('error', reject);
+  });
+
+const awaitUnexpectedResponse = (ws: WebSocket): Promise<{ status: number }> =>
+  new Promise((resolve, reject) => {
+    ws.once('unexpected-response', (_req, res) => {
+      resolve({ status: res.statusCode ?? 0 });
+    });
+    ws.once('open', () =>
+      reject(new Error('unexpected-response did not fire; handshake succeeded')),
+    );
+    ws.once('error', () => {
+      // ignore — wrapped unexpected-response fires first on reject
+    });
+  });
+
+describe('WebSocket /relay route (IMPL-420)', () => {
+  let harness: AppHarness | null = null;
+
+  beforeEach(() => {
+    harness = null;
+  });
+
+  afterEach(async () => {
+    if (harness !== null) await harness.app.close();
+  });
+
+  it('sends session.ready event after a successful handshake', async () => {
+    harness = await startApp(okVerifier);
+    const ws = connectWithAuth(relayUrl(harness), 'valid.jwt.token');
+    try {
+      const raw = await awaitFirstMessage(ws);
+      const parsed: unknown = JSON.parse(raw);
+      expect(parsed).toMatchObject({
+        type: 'session.ready',
+        sessionId: SESSION_ID,
+        heartbeatIntervalSec: 15,
+      });
+    } finally {
+      ws.close();
+    }
+  });
+
+  it('rejects the upgrade with 401 when Authorization is missing', async () => {
+    harness = await startApp(okVerifier);
+    const ws = connectWithAuth(relayUrl(harness), null);
+    try {
+      const { status } = await awaitUnexpectedResponse(ws);
+      expect(status).toBe(401);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it('rejects the upgrade with 401 when the verifier fails', async () => {
+    harness = await startApp(failingVerifier);
+    const ws = connectWithAuth(relayUrl(harness), 'expired.jwt');
+    try {
+      const { status } = await awaitUnexpectedResponse(ws);
+      expect(status).toBe(401);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it('rejects the upgrade with 401 when sessionId query mismatches sub', async () => {
+    harness = await startApp(okVerifier);
+    const ws = connectWithAuth(
+      relayUrl(harness, `sessionId=${OTHER_SESSION_ID}&protocolVersion=1.0`),
+      'valid.jwt',
+    );
+    try {
+      const { status } = await awaitUnexpectedResponse(ws);
+      expect(status).toBe(401);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it('rejects the upgrade with 401 when protocolVersion is missing', async () => {
+    harness = await startApp(okVerifier);
+    const ws = connectWithAuth(relayUrl(harness, `sessionId=${SESSION_ID}`), 'valid.jwt');
+    try {
+      const { status } = await awaitUnexpectedResponse(ws);
+      expect(status).toBe(401);
+    } finally {
+      ws.close();
+    }
+  });
+});

--- a/packages/relay-api/src/presentation/ws/relay-route.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.ts
@@ -1,0 +1,83 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { type JwtVerifier } from '../../application/ports/jwt-verifier';
+import { toHttpErrorEnvelope } from '../http/error-mapper';
+import { authorizeRelayUpgrade, type RelayAuthorizedContext } from './relay-auth';
+
+export type RelayRouteDependencies = Readonly<{
+  jwtVerifier: JwtVerifier;
+}>;
+
+type RelayQuery = Readonly<{
+  sessionId?: string;
+  protocolVersion?: string;
+}>;
+
+/**
+ * preValidation で確立した認可情報を handler へ渡す。request オブジェクトの
+ * 拡張プロパティは型的に扱いづらく、WebSocket upgrade 経路で参照が変わる
+ * リスクがあるため、WeakMap 経由で明示的に受け渡す。
+ */
+const contextMap = new WeakMap<FastifyRequest, RelayAuthorizedContext>();
+
+/**
+ * IMPL-420 `/relay` WebSocket 接続ルート。
+ *
+ * api-specification §6.1:
+ * - URL: `/relay?sessionId={sessionId}&protocolVersion=1.0`
+ * - 認証: `Authorization: Bearer <stream_token>`
+ *
+ * 本 PR は upgrade 時の **認可チェック** と **session.ready** 送信のみ。
+ * client/server event loop は IMPL-421 / 422、heartbeat は IMPL-423 で追加。
+ */
+export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDependencies): void => {
+  app.get<{ Querystring: RelayQuery }>(
+    '/relay',
+    {
+      websocket: true,
+      preValidation: async (request, reply) => {
+        const result = await authorizeRelayUpgrade(
+          {
+            authorizationHeader: request.headers.authorization,
+            sessionIdQuery: request.query.sessionId,
+            protocolVersionQuery: request.query.protocolVersion,
+          },
+          deps.jwtVerifier,
+        );
+        if (result.isErr()) {
+          const envelope = toHttpErrorEnvelope(result.error);
+          const status = envelope.status === 400 ? 401 : envelope.status;
+          reply.code(status);
+          await reply.send({ ...envelope.body, meta: { requestId: request.id } });
+          return reply;
+        }
+        contextMap.set(request, result.value);
+        request.log.info(
+          {
+            sessionId: result.value.sessionId,
+            jti: result.value.tokenPayload.jti,
+            protocolVersion: result.value.protocolVersion,
+          },
+          'relay upgrade authorized',
+        );
+      },
+    },
+    (socket, request) => {
+      const context = contextMap.get(request);
+      if (context === undefined) {
+        socket.close(1011, 'relay context missing');
+        return;
+      }
+      contextMap.delete(request);
+      socket.send(
+        JSON.stringify({
+          type: 'session.ready',
+          sessionId: context.sessionId,
+          streamToken: context.tokenPayload.jti,
+          heartbeatIntervalSec: 15,
+        }),
+      );
+      // IMPL-421 / 422 / 423 で incoming message, server events, heartbeat を実装。
+      // 現時点では送信後に接続を保持するだけ (close せず idle 維持)。
+    },
+  );
+};

--- a/packages/relay-api/tests/smoke.test.ts
+++ b/packages/relay-api/tests/smoke.test.ts
@@ -1,5 +1,6 @@
 import { okAsync } from 'neverthrow';
 import { afterAll, describe, expect, it } from 'vitest';
+import { type JwtVerifier } from '../src/application/ports/jwt-verifier';
 import { type IssueStreamTokenUseCase } from '../src/application/use-cases/issue-stream-token-use-case';
 import { buildApp } from '../src/presentation/http/server';
 
@@ -20,7 +21,18 @@ const noopUseCase: IssueStreamTokenUseCase = () =>
     limits: { maxConcurrentSessions: 3, maxFrameRatePerSecond: 10 },
   });
 
-const app = buildApp({ issueStreamTokenUseCase: noopUseCase });
+const noopVerifier: JwtVerifier = {
+  verify: () =>
+    okAsync({
+      jti: 'strm_xxx',
+      sub: '01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+      expiresAtEpochSec: Math.floor(Date.now() / 1000) + 600,
+      issuedAtEpochSec: Math.floor(Date.now() / 1000),
+      claims: {},
+    }),
+};
+
+const app = buildApp({ issueStreamTokenUseCase: noopUseCase, jwtVerifier: noopVerifier });
 
 afterAll(async () => {
   await app.close();


### PR DESCRIPTION
## Summary

Phase 4 §6.3 最初の一歩。`/relay` WebSocket 接続の upgrade 時認可と `session.ready` 送信までを実装。client/server event loop と heartbeat は IMPL-421 / 422 / 423 で追加予定。

## relay-auth.ts (pure function)

- `extractBearerToken`: Authorization ヘッダ検証 (Bearer scheme 必須)
- `validateProtocolVersion`: サポート済みバージョン (現状 `'1.0'`) チェック
- `validateSessionIdMatch`: クエリ `sessionId` ↔ JWT `sub` 一致検証
- `authorizeRelayUpgrade`: 上記を `ResultAsync` でチェーン、`JwtVerifier` でトークン検証

## relay-route.ts

- `preValidation` hook で `authorizeRelayUpgrade` を呼び、失敗時は 401 で upgrade を拒否 (`error-mapper` でマッピング、400 → 401 へ昇格)
- 成功時は `RelayAuthorizedContext` を **WeakMap** 経由で handler へ渡す (`Reflect.set` は WebSocket upgrade 経路で参照が不安定になり得るため)
- handler で JSON の `session.ready` を送信: `{ type, sessionId, streamToken (jti), heartbeatIntervalSec }`

## server.ts

- `@fastify/websocket` を `void app.register` で登録
- WebSocket route は plugin の `onRoute` hook 適用のため、**ネスト plugin 内で遅延登録** する (plugin load 順序の制約で、routes を plugin 登録直後に並べると onRoute hook が効かず `{ websocket: true }` オプションが通常の GET として扱われて 500 を返す)
- `jwtVerifier` を `AppDependencies` に追加し、production では同じ HS256 secret / issuer / audience で signer と対にして配線

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 91 relay-api tests + 593 extension tests)
- [x] `relay-auth.test.ts` (9 cases): 正常系 / Authorization 欠落 / Bearer 以外 / 空トークン / verifier 失敗 / protocolVersion 欠落・非サポート / sessionId 欠落・mismatch
- [x] `relay-route.test.ts` (5 cases, 実 listener + ws client): `session.ready` 受信 / 401 応答 4 種
- [x] `sessions.test.ts` / `smoke.test.ts`: `buildApp` シグネチャ変更に追随

## Out of scope (後続)

- IMPL-421 client events 受信 (`session.start` / `audio.frame` / `pause` / `resume` / `stop` / `ping`)
- IMPL-422 server events 送信 (`transcript.*` / `translation.final` / `session.error` / `session.state.changed` / `session.pong`)
- IMPL-423 heartbeat 15 秒間隔
- IMPL-440-446 ACL (STT / Translation providers)
- IMPL-430 HTTP access token Bearer 検証 (POST /sessions の preHandler)