### PR TITLE
feat(relay-api): IMPL-421/422 client event parse + session.ready/pong/error envelopes

### DIFF
--- a/packages/relay-api/src/presentation/http/server.ts
+++ b/packages/relay-api/src/presentation/http/server.ts
@@ -34,7 +34,11 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
   registerHealthRoute(app);
   registerSessionsRoute(app, { issueStreamTokenUseCase: deps.issueStreamTokenUseCase });
   void app.register((instance, _opts, done) => {
-    registerRelayRoute(instance, { jwtVerifier: deps.jwtVerifier });
+    registerRelayRoute(instance, {
+      jwtVerifier: deps.jwtVerifier,
+      clock: () => new Date().toISOString(),
+      heartbeatIntervalSec: 15,
+    });
     done();
   });
 

--- a/packages/relay-api/src/presentation/ws/client-events.test.ts
+++ b/packages/relay-api/src/presentation/ws/client-events.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { parseClientEvent } from './client-events';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const TIMESTAMP = '2026-04-21T00:00:00.000Z';
+
+const envelope = (eventType: string, payload: unknown, overrides: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    eventType,
+    sessionId: SESSION_ID,
+    sequence: 1,
+    timestamp: TIMESTAMP,
+    payload,
+    ...overrides,
+  });
+
+describe('parseClientEvent', () => {
+  it('parses session.start with full payload', () => {
+    const raw = envelope('session.start', {
+      sourceLanguage: 'en-US',
+      autoDetectLanguage: false,
+      targetLanguage: 'ja-JP',
+      translationEnabled: true,
+    });
+    const result = parseClientEvent(raw);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.eventType).toBe('session.start');
+      if (result.value.eventType === 'session.start') {
+        expect(result.value.payload.targetLanguage).toBe('ja-JP');
+      }
+    }
+  });
+
+  it('parses session.start with sourceLanguage=null (auto-detect)', () => {
+    const raw = envelope('session.start', {
+      sourceLanguage: null,
+      autoDetectLanguage: true,
+      targetLanguage: 'ja-JP',
+      translationEnabled: true,
+    });
+    expect(parseClientEvent(raw).isOk()).toBe(true);
+  });
+
+  it('parses audio.frame with full PCM envelope', () => {
+    const raw = envelope('audio.frame', {
+      chunkId: 'chk_000001',
+      audioBase64: 'AAABAAIAAwAEAAUA',
+      encoding: 'pcm_s16le',
+      sampleRateHz: 16000,
+      channels: 1,
+      frameDurationMs: 100,
+      capturedAt: TIMESTAMP,
+    });
+    const result = parseClientEvent(raw);
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects audio.frame with wrong encoding', () => {
+    const raw = envelope('audio.frame', {
+      chunkId: 'chk_1',
+      audioBase64: 'AAA',
+      encoding: 'opus',
+      sampleRateHz: 16000,
+      channels: 1,
+      frameDurationMs: 100,
+      capturedAt: TIMESTAMP,
+    });
+    const result = parseClientEvent(raw);
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects audio.frame with wrong sampleRate', () => {
+    const raw = envelope('audio.frame', {
+      chunkId: 'chk_1',
+      audioBase64: 'AAA',
+      encoding: 'pcm_s16le',
+      sampleRateHz: 48000,
+      channels: 1,
+      frameDurationMs: 100,
+      capturedAt: TIMESTAMP,
+    });
+    expect(parseClientEvent(raw).isErr()).toBe(true);
+  });
+
+  it.each(['session.pause', 'session.resume', 'session.stop'] as const)(
+    'parses %s with optional reason',
+    (type) => {
+      const withReason = envelope(type, { reason: 'user-initiated' });
+      expect(parseClientEvent(withReason).isOk()).toBe(true);
+      const withoutReason = envelope(type, {});
+      expect(parseClientEvent(withoutReason).isOk()).toBe(true);
+    },
+  );
+
+  it('parses session.ping with empty payload', () => {
+    const raw = envelope('session.ping', {});
+    const result = parseClientEvent(raw);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value.eventType).toBe('session.ping');
+  });
+
+  it('rejects session.ping with non-empty payload (strict)', () => {
+    const raw = envelope('session.ping', { extra: 'unexpected' });
+    expect(parseClientEvent(raw).isErr()).toBe(true);
+  });
+
+  it('rejects unknown eventType', () => {
+    const raw = envelope('weather.update', { temp: 20 });
+    const result = parseClientEvent(raw);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+  });
+
+  it('rejects invalid JSON', () => {
+    const result = parseClientEvent('{ not json');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('client-event-invalid-json');
+    }
+  });
+
+  it('rejects envelope missing sessionId', () => {
+    const raw = JSON.stringify({
+      eventType: 'session.ping',
+      sequence: 1,
+      timestamp: TIMESTAMP,
+      payload: {},
+    });
+    expect(parseClientEvent(raw).isErr()).toBe(true);
+  });
+
+  it('rejects envelope with non-ISO timestamp', () => {
+    const raw = envelope('session.ping', {}, { timestamp: 'yesterday' });
+    expect(parseClientEvent(raw).isErr()).toBe(true);
+  });
+});

--- a/packages/relay-api/src/presentation/ws/client-events.ts
+++ b/packages/relay-api/src/presentation/ws/client-events.ts
@@ -1,0 +1,109 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+
+/**
+ * クライアント送信イベント (api-specification §6.2)。
+ *
+ * 全イベント共通の envelope:
+ * - eventType: 識別子
+ * - sessionId: セッション ID
+ * - sequence: クライアント単調増加 integer
+ * - timestamp: ISO 8601
+ * - payload: 型別ペイロード
+ *
+ * zod discriminated union で eventType を key にパースする。
+ */
+
+const envelopeBase = z.object({
+  sessionId: z.string().min(1),
+  sequence: z.number().int().nonnegative(),
+  timestamp: z.string().datetime(),
+});
+
+const sessionStartPayload = z.object({
+  sourceLanguage: z.string().nullable().optional(),
+  autoDetectLanguage: z.boolean(),
+  targetLanguage: z.string(),
+  translationEnabled: z.boolean(),
+});
+
+const audioFramePayload = z.object({
+  chunkId: z.string().min(1),
+  audioBase64: z.string().min(1),
+  encoding: z.literal('pcm_s16le'),
+  sampleRateHz: z.literal(16000),
+  channels: z.literal(1),
+  frameDurationMs: z.literal(100),
+  capturedAt: z.string().datetime(),
+});
+
+const reasonPayload = z.object({
+  reason: z.string().optional(),
+});
+
+const emptyPayload = z.object({}).strict();
+
+const clientEventSchema = z.discriminatedUnion('eventType', [
+  envelopeBase.extend({
+    eventType: z.literal('session.start'),
+    payload: sessionStartPayload,
+  }),
+  envelopeBase.extend({
+    eventType: z.literal('audio.frame'),
+    payload: audioFramePayload,
+  }),
+  envelopeBase.extend({
+    eventType: z.literal('session.pause'),
+    payload: reasonPayload,
+  }),
+  envelopeBase.extend({
+    eventType: z.literal('session.resume'),
+    payload: reasonPayload,
+  }),
+  envelopeBase.extend({
+    eventType: z.literal('session.stop'),
+    payload: reasonPayload,
+  }),
+  envelopeBase.extend({
+    eventType: z.literal('session.ping'),
+    payload: emptyPayload,
+  }),
+]);
+
+export type ClientEvent = z.infer<typeof clientEventSchema>;
+
+export type ClientEventType = ClientEvent['eventType'];
+
+/**
+ * 受信 raw (string / Buffer) を ClientEvent にパースする。
+ *
+ * 失敗時は `invariantViolationError` を返す:
+ * - `invariant: 'client-event-invalid-json'`: JSON parse 失敗
+ * - `invariant: 'client-event-validation'`: Zod 検証失敗
+ */
+export const parseClientEvent = (raw: string): Result<ClientEvent, DomainError> => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    return err(
+      invariantViolationError({
+        invariant: 'client-event-invalid-json',
+        details: cause instanceof Error ? cause.message : 'JSON parse error',
+      }),
+    );
+  }
+  const result = clientEventSchema.safeParse(parsed);
+  if (!result.success) {
+    return err(
+      invariantViolationError({
+        invariant: 'client-event-validation',
+        details: result.error.issues
+          .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+          .join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/relay-api/src/presentation/ws/relay-route.test.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.test.ts
@@ -69,18 +69,59 @@ const connectWithAuth = (url: string, token: string | null): WebSocket =>
     token === null ? undefined : { headers: { authorization: `Bearer ${token}` } },
   );
 
-const awaitFirstMessage = (ws: WebSocket): Promise<string> =>
+const decodeMessage = (data: WebSocket.RawData): string => {
+  if (Array.isArray(data)) return Buffer.concat(data).toString('utf8');
+  if (Buffer.isBuffer(data)) return data.toString('utf8');
+  return Buffer.from(data).toString('utf8');
+};
+
+const awaitOpen = (ws: WebSocket): Promise<void> =>
   new Promise((resolve, reject) => {
-    ws.once('message', (data) => {
-      const buf = Array.isArray(data)
-        ? Buffer.concat(data)
-        : Buffer.isBuffer(data)
-          ? data
-          : Buffer.from(data);
-      resolve(buf.toString('utf8'));
-    });
+    ws.once('open', () => resolve());
     ws.once('error', reject);
   });
+
+/**
+ * 入ってくる message を queue に蓄積し、pop 時に待機する helper。
+ * `once('message')` を送信後に attach すると race して message を落とすため、
+ * 接続直後に attach して以降すべて拾う。
+ */
+type MessageQueue = Readonly<{
+  next: (timeoutMs?: number) => Promise<unknown>;
+}>;
+
+const createMessageQueue = (ws: WebSocket): MessageQueue => {
+  const pending: unknown[] = [];
+  const waiters: ((value: unknown) => void)[] = [];
+  ws.on('message', (data) => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(decodeMessage(data));
+    } catch {
+      parsed = decodeMessage(data);
+    }
+    const waiter = waiters.shift();
+    if (waiter !== undefined) waiter(parsed);
+    else pending.push(parsed);
+  });
+  return {
+    next: (timeoutMs = 3000) =>
+      new Promise<unknown>((resolve, reject) => {
+        const buffered = pending.shift();
+        if (buffered !== undefined) {
+          resolve(buffered);
+          return;
+        }
+        const timer = setTimeout(() => {
+          reject(new Error(`timed out waiting for ws message (${timeoutMs}ms)`));
+        }, timeoutMs);
+        waiters.push((value) => {
+          clearTimeout(timer);
+          resolve(value);
+        });
+      }),
+  };
+};
 
 const awaitUnexpectedResponse = (ws: WebSocket): Promise<{ status: number }> =>
   new Promise((resolve, reject) => {
@@ -95,7 +136,7 @@ const awaitUnexpectedResponse = (ws: WebSocket): Promise<{ status: number }> =>
     });
   });
 
-describe('WebSocket /relay route (IMPL-420)', () => {
+describe('WebSocket /relay route', () => {
   let harness: AppHarness | null = null;
 
   beforeEach(() => {
@@ -106,66 +147,191 @@ describe('WebSocket /relay route (IMPL-420)', () => {
     if (harness !== null) await harness.app.close();
   });
 
-  it('sends session.ready event after a successful handshake', async () => {
-    harness = await startApp(okVerifier);
-    const ws = connectWithAuth(relayUrl(harness), 'valid.jwt.token');
-    try {
-      const raw = await awaitFirstMessage(ws);
-      const parsed: unknown = JSON.parse(raw);
-      expect(parsed).toMatchObject({
-        type: 'session.ready',
-        sessionId: SESSION_ID,
-        heartbeatIntervalSec: 15,
-      });
-    } finally {
-      ws.close();
-    }
+  describe('IMPL-420 handshake + session.ready', () => {
+    it('sends session.ready with spec §6.3 envelope + payload', async () => {
+      harness = await startApp(okVerifier);
+      const ws = connectWithAuth(relayUrl(harness), 'valid.jwt.token');
+      const queue = createMessageQueue(ws);
+      try {
+        const msg = await queue.next();
+        expect(msg).toMatchObject({
+          eventType: 'session.ready',
+          sessionId: SESSION_ID,
+          sequence: 0,
+          payload: {
+            state: 'capturing',
+            heartbeatIntervalSec: 15,
+            acceptedAudio: {
+              transport: 'json-base64',
+              sampleRateHz: 16000,
+              channels: 1,
+              frameDurationMs: 100,
+            },
+          },
+        });
+      } finally {
+        ws.close();
+      }
+    });
+
+    it('rejects the upgrade with 401 when Authorization is missing', async () => {
+      harness = await startApp(okVerifier);
+      const ws = connectWithAuth(relayUrl(harness), null);
+      try {
+        const { status } = await awaitUnexpectedResponse(ws);
+        expect(status).toBe(401);
+      } finally {
+        ws.close();
+      }
+    });
+
+    it('rejects the upgrade with 401 when the verifier fails', async () => {
+      harness = await startApp(failingVerifier);
+      const ws = connectWithAuth(relayUrl(harness), 'expired.jwt');
+      try {
+        const { status } = await awaitUnexpectedResponse(ws);
+        expect(status).toBe(401);
+      } finally {
+        ws.close();
+      }
+    });
+
+    it('rejects the upgrade with 401 when sessionId query mismatches sub', async () => {
+      harness = await startApp(okVerifier);
+      const ws = connectWithAuth(
+        relayUrl(harness, `sessionId=${OTHER_SESSION_ID}&protocolVersion=1.0`),
+        'valid.jwt',
+      );
+      try {
+        const { status } = await awaitUnexpectedResponse(ws);
+        expect(status).toBe(401);
+      } finally {
+        ws.close();
+      }
+    });
+
+    it('rejects the upgrade with 401 when protocolVersion is missing', async () => {
+      harness = await startApp(okVerifier);
+      const ws = connectWithAuth(relayUrl(harness, `sessionId=${SESSION_ID}`), 'valid.jwt');
+      try {
+        const { status } = await awaitUnexpectedResponse(ws);
+        expect(status).toBe(401);
+      } finally {
+        ws.close();
+      }
+    });
   });
 
-  it('rejects the upgrade with 401 when Authorization is missing', async () => {
-    harness = await startApp(okVerifier);
-    const ws = connectWithAuth(relayUrl(harness), null);
-    try {
-      const { status } = await awaitUnexpectedResponse(ws);
-      expect(status).toBe(401);
-    } finally {
-      ws.close();
-    }
-  });
+  describe('IMPL-421 client event dispatch', () => {
+    it('responds to session.ping with session.pong (monotonic sequence)', async () => {
+      harness = await startApp(okVerifier);
+      const ws = connectWithAuth(relayUrl(harness), 'valid.jwt');
+      const queue = createMessageQueue(ws);
+      try {
+        await awaitOpen(ws);
+        const ready = await queue.next();
+        expect(ready).toMatchObject({ sequence: 0 });
 
-  it('rejects the upgrade with 401 when the verifier fails', async () => {
-    harness = await startApp(failingVerifier);
-    const ws = connectWithAuth(relayUrl(harness), 'expired.jwt');
-    try {
-      const { status } = await awaitUnexpectedResponse(ws);
-      expect(status).toBe(401);
-    } finally {
-      ws.close();
-    }
-  });
+        ws.send(
+          JSON.stringify({
+            eventType: 'session.ping',
+            sessionId: SESSION_ID,
+            sequence: 1,
+            timestamp: new Date().toISOString(),
+            payload: {},
+          }),
+        );
+        const pong = await queue.next();
+        expect(pong).toMatchObject({
+          eventType: 'session.pong',
+          sessionId: SESSION_ID,
+          sequence: 1,
+          payload: {},
+        });
+      } finally {
+        ws.close();
+      }
+    });
 
-  it('rejects the upgrade with 401 when sessionId query mismatches sub', async () => {
-    harness = await startApp(okVerifier);
-    const ws = connectWithAuth(
-      relayUrl(harness, `sessionId=${OTHER_SESSION_ID}&protocolVersion=1.0`),
-      'valid.jwt',
-    );
-    try {
-      const { status } = await awaitUnexpectedResponse(ws);
-      expect(status).toBe(401);
-    } finally {
-      ws.close();
-    }
-  });
+    it('sends session.error when the payload is invalid JSON', async () => {
+      harness = await startApp(okVerifier);
+      const ws = connectWithAuth(relayUrl(harness), 'valid.jwt');
+      const queue = createMessageQueue(ws);
+      try {
+        await awaitOpen(ws);
+        await queue.next(); // consume session.ready
+        ws.send('{ not-json');
+        const err = await queue.next();
+        expect(err).toMatchObject({
+          eventType: 'session.error',
+          payload: { code: 'VALIDATION_ERROR', retryable: false, fatal: false },
+        });
+      } finally {
+        ws.close();
+      }
+    });
 
-  it('rejects the upgrade with 401 when protocolVersion is missing', async () => {
-    harness = await startApp(okVerifier);
-    const ws = connectWithAuth(relayUrl(harness, `sessionId=${SESSION_ID}`), 'valid.jwt');
-    try {
-      const { status } = await awaitUnexpectedResponse(ws);
-      expect(status).toBe(401);
-    } finally {
-      ws.close();
-    }
+    it('sends session.error for unknown eventType', async () => {
+      harness = await startApp(okVerifier);
+      const ws = connectWithAuth(relayUrl(harness), 'valid.jwt');
+      const queue = createMessageQueue(ws);
+      try {
+        await awaitOpen(ws);
+        await queue.next();
+        ws.send(
+          JSON.stringify({
+            eventType: 'weather.update',
+            sessionId: SESSION_ID,
+            sequence: 1,
+            timestamp: new Date().toISOString(),
+            payload: {},
+          }),
+        );
+        const err = await queue.next();
+        expect(err).toMatchObject({
+          eventType: 'session.error',
+          payload: { code: 'VALIDATION_ERROR' },
+        });
+      } finally {
+        ws.close();
+      }
+    });
+
+    it('silently accepts session.start followed by session.ping (only pong returned)', async () => {
+      harness = await startApp(okVerifier);
+      const ws = connectWithAuth(relayUrl(harness), 'valid.jwt');
+      const queue = createMessageQueue(ws);
+      try {
+        await awaitOpen(ws);
+        await queue.next();
+        ws.send(
+          JSON.stringify({
+            eventType: 'session.start',
+            sessionId: SESSION_ID,
+            sequence: 1,
+            timestamp: new Date().toISOString(),
+            payload: {
+              sourceLanguage: 'en-US',
+              autoDetectLanguage: false,
+              targetLanguage: 'ja-JP',
+              translationEnabled: true,
+            },
+          }),
+        );
+        ws.send(
+          JSON.stringify({
+            eventType: 'session.ping',
+            sessionId: SESSION_ID,
+            sequence: 2,
+            timestamp: new Date().toISOString(),
+            payload: {},
+          }),
+        );
+        const nextMessage = await queue.next();
+        expect(nextMessage).toMatchObject({ eventType: 'session.pong' });
+      } finally {
+        ws.close();
+      }
+    });
   });
 });

--- a/packages/relay-api/src/presentation/ws/relay-route.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.ts
@@ -1,10 +1,21 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
+import type { RawData, WebSocket } from 'ws';
 import { type JwtVerifier } from '../../application/ports/jwt-verifier';
 import { toHttpErrorEnvelope } from '../http/error-mapper';
+import { parseClientEvent, type ClientEvent } from './client-events';
+import {
+  buildSessionError,
+  buildSessionPong,
+  buildSessionReady,
+  serializeServerEvent,
+  type SessionErrorCode,
+} from './server-events';
 import { authorizeRelayUpgrade, type RelayAuthorizedContext } from './relay-auth';
 
 export type RelayRouteDependencies = Readonly<{
   jwtVerifier: JwtVerifier;
+  clock: () => string;
+  heartbeatIntervalSec: number;
 }>;
 
 type RelayQuery = Readonly<{
@@ -13,21 +24,107 @@ type RelayQuery = Readonly<{
 }>;
 
 /**
- * preValidation で確立した認可情報を handler へ渡す。request オブジェクトの
- * 拡張プロパティは型的に扱いづらく、WebSocket upgrade 経路で参照が変わる
- * リスクがあるため、WeakMap 経由で明示的に受け渡す。
+ * preValidation で確立した認可情報を handler へ渡す。request 拡張プロパティは
+ * WebSocket upgrade 経路で参照が不安定なため、WeakMap で明示的に受け渡す。
  */
 const contextMap = new WeakMap<FastifyRequest, RelayAuthorizedContext>();
 
+const decodeRawMessage = (data: RawData): string => {
+  if (Array.isArray(data)) return Buffer.concat(data).toString('utf8');
+  if (Buffer.isBuffer(data)) return data.toString('utf8');
+  return Buffer.from(data).toString('utf8');
+};
+
 /**
- * IMPL-420 `/relay` WebSocket 接続ルート。
+ * 接続ごとの server event `sequence` 採番器。
+ */
+const createSequencer = (): (() => number) => {
+  let next = 0;
+  return () => next++;
+};
+
+/**
+ * クライアントイベントを dispatch する。MVP では session.ping のみ応答を返し、
+ * それ以外は log に記録するだけ (IMPL-441/442 で mock STT/翻訳と連携する際に
+ * 実処理を接続する)。
+ */
+const dispatchClientEvent = (
+  event: ClientEvent,
+  send: (eventJson: string) => void,
+  deps: RelayRouteDependencies,
+  context: RelayAuthorizedContext,
+  nextSequence: () => number,
+  logger: FastifyRequest['log'],
+): void => {
+  switch (event.eventType) {
+    case 'session.ping': {
+      send(
+        serializeServerEvent(
+          buildSessionPong({
+            sessionId: context.sessionId,
+            sequence: nextSequence(),
+            timestamp: deps.clock(),
+          }),
+        ),
+      );
+      return;
+    }
+    case 'session.start':
+    case 'audio.frame':
+    case 'session.pause':
+    case 'session.resume':
+    case 'session.stop': {
+      logger.debug(
+        { eventType: event.eventType, sequence: event.sequence },
+        'client event received',
+      );
+      return;
+    }
+  }
+};
+
+const sendSessionError = (
+  socket: WebSocket,
+  context: RelayAuthorizedContext,
+  nextSequence: () => number,
+  clock: () => string,
+  params: {
+    code: SessionErrorCode;
+    message: string;
+    retryable: boolean;
+    fatal: boolean;
+  },
+): void => {
+  socket.send(
+    serializeServerEvent(
+      buildSessionError({
+        sessionId: context.sessionId,
+        sequence: nextSequence(),
+        timestamp: clock(),
+        code: params.code,
+        message: params.message,
+        retryable: params.retryable,
+        fatal: params.fatal,
+      }),
+    ),
+  );
+};
+
+/**
+ * IMPL-420 + IMPL-421 + IMPL-422 (部分) `/relay` WebSocket 接続ルート。
  *
- * api-specification §6.1:
- * - URL: `/relay?sessionId={sessionId}&protocolVersion=1.0`
- * - 認証: `Authorization: Bearer <stream_token>`
+ * 対応範囲:
+ * - upgrade 時認可 (JWT verify + sessionId ↔ sub 一致 + protocolVersion)
+ * - `session.ready` 送信 (api-specification §6.3 準拠)
+ * - client event 受信 + JSON / Zod validation
+ * - `session.ping` → `session.pong` 応答
+ * - 不正 payload は `session.error(VALIDATION_ERROR)` を返信 (接続は維持)
  *
- * 本 PR は upgrade 時の **認可チェック** と **session.ready** 送信のみ。
- * client/server event loop は IMPL-421 / 422、heartbeat は IMPL-423 で追加。
+ * 未対応 (後続):
+ * - `session.start` / `audio.frame` に対応する STT / 翻訳 dispatch (IMPL-441/442)
+ * - `pause` / `resume` / `stop` の session state 連携
+ * - `transcript.*` / `translation.final` サーバーイベント生成 (IMPL-441/442)
+ * - heartbeat (IMPL-423)
  */
 export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDependencies): void => {
   app.get<{ Querystring: RelayQuery }>(
@@ -51,14 +148,6 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
           return reply;
         }
         contextMap.set(request, result.value);
-        request.log.info(
-          {
-            sessionId: result.value.sessionId,
-            jti: result.value.tokenPayload.jti,
-            protocolVersion: result.value.protocolVersion,
-          },
-          'relay upgrade authorized',
-        );
       },
     },
     (socket, request) => {
@@ -68,16 +157,52 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
         return;
       }
       contextMap.delete(request);
+
+      const nextSequence = createSequencer();
       socket.send(
-        JSON.stringify({
-          type: 'session.ready',
-          sessionId: context.sessionId,
-          streamToken: context.tokenPayload.jti,
-          heartbeatIntervalSec: 15,
-        }),
+        serializeServerEvent(
+          buildSessionReady({
+            sessionId: context.sessionId,
+            sequence: nextSequence(),
+            timestamp: deps.clock(),
+            heartbeatIntervalSec: deps.heartbeatIntervalSec,
+          }),
+        ),
       );
-      // IMPL-421 / 422 / 423 で incoming message, server events, heartbeat を実装。
-      // 現時点では送信後に接続を保持するだけ (close せず idle 維持)。
+
+      socket.on('message', (raw: RawData) => {
+        const text = decodeRawMessage(raw);
+        const parsed = parseClientEvent(text);
+        if (parsed.isErr()) {
+          const detail =
+            parsed.error.kind === 'invariant-violation' ? parsed.error.details : 'invalid event';
+          sendSessionError(socket, context, nextSequence, deps.clock, {
+            code: 'VALIDATION_ERROR',
+            message: detail,
+            retryable: false,
+            fatal: false,
+          });
+          return;
+        }
+        try {
+          dispatchClientEvent(
+            parsed.value,
+            (json) => socket.send(json),
+            deps,
+            context,
+            nextSequence,
+            request.log,
+          );
+        } catch (cause) {
+          request.log.error({ err: cause }, 'dispatch failure');
+          sendSessionError(socket, context, nextSequence, deps.clock, {
+            code: 'INTERNAL_ERROR',
+            message: cause instanceof Error ? cause.message : 'unknown internal error',
+            retryable: false,
+            fatal: true,
+          });
+        }
+      });
     },
   );
 };

--- a/packages/relay-api/src/presentation/ws/server-events.test.ts
+++ b/packages/relay-api/src/presentation/ws/server-events.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSessionError,
+  buildSessionPong,
+  buildSessionReady,
+  serializeServerEvent,
+} from './server-events';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const TIMESTAMP = '2026-04-21T00:00:00.000Z';
+
+describe('server event builders', () => {
+  it('buildSessionReady includes state + heartbeatIntervalSec + acceptedAudio per spec §6.3', () => {
+    const event = buildSessionReady({
+      sessionId: SESSION_ID,
+      sequence: 0,
+      timestamp: TIMESTAMP,
+      heartbeatIntervalSec: 15,
+    });
+    expect(event).toEqual({
+      eventType: 'session.ready',
+      sessionId: SESSION_ID,
+      sequence: 0,
+      timestamp: TIMESTAMP,
+      payload: {
+        state: 'capturing',
+        heartbeatIntervalSec: 15,
+        acceptedAudio: {
+          transport: 'json-base64',
+          sampleRateHz: 16000,
+          channels: 1,
+          frameDurationMs: 100,
+        },
+      },
+    });
+  });
+
+  it('buildSessionPong has empty payload', () => {
+    const event = buildSessionPong({
+      sessionId: SESSION_ID,
+      sequence: 5,
+      timestamp: TIMESTAMP,
+    });
+    expect(event.eventType).toBe('session.pong');
+    expect(event.payload).toEqual({});
+  });
+
+  it('buildSessionError carries code / message / retryable / fatal', () => {
+    const event = buildSessionError({
+      sessionId: SESSION_ID,
+      sequence: 7,
+      timestamp: TIMESTAMP,
+      code: 'VALIDATION_ERROR',
+      message: 'bad payload',
+      retryable: false,
+      fatal: false,
+    });
+    expect(event.payload).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: 'bad payload',
+      retryable: false,
+      fatal: false,
+    });
+  });
+
+  it('serializeServerEvent produces parseable JSON', () => {
+    const event = buildSessionPong({
+      sessionId: SESSION_ID,
+      sequence: 1,
+      timestamp: TIMESTAMP,
+    });
+    const parsed: unknown = JSON.parse(serializeServerEvent(event));
+    expect(parsed).toEqual(event);
+  });
+});

--- a/packages/relay-api/src/presentation/ws/server-events.ts
+++ b/packages/relay-api/src/presentation/ws/server-events.ts
@@ -1,0 +1,105 @@
+/**
+ * サーバー送信イベント builder (api-specification §6.3)。
+ *
+ * 全イベント共通 envelope:
+ * - eventType: 識別子
+ * - sessionId: セッション ID
+ * - sequence: サーバー側の monotonically-increasing 番号 (connection 毎に採番)
+ * - timestamp: ISO 8601 (サーバー発行時刻)
+ * - payload: 型別
+ *
+ * 本 module は JSON 文字列化した wire format を builder 経由で生成する。
+ * sequence 管理は呼び出し側 (relay-route) で connection-scoped に行う。
+ */
+
+export type ServerEventEnvelope = Readonly<{
+  eventType: string;
+  sessionId: string;
+  sequence: number;
+  timestamp: string;
+  payload: Readonly<Record<string, unknown>>;
+}>;
+
+export type SessionReadyPayload = Readonly<{
+  state: 'capturing';
+  heartbeatIntervalSec: number;
+  acceptedAudio: Readonly<{
+    transport: 'json-base64';
+    sampleRateHz: 16000;
+    channels: 1;
+    frameDurationMs: 100;
+  }>;
+}>;
+
+export const buildSessionReady = (params: {
+  sessionId: string;
+  sequence: number;
+  timestamp: string;
+  heartbeatIntervalSec: number;
+}): ServerEventEnvelope => ({
+  eventType: 'session.ready',
+  sessionId: params.sessionId,
+  sequence: params.sequence,
+  timestamp: params.timestamp,
+  payload: {
+    state: 'capturing',
+    heartbeatIntervalSec: params.heartbeatIntervalSec,
+    acceptedAudio: {
+      transport: 'json-base64',
+      sampleRateHz: 16000,
+      channels: 1,
+      frameDurationMs: 100,
+    },
+  } satisfies SessionReadyPayload,
+});
+
+export const buildSessionPong = (params: {
+  sessionId: string;
+  sequence: number;
+  timestamp: string;
+}): ServerEventEnvelope => ({
+  eventType: 'session.pong',
+  sessionId: params.sessionId,
+  sequence: params.sequence,
+  timestamp: params.timestamp,
+  payload: {},
+});
+
+export type SessionErrorCode =
+  | 'VALIDATION_ERROR'
+  | 'INVALID_STATE_TRANSITION'
+  | 'SESSION_NOT_READY'
+  | 'RATE_LIMIT_EXCEEDED'
+  | 'INTERNAL_ERROR'
+  | 'STT_ERROR'
+  | 'TRANSLATION_ERROR';
+
+export type SessionErrorPayload = Readonly<{
+  code: SessionErrorCode;
+  message: string;
+  retryable: boolean;
+  fatal: boolean;
+}>;
+
+export const buildSessionError = (params: {
+  sessionId: string;
+  sequence: number;
+  timestamp: string;
+  code: SessionErrorCode;
+  message: string;
+  retryable: boolean;
+  fatal: boolean;
+}): ServerEventEnvelope => ({
+  eventType: 'session.error',
+  sessionId: params.sessionId,
+  sequence: params.sequence,
+  timestamp: params.timestamp,
+  payload: {
+    code: params.code,
+    message: params.message,
+    retryable: params.retryable,
+    fatal: params.fatal,
+  } satisfies SessionErrorPayload,
+});
+
+export const serializeServerEvent = (event: ServerEventEnvelope): string => JSON.stringify(event);


### PR DESCRIPTION
## Summary

Phase 4 §6.2 client events 受信の最初の一歩、および §6.3 server events の共通 envelope を spec 準拠化する。WebSocket 接続中の message 往復を確立。

## Client events (client-events.ts)

- zod discriminated union で 6 種の `eventType` (`session.start` / `audio.frame` / `session.pause` / `session.resume` / `session.stop` / `session.ping`) を envelope base + per-type payload にパース
- `audio.frame` は `encoding=pcm_s16le` / `sampleRateHz=16000` / `channels=1` / `frameDurationMs=100` を literal で固定 (api-spec §6.2 準拠)
- `session.ping` は `strict()` で余剰プロパティを拒否
- `parseClientEvent: string → Result<ClientEvent, DomainError>`
  - invalid JSON → `invariant-violation('client-event-invalid-json')`
  - Zod 失敗 → `invariant-violation('client-event-validation')` + issue 詳細

## Server event envelopes (server-events.ts)

- `ServerEventEnvelope`: `eventType` / `sessionId` / `sequence` / `timestamp` / `payload`
- `buildSessionReady`: payload に `state='capturing'` / `heartbeatIntervalSec` / `acceptedAudio` (api-spec §6.3 準拠)。**以前の独自 shape から spec 準拠へ修正**
- `buildSessionPong`: 空 payload (api-spec §6.3)
- `buildSessionError`: `code` / `message` / `retryable` / `fatal` (api-spec §6.4)
- `serializeServerEvent`: `JSON.stringify` の wrapper

## relay-route.ts

- connection-scoped sequence 採番器で server event に monotonic な番号付与
- `socket.on('message')` でクライアント event を受信 → `parseClientEvent` → `dispatchClientEvent`
- `session.ping` → `session.pong` 応答 (MVP で唯一の response-producing 処理)
- `session.start` / `audio.frame` / `session.pause` / `session.resume` / `session.stop` は現状 `log.debug` stub (IMPL-441/442 で STT/翻訳配線)
- parse 失敗は `session.error(VALIDATION_ERROR)` を返信 (接続は維持)
- dispatch 例外は `session.error(INTERNAL_ERROR, fatal=true)`

## server.ts

`RelayRouteDependencies` に `clock` / `heartbeatIntervalSec` を追加し、`buildApp` で production clock (`Date.now` ISO) と設定値 15 秒を注入。

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 113 relay-api tests + 593 extension tests)
- [x] `client-events.test.ts` (13 cases): 6 event type の正常系 / audio.frame の不正 encoding / ping strict / unknown eventType / 不正 JSON / envelope 欠落
- [x] `server-events.test.ts` (4 cases): session.ready / pong / error / serialize
- [x] `relay-route.test.ts` (9 cases, 実 WS 通信):
  - IMPL-420: session.ready 受信 (spec §6.3 shape) + 401 応答 4 種
  - IMPL-421: ping → pong / invalid JSON / unknown eventType / session.start → silent + ping で pong

## Out of scope (後続)

- IMPL-423 heartbeat 15 秒間隔 server-push
- IMPL-440/442 SttPort + MockSttProvider (audio.frame → transcript.* 生成)
- IMPL-441/443 TranslationPort + MockTranslationProvider (transcript.final → translation.final)
- IMPL-430 HTTP access token Bearer 検証 (POST /sessions の preHandler)