### PR TITLE
feat(relay-api): IMPL-423 heartbeat-based disconnect detection

### DIFF
--- a/packages/relay-api/src/presentation/ws/relay-route.test.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.test.ts
@@ -1,11 +1,13 @@
+import fastifyWebsocket from '@fastify/websocket';
 import { errAsync, okAsync } from 'neverthrow';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import WebSocket from 'ws';
-import { type FastifyInstance } from 'fastify';
+import Fastify, { type FastifyInstance } from 'fastify';
 import { type JwtVerifiedPayload, type JwtVerifier } from '../../application/ports/jwt-verifier';
 import { type IssueStreamTokenUseCase } from '../../application/use-cases/issue-stream-token-use-case';
 import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
 import { buildApp } from '../http/server';
+import { registerRelayRoute, type RelayRouteDependencies } from './relay-route';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const OTHER_SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7XX';
@@ -333,5 +335,79 @@ describe('WebSocket /relay route', () => {
         ws.close();
       }
     });
+  });
+
+  describe('IMPL-423 heartbeat', () => {
+    const startAppWithHeartbeat = async (
+      routeOverrides: Partial<RelayRouteDependencies> = {},
+    ): Promise<AppHarness> => {
+      const app = Fastify({ trustProxy: true });
+      void app.register(fastifyWebsocket);
+      void app.register((instance, _opts, done) => {
+        registerRelayRoute(instance, {
+          jwtVerifier: okVerifier,
+          clock: () => new Date().toISOString(),
+          heartbeatIntervalSec: 1,
+          heartbeatCheckIntervalMs: 50,
+          heartbeatTimeoutFactor: 2,
+          ...routeOverrides,
+        });
+        done();
+      });
+      await app.listen({ port: 0, host: '127.0.0.1' });
+      const address = app.server.address();
+      const port = typeof address === 'object' && address !== null ? address.port : 0;
+      return { app, port };
+    };
+
+    const awaitClose = (ws: WebSocket): Promise<{ code: number; reason: string }> =>
+      new Promise((resolve) => {
+        ws.once('close', (code: number, reason: Buffer) => {
+          resolve({ code, reason: reason.toString('utf8') });
+        });
+      });
+
+    it('closes the connection when the client stops sending for more than interval * factor', async () => {
+      harness = await startAppWithHeartbeat();
+      const ws = connectWithAuth(relayUrl(harness), 'valid.jwt');
+      const queue = createMessageQueue(ws);
+      await awaitOpen(ws);
+      await queue.next(); // consume session.ready
+
+      const closed = await awaitClose(ws);
+      expect(closed.code).toBe(1001);
+      expect(closed.reason).toBe('heartbeat timeout');
+    }, 8000);
+
+    it('does not close the connection while the client keeps pinging within the interval', async () => {
+      harness = await startAppWithHeartbeat();
+      const ws = connectWithAuth(relayUrl(harness), 'valid.jwt');
+      const queue = createMessageQueue(ws);
+      await awaitOpen(ws);
+      await queue.next(); // consume session.ready
+
+      let closed = false;
+      ws.once('close', () => {
+        closed = true;
+      });
+
+      // heartbeatIntervalSec=1 / factor=2 → timeout=2s. Ping at 500ms intervals
+      // for ~2.5s to prove the timer resets on each ping.
+      for (let i = 1; i <= 5; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        ws.send(
+          JSON.stringify({
+            eventType: 'session.ping',
+            sessionId: SESSION_ID,
+            sequence: i,
+            timestamp: new Date().toISOString(),
+            payload: {},
+          }),
+        );
+        await queue.next(); // consume session.pong
+      }
+      expect(closed).toBe(false);
+      ws.close();
+    }, 10000);
   });
 });

--- a/packages/relay-api/src/presentation/ws/relay-route.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.ts
@@ -15,8 +15,25 @@ import { authorizeRelayUpgrade, type RelayAuthorizedContext } from './relay-auth
 export type RelayRouteDependencies = Readonly<{
   jwtVerifier: JwtVerifier;
   clock: () => string;
+  /**
+   * クライアントに伝える `session.ready.payload.heartbeatIntervalSec`。
+   * クライアントはこの間隔で `session.ping` を送信する想定 (api-spec §6.2)。
+   */
   heartbeatIntervalSec: number;
+  /**
+   * サーバー側のハートビート監視スキャン間隔 (ミリ秒)。タイムアウト判定のため
+   * `setInterval` でポーリングする。既定 5 秒。
+   */
+  heartbeatCheckIntervalMs?: number;
+  /**
+   * `heartbeatIntervalSec` に対するタイムアウト倍率。既定 2 倍。
+   * 前回の受信からこの時間を超えたら接続を切断する (1001 Going Away)。
+   */
+  heartbeatTimeoutFactor?: number;
 }>;
+
+const DEFAULT_HEARTBEAT_CHECK_INTERVAL_MS = 5000;
+const DEFAULT_HEARTBEAT_TIMEOUT_FACTOR = 2;
 
 type RelayQuery = Readonly<{
   sessionId?: string;
@@ -170,7 +187,33 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
         ),
       );
 
+      // IMPL-423 ハートビート監視。前回の受信から
+      // heartbeatIntervalSec * heartbeatTimeoutFactor を超えたら切断。
+      const timeoutMs =
+        deps.heartbeatIntervalSec *
+        (deps.heartbeatTimeoutFactor ?? DEFAULT_HEARTBEAT_TIMEOUT_FACTOR) *
+        1000;
+      const checkIntervalMs = deps.heartbeatCheckIntervalMs ?? DEFAULT_HEARTBEAT_CHECK_INTERVAL_MS;
+      let lastActivityMs = Date.now();
+      const heartbeatTimer = setInterval(() => {
+        if (Date.now() - lastActivityMs > timeoutMs) {
+          request.log.info(
+            { sessionId: context.sessionId, lastActivityMs, timeoutMs },
+            'heartbeat timeout — closing connection',
+          );
+          socket.close(1001, 'heartbeat timeout');
+        }
+      }, checkIntervalMs);
+      heartbeatTimer.unref();
+
+      const cleanup = (): void => {
+        clearInterval(heartbeatTimer);
+      };
+      socket.on('close', cleanup);
+      socket.on('error', cleanup);
+
       socket.on('message', (raw: RawData) => {
+        lastActivityMs = Date.now();
         const text = decodeRawMessage(raw);
         const parsed = parseClientEvent(text);
         if (parsed.isErr()) {


### PR DESCRIPTION
## Summary

Phase 4 §6.3 ハートビート (`infrastructure.md` §4.3 "ハートビート間隔 15秒 / 切断検知")。クライアントからの `session.ping` 不達を検知して接続を切断する受動的な実装を追加。

## 方針

api-spec では client 側が `session.ping` を 15 秒間隔で送信することを示唆 (`session.ready` payload の `heartbeatIntervalSec` でクライアントに伝える)。サーバー側は単純に **最後の受信から一定時間経過したら切断** する受動的実装にする (サーバーから ping を push するのは過剰)。

## RelayRouteDependencies 追加

- `heartbeatCheckIntervalMs`: タイムアウト判定のポーリング間隔 (既定 5 秒)
- `heartbeatTimeoutFactor`: `heartbeatIntervalSec` に対するタイムアウト倍率 (既定 2 倍 → 30 秒で切断)

## relay-route.ts

- 接続直後に `setInterval` でタイムアウト監視を開始
- `socket.on('message')` で `lastActivityMs` を更新
- `now - lastActivityMs > heartbeatIntervalSec * factor * 1000` で `socket.close(1001, 'heartbeat timeout')`
- `close` / `error` で `clearInterval` + `timer.unref()` で graceful shutdown 促進

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 115 relay-api tests + 593 extension tests)
- [x] タイムアウト発火: `heartbeatIntervalSec=1` / `factor=2` で 2 秒無送信 → 1001 切断
- [x] 継続 ping で維持: 500ms 間隔で 5 回 ping / pong 往復しても切断しない

## Out of scope (後続)

- IMPL-440/442 `SttPort` + `MockSttProvider` (audio.frame → transcript.* 生成)
- IMPL-441/443 `TranslationPort` + `MockTranslationProvider` (transcript.final → translation.final)
- IMPL-430 HTTP access token Bearer 検証 (POST /sessions の preHandler)
- IMPL-432 `@fastify/rate-limit` 設定
- IMPL-433/434 CORS / Helmet