### PR TITLE
feat(relay-api): IMPL-430 HTTP access token Bearer 認証

### DIFF
--- a/packages/relay-api/src/application/ports/access-token-verifier.test.ts
+++ b/packages/relay-api/src/application/ports/access-token-verifier.test.ts
@@ -1,0 +1,22 @@
+import { err, ok } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { type AccessTokenVerifier } from './access-token-verifier';
+
+describe('AccessTokenVerifier port contract', () => {
+  it('can be implemented with ok/err Result', () => {
+    const verifier: AccessTokenVerifier = {
+      verify: (bearer) =>
+        bearer === 'secret'
+          ? ok<void, DomainError>(undefined)
+          : err<void, DomainError>(
+              invariantViolationError({
+                invariant: 'access-token-invalid',
+                details: 'mismatch',
+              }),
+            ),
+    };
+    expect(verifier.verify('secret').isOk()).toBe(true);
+    expect(verifier.verify('other').isErr()).toBe(true);
+  });
+});

--- a/packages/relay-api/src/application/ports/access-token-verifier.ts
+++ b/packages/relay-api/src/application/ports/access-token-verifier.ts
@@ -1,0 +1,20 @@
+import { type Result } from 'neverthrow';
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * HTTP Bearer アクセストークン検証ポート (IMPL-430)。
+ *
+ * api-specification §2.3 の「HTTP 制御 API は拡張利用者に紐づくアクセス
+ * トークン」に対応。拡張から送信される `Authorization: Bearer <token>` の
+ * トークン文字列を検証する。
+ *
+ * MVP では env 変数由来の静的シークレット比較 (StaticAccessTokenVerifier)。
+ * 将来的に IdP 連携が必要になれば port 実装を差し替える。
+ *
+ * **stream token との違い**:
+ * - access token: HTTP control API (POST /sessions / GET /sessions/:id) で検証
+ * - stream token: WebSocket /relay で JWT として検証 (JwtVerifier が担当)
+ */
+export type AccessTokenVerifier = Readonly<{
+  verify: (bearer: string) => Result<void, DomainError>;
+}>;

--- a/packages/relay-api/src/infrastructure/auth/static-access-token-verifier.test.ts
+++ b/packages/relay-api/src/infrastructure/auth/static-access-token-verifier.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { createStaticAccessTokenVerifier } from './static-access-token-verifier';
+
+const TOKEN_A = 'access-token-aaaaaaaaaaaaaaaaaaa';
+const TOKEN_B = 'access-token-bbbbbbbbbbbbbbbbbbb';
+
+describe('createStaticAccessTokenVerifier', () => {
+  it('throws synchronously when allowedTokens is empty', () => {
+    expect(() => createStaticAccessTokenVerifier({ allowedTokens: [] })).toThrow(
+      /must not be empty/,
+    );
+  });
+
+  it('throws synchronously when a token is shorter than 16 characters', () => {
+    expect(() => createStaticAccessTokenVerifier({ allowedTokens: ['short-token'] })).toThrow(
+      /at least 16 characters/,
+    );
+  });
+
+  it('accepts a matching token', () => {
+    const verifier = createStaticAccessTokenVerifier({ allowedTokens: [TOKEN_A] });
+    expect(verifier.verify(TOKEN_A).isOk()).toBe(true);
+  });
+
+  it('rejects a non-matching token', () => {
+    const verifier = createStaticAccessTokenVerifier({ allowedTokens: [TOKEN_A] });
+    const result = verifier.verify('definitely-wrong-token-xxxxxxxx');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+  });
+
+  it('accepts any of multiple allowed tokens (rotation support)', () => {
+    const verifier = createStaticAccessTokenVerifier({
+      allowedTokens: [TOKEN_A, TOKEN_B],
+    });
+    expect(verifier.verify(TOKEN_A).isOk()).toBe(true);
+    expect(verifier.verify(TOKEN_B).isOk()).toBe(true);
+  });
+
+  it('rejects empty string even if it would be a zero-length match', () => {
+    const verifier = createStaticAccessTokenVerifier({ allowedTokens: [TOKEN_A] });
+    const result = verifier.verify('');
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects tokens that differ only in length (prefix match attempt)', () => {
+    const verifier = createStaticAccessTokenVerifier({ allowedTokens: [TOKEN_A] });
+    const shorter = TOKEN_A.slice(0, -1);
+    const longer = TOKEN_A + 'x';
+    expect(verifier.verify(shorter).isErr()).toBe(true);
+    expect(verifier.verify(longer).isErr()).toBe(true);
+  });
+});

--- a/packages/relay-api/src/infrastructure/auth/static-access-token-verifier.ts
+++ b/packages/relay-api/src/infrastructure/auth/static-access-token-verifier.ts
@@ -1,0 +1,63 @@
+import { timingSafeEqual } from 'node:crypto';
+import { err, ok, type Result } from 'neverthrow';
+import { type AccessTokenVerifier } from '../../application/ports/access-token-verifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+
+/**
+ * `AccessTokenVerifier` の静的シークレット実装 (IMPL-430)。
+ *
+ * env 変数から配列で供給されたトークンと `timingSafeEqual` で比較する
+ * (タイミング攻撃対策)。Mock / in-memory とは異なり、**本番運用で直接利用
+ * される** production 実装。
+ *
+ * **allowedTokens の運用**:
+ * - MVP は 1 つのトークンで運用
+ * - 鍵ローテーション時は `[old, new]` の 2 本体制にして切替
+ * - 全数を `timingSafeEqual` で比較するため、N 個あると O(N) 時間
+ *
+ * **Fail-fast**:
+ * - `allowedTokens` が空 → factory で `throw`
+ * - 各トークンが 16 文字未満 → factory で `throw` (エントロピー不足防止)
+ */
+export type StaticAccessTokenVerifierDependencies = Readonly<{
+  allowedTokens: readonly string[];
+}>;
+
+const MIN_TOKEN_LENGTH = 16;
+
+const safeStringCompare = (a: string, b: string): boolean => {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+};
+
+export const createStaticAccessTokenVerifier = (
+  deps: StaticAccessTokenVerifierDependencies,
+): AccessTokenVerifier => {
+  if (deps.allowedTokens.length === 0) {
+    throw new Error('StaticAccessTokenVerifier: allowedTokens must not be empty');
+  }
+  for (const token of deps.allowedTokens) {
+    if (token.length < MIN_TOKEN_LENGTH) {
+      throw new Error(
+        `StaticAccessTokenVerifier: each token must be at least ${MIN_TOKEN_LENGTH} characters`,
+      );
+    }
+  }
+  const tokens = [...deps.allowedTokens];
+  return {
+    verify: (bearer: string): Result<void, DomainError> => {
+      const matched = tokens.some((allowed) => safeStringCompare(bearer, allowed));
+      if (!matched) {
+        return err(
+          invariantViolationError({
+            invariant: 'access-token-invalid',
+            details: 'access token does not match any allowed token',
+          }),
+        );
+      }
+      return ok(undefined);
+    },
+  };
+};

--- a/packages/relay-api/src/presentation/http/access-token-hook.ts
+++ b/packages/relay-api/src/presentation/http/access-token-hook.ts
@@ -1,0 +1,48 @@
+import type { FastifyReply, FastifyRequest, preHandlerAsyncHookHandler } from 'fastify';
+import { type AccessTokenVerifier } from '../../application/ports/access-token-verifier';
+
+/**
+ * IMPL-430 HTTP access token Bearer 検証 preHandler hook。
+ *
+ * api-specification §2.3 「HTTP 制御 API は拡張利用者に紐づくアクセストークン」
+ * に対応。POST /sessions / GET /sessions/:id など HTTP 制御 API に適用する。
+ *
+ * 検証フロー:
+ * 1. `Authorization` ヘッダが `Bearer ` で始まることを確認
+ * 2. トークンを切り出して `AccessTokenVerifier.verify` に渡す
+ * 3. 失敗時は 401 UNAUTHORIZED を送信して後続処理を停止
+ *
+ * 成功時は何もせず次の hook / handler へ (request 拡張プロパティは現時点では
+ * 付与しない。将来の audit 用に token hash 等を attach することは可能)。
+ */
+export const createBearerAuthPreHandler = (
+  verifier: AccessTokenVerifier,
+): preHandlerAsyncHookHandler => {
+  return async (request: FastifyRequest, reply: FastifyReply): Promise<FastifyReply | void> => {
+    const header = request.headers.authorization;
+    if (!header?.startsWith('Bearer ')) {
+      reply.code(401);
+      await reply.send({
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Authorization header with Bearer scheme is required',
+        },
+        meta: { requestId: request.id },
+      });
+      return reply;
+    }
+    const token = header.slice('Bearer '.length).trim();
+    const result = verifier.verify(token);
+    if (result.isErr()) {
+      reply.code(401);
+      await reply.send({
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'access token is invalid or expired',
+        },
+        meta: { requestId: request.id },
+      });
+      return reply;
+    }
+  };
+};

--- a/packages/relay-api/src/presentation/http/routes/sessions.test.ts
+++ b/packages/relay-api/src/presentation/http/routes/sessions.test.ts
@@ -1,5 +1,6 @@
-import { errAsync, okAsync } from 'neverthrow';
+import { err, errAsync, ok, okAsync } from 'neverthrow';
 import { describe, expect, it, vi } from 'vitest';
+import { type AccessTokenVerifier } from '../../../application/ports/access-token-verifier';
 import { type JwtVerifier } from '../../../application/ports/jwt-verifier';
 import { type IssueStreamTokenOutput } from '../../../application/dto/issue-stream-token-dto';
 import { type IssueStreamTokenUseCase } from '../../../application/use-cases/issue-stream-token-use-case';
@@ -9,6 +10,8 @@ import {
   type DomainError,
 } from '../../../domain/shared/errors';
 import { buildApp } from '../server';
+
+const VALID_ACCESS_TOKEN = 'access-token-test-fixture-aaaa';
 
 const noopVerifier: JwtVerifier = {
   verify: () =>
@@ -21,8 +24,26 @@ const noopVerifier: JwtVerifier = {
     }),
 };
 
+const buildAccessTokenVerifier = (expected = VALID_ACCESS_TOKEN): AccessTokenVerifier => ({
+  verify: (bearer) =>
+    bearer === expected
+      ? ok<void, DomainError>(undefined)
+      : err<void, DomainError>(
+          invariantViolationError({
+            invariant: 'access-token-invalid',
+            details: 'mismatch',
+          }),
+        ),
+});
+
 const buildTestApp = (issueStreamTokenUseCase: IssueStreamTokenUseCase) =>
-  buildApp({ issueStreamTokenUseCase, jwtVerifier: noopVerifier });
+  buildApp({
+    issueStreamTokenUseCase,
+    jwtVerifier: noopVerifier,
+    accessTokenVerifier: buildAccessTokenVerifier(),
+  });
+
+const authHeaders = (token = VALID_ACCESS_TOKEN) => ({ authorization: `Bearer ${token}` });
 
 const successOutput: IssueStreamTokenOutput = {
   sessionId: '01HZX8Y1R8M7D3Q2P4T5V6W7A1',
@@ -63,6 +84,7 @@ describe('POST /sessions route (IMPL-411, stateless)', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/sessions',
+        headers: authHeaders(),
         payload: validBody,
       });
       expect(response.statusCode).toBe(201);
@@ -84,6 +106,7 @@ describe('POST /sessions route (IMPL-411, stateless)', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/sessions',
+        headers: authHeaders(),
         payload: validBody,
       });
       const parsed: unknown = response.json();
@@ -112,6 +135,7 @@ describe('POST /sessions route (IMPL-411, stateless)', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/sessions',
+        headers: authHeaders(),
         payload: { ...validBody, displayName: '' },
       });
       expect(response.statusCode).toBe(400);
@@ -132,11 +156,72 @@ describe('POST /sessions route (IMPL-411, stateless)', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/sessions',
+        headers: authHeaders(),
         payload: validBody,
       });
       expect(response.statusCode).toBe(400);
       const parsed: unknown = response.json();
       expect(parsed).toMatchObject({ error: { code: 'INVARIANT_VIOLATION' } });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns 401 UNAUTHORIZED when Authorization is missing (IMPL-430)', async () => {
+    const useCase = vi.fn<IssueStreamTokenUseCase>(() =>
+      okAsync<IssueStreamTokenOutput, DomainError>(successOutput),
+    );
+    const app = buildTestApp(useCase);
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/sessions',
+        payload: validBody,
+      });
+      expect(response.statusCode).toBe(401);
+      const parsed: unknown = response.json();
+      expect(parsed).toMatchObject({ error: { code: 'UNAUTHORIZED' } });
+      expect(useCase).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns 401 UNAUTHORIZED when access token is invalid (IMPL-430)', async () => {
+    const useCase = vi.fn<IssueStreamTokenUseCase>(() =>
+      okAsync<IssueStreamTokenOutput, DomainError>(successOutput),
+    );
+    const app = buildTestApp(useCase);
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/sessions',
+        headers: authHeaders('wrong-token-xxxxxxxxxxxxxxxxx'),
+        payload: validBody,
+      });
+      expect(response.statusCode).toBe(401);
+      const parsed: unknown = response.json();
+      expect(parsed).toMatchObject({ error: { code: 'UNAUTHORIZED' } });
+      expect(useCase).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns 401 UNAUTHORIZED when Authorization scheme is not Bearer', async () => {
+    const useCase = vi.fn<IssueStreamTokenUseCase>(() =>
+      okAsync<IssueStreamTokenOutput, DomainError>(successOutput),
+    );
+    const app = buildTestApp(useCase);
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/sessions',
+        headers: { authorization: `Basic ${VALID_ACCESS_TOKEN}` },
+        payload: validBody,
+      });
+      expect(response.statusCode).toBe(401);
+      expect(useCase).not.toHaveBeenCalled();
     } finally {
       await app.close();
     }

--- a/packages/relay-api/src/presentation/http/routes/sessions.ts
+++ b/packages/relay-api/src/presentation/http/routes/sessions.ts
@@ -1,38 +1,45 @@
 import type { FastifyInstance } from 'fastify';
+import { type AccessTokenVerifier } from '../../../application/ports/access-token-verifier';
 import { type IssueStreamTokenUseCase } from '../../../application/use-cases/issue-stream-token-use-case';
+import { createBearerAuthPreHandler } from '../access-token-hook';
 import { toHttpErrorEnvelope } from '../error-mapper';
 
 export type SessionsRouteDependencies = Readonly<{
   issueStreamTokenUseCase: IssueStreamTokenUseCase;
+  accessTokenVerifier: AccessTokenVerifier;
 }>;
 
 /**
- * IMPL-411 POST /sessions HTTP route。
+ * IMPL-411 POST /sessions HTTP route + IMPL-430 access token Bearer 認証。
  *
- * api-specification §4.2 に従い:
+ * api-specification §4.2:
  * - 入力: `IssueStreamTokenInput` (UseCase 側で Zod 検証)
  * - 成功: 201 Created + `{ data, meta: { requestId } }`
  * - 失敗: DomainError を `toHttpErrorEnvelope` で HTTP ステータスへマッピング
  *
- * 認証 (IMPL-430: アクセストークン Bearer 検証) は後続 PR で preHandler hook
- * として追加する。本 route では stateless JWT 発行の shape のみ確立する。
+ * preHandler で `Authorization: Bearer <access_token>` を `AccessTokenVerifier`
+ * (env 由来の静的シークレット) で検証。失敗時は 401 で停止。
  */
 export const registerSessionsRoute = (
   app: FastifyInstance,
   deps: SessionsRouteDependencies,
 ): void => {
-  app.post('/sessions', async (request, reply) => {
-    const result = await deps.issueStreamTokenUseCase(request.body);
-    return result.match(
-      (output) => {
-        reply.code(201);
-        return { data: output, meta: { requestId: request.id } };
-      },
-      (error) => {
-        const envelope = toHttpErrorEnvelope(error);
-        reply.code(envelope.status);
-        return { ...envelope.body, meta: { requestId: request.id } };
-      },
-    );
-  });
+  app.post(
+    '/sessions',
+    { preHandler: createBearerAuthPreHandler(deps.accessTokenVerifier) },
+    async (request, reply) => {
+      const result = await deps.issueStreamTokenUseCase(request.body);
+      return result.match(
+        (output) => {
+          reply.code(201);
+          return { data: output, meta: { requestId: request.id } };
+        },
+        (error) => {
+          const envelope = toHttpErrorEnvelope(error);
+          reply.code(envelope.status);
+          return { ...envelope.body, meta: { requestId: request.id } };
+        },
+      );
+    },
+  );
 };

--- a/packages/relay-api/src/presentation/http/server.ts
+++ b/packages/relay-api/src/presentation/http/server.ts
@@ -1,6 +1,7 @@
 import fastifyWebsocket from '@fastify/websocket';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { ulid } from 'ulid';
+import { type AccessTokenVerifier } from '../../application/ports/access-token-verifier';
 import { type JwtVerifier } from '../../application/ports/jwt-verifier';
 import {
   createIssueStreamTokenUseCase,
@@ -8,6 +9,7 @@ import {
 } from '../../application/use-cases/issue-stream-token-use-case';
 import { createJoseJwtSigner } from '../../infrastructure/auth/jose-jwt-signer';
 import { createJoseJwtVerifier } from '../../infrastructure/auth/jose-jwt-verifier';
+import { createStaticAccessTokenVerifier } from '../../infrastructure/auth/static-access-token-verifier';
 import { loggerOptions } from '../../infrastructure/logging/logger';
 import { registerRelayRoute } from '../ws/relay-route';
 import { registerHealthRoute } from './routes/health';
@@ -16,6 +18,7 @@ import { registerSessionsRoute } from './routes/sessions';
 export type AppDependencies = Readonly<{
   issueStreamTokenUseCase: IssueStreamTokenUseCase;
   jwtVerifier: JwtVerifier;
+  accessTokenVerifier: AccessTokenVerifier;
 }>;
 
 export function buildApp(deps: AppDependencies): FastifyInstance {
@@ -32,7 +35,10 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
   void app.register(fastifyWebsocket);
 
   registerHealthRoute(app);
-  registerSessionsRoute(app, { issueStreamTokenUseCase: deps.issueStreamTokenUseCase });
+  registerSessionsRoute(app, {
+    issueStreamTokenUseCase: deps.issueStreamTokenUseCase,
+    accessTokenVerifier: deps.accessTokenVerifier,
+  });
   void app.register((instance, _opts, done) => {
     registerRelayRoute(instance, {
       jwtVerifier: deps.jwtVerifier,
@@ -59,6 +65,8 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
  * - STREAM_TOKEN_AUDIENCE: JWT aud (例: perapera-extension)
  * - RELAY_PUBLIC_URL: クライアントに返す WebSocket URL (wss://...)
  * - STREAM_TOKEN_TTL_SEC: 短命トークンの TTL 秒数 (既定 1800 = 30 分)
+ * - ACCESS_TOKENS: HTTP control API の Bearer トークン (カンマ区切り。
+ *   鍵ローテーション時は複数指定可)。各要素は 16 文字以上
  */
 const buildProductionDependencies = (): AppDependencies => {
   const secret = process.env['STREAM_TOKEN_SECRET'];
@@ -74,6 +82,17 @@ const buildProductionDependencies = (): AppDependencies => {
   const jwtSigner = createJoseJwtSigner({ secretKey, issuer, audience });
   const jwtVerifier = createJoseJwtVerifier({ secretKey, issuer, audience });
 
+  const rawAccessTokens = process.env['ACCESS_TOKENS'];
+  if (rawAccessTokens === undefined || rawAccessTokens.trim().length === 0) {
+    throw new Error('ACCESS_TOKENS env var is required (comma-separated, each >= 16 chars)');
+  }
+  const accessTokenVerifier = createStaticAccessTokenVerifier({
+    allowedTokens: rawAccessTokens
+      .split(',')
+      .map((token) => token.trim())
+      .filter((token) => token.length > 0),
+  });
+
   const issueStreamTokenUseCase = createIssueStreamTokenUseCase({
     jwtSigner,
     clock: () => new Date().toISOString(),
@@ -86,7 +105,7 @@ const buildProductionDependencies = (): AppDependencies => {
     maxFrameRatePerSecond: 10,
   });
 
-  return { issueStreamTokenUseCase, jwtVerifier };
+  return { issueStreamTokenUseCase, jwtVerifier, accessTokenVerifier };
 };
 
 async function start(): Promise<void> {

--- a/packages/relay-api/src/presentation/ws/relay-route.test.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.test.ts
@@ -1,8 +1,9 @@
 import fastifyWebsocket from '@fastify/websocket';
-import { errAsync, okAsync } from 'neverthrow';
+import { errAsync, ok, okAsync } from 'neverthrow';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import WebSocket from 'ws';
 import Fastify, { type FastifyInstance } from 'fastify';
+import { type AccessTokenVerifier } from '../../application/ports/access-token-verifier';
 import { type JwtVerifiedPayload, type JwtVerifier } from '../../application/ports/jwt-verifier';
 import { type IssueStreamTokenUseCase } from '../../application/use-cases/issue-stream-token-use-case';
 import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
@@ -52,8 +53,16 @@ type AppHarness = Readonly<{
   port: number;
 }>;
 
+const noopAccessTokenVerifier: AccessTokenVerifier = {
+  verify: () => ok(undefined),
+};
+
 const startApp = async (verifier: JwtVerifier): Promise<AppHarness> => {
-  const app = buildApp({ issueStreamTokenUseCase: noopUseCase, jwtVerifier: verifier });
+  const app = buildApp({
+    issueStreamTokenUseCase: noopUseCase,
+    jwtVerifier: verifier,
+    accessTokenVerifier: noopAccessTokenVerifier,
+  });
   await app.listen({ port: 0, host: '127.0.0.1' });
   const address = app.server.address();
   const port = typeof address === 'object' && address !== null ? address.port : 0;

--- a/packages/relay-api/tests/smoke.test.ts
+++ b/packages/relay-api/tests/smoke.test.ts
@@ -1,5 +1,6 @@
-import { okAsync } from 'neverthrow';
+import { ok, okAsync } from 'neverthrow';
 import { afterAll, describe, expect, it } from 'vitest';
+import { type AccessTokenVerifier } from '../src/application/ports/access-token-verifier';
 import { type JwtVerifier } from '../src/application/ports/jwt-verifier';
 import { type IssueStreamTokenUseCase } from '../src/application/use-cases/issue-stream-token-use-case';
 import { buildApp } from '../src/presentation/http/server';
@@ -32,7 +33,15 @@ const noopVerifier: JwtVerifier = {
     }),
 };
 
-const app = buildApp({ issueStreamTokenUseCase: noopUseCase, jwtVerifier: noopVerifier });
+const noopAccessTokenVerifier: AccessTokenVerifier = {
+  verify: () => ok(undefined),
+};
+
+const app = buildApp({
+  issueStreamTokenUseCase: noopUseCase,
+  jwtVerifier: noopVerifier,
+  accessTokenVerifier: noopAccessTokenVerifier,
+});
 
 afterAll(async () => {
   await app.close();


### PR DESCRIPTION
## Summary

Phase 4 §6.4 の最初の一歩。`POST /sessions` (および将来の `GET /sessions/:id`) に Bearer access token 認証を追加する。**Mock / in-memory には依存せず、env 変数由来の静的シークレットを `timingSafeEqual` で比較する本番利用前提の実装**。

## AccessTokenVerifier port (application/ports/)

- `verify(bearer: string): Result<void, DomainError>`
- HTTP control API 側の認証専用。stream token (WebSocket JWT) とは別経路

## StaticAccessTokenVerifier (infrastructure/auth/)

- `allowedTokens` 配列に対して `crypto.timingSafeEqual` でタイミング攻撃耐性のある比較
- 複数トークン対応 (鍵ローテーション運用)
- **Fail-fast**: 空配列 / 16 文字未満のトークンは factory で `throw`
- 長さ違いは早期 `false` (`timingSafeEqual` は同一長要件)
- **Mock / in-memory ではない本番実装**

## Bearer auth preHandler (presentation/http/access-token-hook.ts)

- `Authorization` ヘッダの Bearer scheme チェック
- `AccessTokenVerifier.verify` を呼び、失敗時は **401 UNAUTHORIZED** を返信 (`error-mapper` で定義された envelope 形式に合わせる: `error.code` + `meta`)

## POST /sessions route

- `SessionsRouteDependencies` に `accessTokenVerifier` を追加 (必須 DI)
- preHandler に `createBearerAuthPreHandler` を配線

## server.ts

- `AppDependencies` に `accessTokenVerifier` を追加 (必須)
- `buildProductionDependencies` は `ACCESS_TOKENS` env 変数 (カンマ区切り) を読み、空または未設定は `throw` (fail-fast で mock fallback を排除)

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 126 relay-api tests + 593 extension tests)
- [x] `access-token-verifier.test.ts` (1 case): port contract
- [x] `static-access-token-verifier.test.ts` (7 cases): 空配列 / 短鍵 throw / 一致 / 不一致 / 複数トークン / 空文字列 / 長さ違い
- [x] `sessions.test.ts` 更新: 既存全テストに Authorization ヘッダ追加、401 応答 3 種 (missing / invalid / non-Bearer scheme) 追加

## Out of scope (後続)

- IMPL-432 `@fastify/rate-limit` 設定 (POST /sessions 30/分、audio.frame 10/秒)
- IMPL-433 `@fastify/cors` (拡張 origin 限定)
- IMPL-434 `@fastify/helmet`
- IMPL-440/442 SttPort + MockSttProvider (CI/dev 用)
- IMPL-441/443 TranslationPort + MockTranslationProvider (CI/dev 用)
- IMPL-450 pino redact 検証テスト (access token も redact 対象)