### PR TITLE
feat(relay-api): IMPL-450/451 logging hygiene — redact contract + sessionId binding

### DIFF
--- a/packages/relay-api/src/infrastructure/logging/logger.test.ts
+++ b/packages/relay-api/src/infrastructure/logging/logger.test.ts
@@ -1,0 +1,155 @@
+import pino from 'pino';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import { loggerOptions } from './logger';
+
+/**
+ * IMPL-450 redact 契約検証。
+ *
+ * pino は `redact` で指定されたパスを censor 文字列に置換する。本テストは
+ * `loggerOptions` を実際に pino インスタンスへ注入し、JSON 出力を captureして
+ * 各 path が `[REDACTED]` になっていること / 字幕本文が平文で残らないこと
+ * を確認する。
+ */
+
+const captureLogLine = (fn: (logger: pino.Logger) => void): unknown => {
+  const stream = new PassThrough();
+  const chunks: Buffer[] = [];
+  stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+  // development transport は別スレッドで動くため、test ではそれを除外して
+  // stream に直接書かせる
+  const { transport: _ignoreTransport, ...restOptions } = loggerOptions;
+  const logger = pino(restOptions, stream);
+  fn(logger);
+  logger.flush();
+  const raw = Buffer.concat(chunks).toString('utf8').trim();
+  const lines = raw.length === 0 ? [] : raw.split('\n').filter((line) => line.length > 0);
+  const last = lines.at(-1);
+  if (last === undefined) return {};
+  return JSON.parse(last);
+};
+
+describe('loggerOptions redact contract (IMPL-450)', () => {
+  it('redacts Authorization header at req.headers.authorization', () => {
+    const line = captureLogLine((logger) => {
+      logger.info({ req: { headers: { authorization: 'Bearer super-secret-token' } } }, 'request');
+    });
+    expect(line).toMatchObject({ req: { headers: { authorization: '[REDACTED]' } } });
+  });
+
+  it('redacts x-api-key header', () => {
+    const line = captureLogLine((logger) => {
+      logger.info({ req: { headers: { 'x-api-key': 'abcd1234' } } }, 'request');
+    });
+    expect(line).toMatchObject({ req: { headers: { 'x-api-key': '[REDACTED]' } } });
+  });
+
+  it('redacts Deepgram and DeepL specific auth headers', () => {
+    const line = captureLogLine((logger) => {
+      logger.info(
+        {
+          req: {
+            headers: {
+              'x-deepgram-authorization': 'Token dg-secret',
+              'x-deepl-auth': 'DeepL-Auth-Key deepl-secret',
+            },
+          },
+        },
+        'request',
+      );
+    });
+    expect(line).toMatchObject({
+      req: {
+        headers: {
+          'x-deepgram-authorization': '[REDACTED]',
+          'x-deepl-auth': '[REDACTED]',
+        },
+      },
+    });
+  });
+
+  it('redacts apiKey / streamToken / accessToken / refreshToken / password under any object', () => {
+    const line = captureLogLine((logger) => {
+      logger.info(
+        {
+          context: {
+            apiKey: 'secret-api',
+            streamToken: 'jwt.a.b.c',
+            accessToken: 'access-secret',
+            refreshToken: 'refresh-secret',
+            password: 'raw-password',
+          },
+        },
+        'credentials',
+      );
+    });
+    expect(line).toMatchObject({
+      context: {
+        apiKey: '[REDACTED]',
+        streamToken: '[REDACTED]',
+        accessToken: '[REDACTED]',
+        refreshToken: '[REDACTED]',
+        password: '[REDACTED]',
+      },
+    });
+  });
+
+  it('redacts transcript text at payload.text (privacy)', () => {
+    const line = captureLogLine((logger) => {
+      logger.info(
+        { payload: { text: 'hello world — sensitive transcript content' } },
+        'transcript',
+      );
+    });
+    expect(line).toMatchObject({ payload: { text: '[REDACTED]' } });
+  });
+
+  it('redacts audio frame binary at payload.audioBase64 (privacy + size)', () => {
+    const line = captureLogLine((logger) => {
+      logger.info({ payload: { audioBase64: 'AAAA='.repeat(1000) } }, 'audio.frame');
+    });
+    expect(line).toMatchObject({ payload: { audioBase64: '[REDACTED]' } });
+  });
+
+  it('redacts event.payload.text and event.payload.audioBase64 (wrapped envelope)', () => {
+    const line = captureLogLine((logger) => {
+      logger.info(
+        {
+          event: {
+            payload: {
+              text: 'should not leak',
+              audioBase64: 'AAAA=',
+            },
+          },
+        },
+        'dispatching',
+      );
+    });
+    expect(line).toMatchObject({
+      event: {
+        payload: {
+          text: '[REDACTED]',
+          audioBase64: '[REDACTED]',
+        },
+      },
+    });
+  });
+
+  it('keeps non-sensitive fields visible (sessionId / requestId remain)', () => {
+    const line = captureLogLine((logger) => {
+      logger.info(
+        {
+          sessionId: 'sess_01ABC',
+          requestId: 'req_01DEF',
+          payload: { chunkId: 'chk_000001' },
+        },
+        'routine log',
+      );
+    });
+    expect(line).toMatchObject({
+      sessionId: 'sess_01ABC',
+      requestId: 'req_01DEF',
+      payload: { chunkId: 'chk_000001' },
+    });
+  });
+});

--- a/packages/relay-api/src/infrastructure/logging/logger.ts
+++ b/packages/relay-api/src/infrastructure/logging/logger.ts
@@ -2,18 +2,43 @@ import type { LoggerOptions } from 'pino';
 
 const isDevelopment = process.env['NODE_ENV'] !== 'production';
 
+/**
+ * pino redact 対象パス (IMPL-450)。
+ *
+ * 機密性の観点:
+ * - 認証 token / API key: production で payload に入った場合を想定し広くカバー
+ * - 字幕本文 (`payload.text` / `payload.audioBase64`): プライバシー保護のため
+ *   content を残さず、存在の事実のみログに出す
+ * - Deepgram / DeepL 固有ヘッダ: provider adapter 内でリクエスト情報を log に
+ *   出した際の漏洩を防ぐ
+ *
+ * pino redact 構文:
+ * - `a.b.c`: path 一致
+ * - `*.foo`: 任意 1 階層下の `foo`
+ * - `*.*.foo`: 任意 2 階層下の `foo`
+ * - `a[*].b`: 配列要素
+ */
 const redactPaths = [
   'req.headers.authorization',
   'req.headers.cookie',
   'req.headers["x-api-key"]',
+  'req.headers["x-deepgram-authorization"]',
+  'req.headers["x-deepl-auth"]',
   'res.headers["set-cookie"]',
   '*.apiKey',
   '*.streamToken',
   '*.accessToken',
   '*.refreshToken',
   '*.password',
+  '*.authorization',
+  '*.audioBase64',
   'payload.audioBase64',
   'payload.text',
+  'payload.*.text',
+  'event.payload.text',
+  'event.payload.audioBase64',
+  'body.payload.audioBase64',
+  'body.payload.text',
 ];
 
 const developmentTransport = {

--- a/packages/relay-api/src/presentation/http/request-context-hook.test.ts
+++ b/packages/relay-api/src/presentation/http/request-context-hook.test.ts
@@ -1,0 +1,74 @@
+import Fastify from 'fastify';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import { registerRequestContextHook } from './request-context-hook';
+
+const collectOutput = (stream: PassThrough): (() => string) => {
+  const chunks: Buffer[] = [];
+  stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+  return () => Buffer.concat(chunks).toString('utf8');
+};
+
+const parseProbeLines = (output: string): unknown[] =>
+  output
+    .split('\n')
+    .filter((line) => line.includes('"msg":"probed"'))
+    .map((line): unknown => JSON.parse(line));
+
+const buildAppWithHook = () => {
+  const stream = new PassThrough();
+  const read = collectOutput(stream);
+  const app = Fastify({ logger: { level: 'info', stream } });
+  registerRequestContextHook(app);
+  app.get('/probe', (request, _reply) => {
+    request.log.info('probed');
+    return { ok: true };
+  });
+  return { app, read };
+};
+
+const waitForLog = (): Promise<void> => new Promise((resolve) => setImmediate(() => resolve()));
+
+describe('registerRequestContextHook (IMPL-451)', () => {
+  it('adds sessionId to request.log when query contains sessionId', async () => {
+    const { app, read } = buildAppWithHook();
+    try {
+      await app.inject({ method: 'GET', url: '/probe?sessionId=sess_TEST_01' });
+      await waitForLog();
+      const probeLines = parseProbeLines(read());
+      expect(probeLines.length).toBeGreaterThan(0);
+      expect(probeLines[0]).toMatchObject({ sessionId: 'sess_TEST_01' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('does not add sessionId to request.log when query has no sessionId', async () => {
+    const { app, read } = buildAppWithHook();
+    try {
+      await app.inject({ method: 'GET', url: '/probe' });
+      await waitForLog();
+      const probeLines = parseProbeLines(read());
+      expect(probeLines.length).toBeGreaterThan(0);
+      const first = probeLines[0];
+      const hasSessionId = typeof first === 'object' && first !== null && 'sessionId' in first;
+      expect(hasSessionId).toBe(false);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('falls back cleanly when sessionId query is empty string', async () => {
+    const { app, read } = buildAppWithHook();
+    try {
+      await app.inject({ method: 'GET', url: '/probe?sessionId=' });
+      await waitForLog();
+      const probeLines = parseProbeLines(read());
+      const first = probeLines[0];
+      const hasSessionId = typeof first === 'object' && first !== null && 'sessionId' in first;
+      expect(hasSessionId).toBe(false);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/relay-api/src/presentation/http/request-context-hook.ts
+++ b/packages/relay-api/src/presentation/http/request-context-hook.ts
@@ -1,0 +1,34 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+
+/**
+ * IMPL-451 structured logging 補強。
+ *
+ * onRequest hook で URL クエリの `sessionId` を抽出し、`request.log` を
+ * child logger に置き換える。以降の全 log line に `sessionId` が bind される
+ * (system-design §9.3 "構造化ログには sessionId / requestId を必ず含める")。
+ *
+ * `requestId` は Fastify が `genReqId` で発番したものを自動付与する。
+ * `sessionId` は URL から抽出できる場合のみ bind (POST /sessions 初回は
+ * session 未確立なので bind しない)。
+ *
+ * WebSocket 経路も Fastify 標準の HTTP upgrade を経由するため、同じ hook で
+ * query.sessionId を拾える。
+ */
+
+const extractSessionId = (request: FastifyRequest): string | undefined => {
+  const query: unknown = request.query;
+  if (typeof query !== 'object' || query === null) return undefined;
+  const candidate: unknown = Reflect.get(query, 'sessionId');
+  if (typeof candidate !== 'string' || candidate.length === 0) return undefined;
+  return candidate;
+};
+
+export const registerRequestContextHook = (app: FastifyInstance): void => {
+  app.addHook('onRequest', (request, _reply, done) => {
+    const sessionId = extractSessionId(request);
+    if (sessionId !== undefined) {
+      request.log = request.log.child({ sessionId });
+    }
+    done();
+  });
+};

--- a/packages/relay-api/src/presentation/http/server.ts
+++ b/packages/relay-api/src/presentation/http/server.ts
@@ -12,6 +12,7 @@ import { createJoseJwtVerifier } from '../../infrastructure/auth/jose-jwt-verifi
 import { createStaticAccessTokenVerifier } from '../../infrastructure/auth/static-access-token-verifier';
 import { loggerOptions } from '../../infrastructure/logging/logger';
 import { registerRelayRoute } from '../ws/relay-route';
+import { registerRequestContextHook } from './request-context-hook';
 import { registerHealthRoute } from './routes/health';
 import { registerSessionsRoute } from './routes/sessions';
 
@@ -28,6 +29,8 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
     trustProxy: true,
     genReqId: () => `req_${ulid()}`,
   });
+
+  registerRequestContextHook(app);
 
   // @fastify/websocket は onRoute hook で `{ websocket: true }` 経路を変換する。
   // hook は plugin load 後にしか有効にならないため、WebSocket route は本 plugin


### PR DESCRIPTION
## Summary

Phase 4 §6.6 ロギング / 監視の最初の一歩 (PR A in roadmap §4)。pino redact パスを拡張して実プロバイダ用ヘッダや event envelope 内字幕本文を網羅し、実際に redact が機能することを**契約テスト**で固定。また onRequest hook で `sessionId` を child logger に bind し、以降の全 log line に自動付与する。

## logger.ts redact 追加

- `req.headers["x-deepgram-authorization"]` / `req.headers["x-deepl-auth"]` — 実プロバイダ ACL 呼び出しに備え
- `*.authorization` / `*.audioBase64` — 任意階層
- `payload.*.text` / `event.payload.text` / `body.payload.*` — WebSocket イベント envelope と HTTP body の wrapped shape を網羅

## logger.test.ts 新規 (8 ケース)

- Authorization / x-api-key / x-deepgram / x-deepl headers → `[REDACTED]`
- apiKey / streamToken / accessToken / refreshToken / password
- `payload.text` (字幕本文プライバシー)
- `payload.audioBase64` (音声バイナリ)
- `event.payload.*` (wrapped envelope)
- sessionId / requestId / chunkId 等の non-sensitive は visible

## request-context-hook.ts 新規

- URL query の `sessionId` を抽出し `request.log` を child logger に差し替え
- 以降の `request.log.info` etc. に `sessionId` が常時付与される
- `Reflect.get` 経由の type guard narrowing (`as` 禁止に対応)

## request-context-hook.test.ts (3 ケース)

- sessionId 付与 / 未指定時の no-op / 空文字列の no-op

## server.ts

onRequest hook を router / plugin より前に登録し、全 route で効くようにする。

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 137 relay-api tests + 593 extension tests)
- [x] logger redact contract 8 cases
- [x] request context hook 3 cases

## Out of scope

roadmap §4 の残 PR (B: security plugins / C: GET /sessions/:id / D-G: providers + UseCases)