### PR TITLE
feat(relay-api): IMPL-432/433/434 security plugins (CORS + Helmet + rate-limit)

### DIFF
--- a/packages/relay-api/src/presentation/http/routes/sessions.ts
+++ b/packages/relay-api/src/presentation/http/routes/sessions.ts
@@ -7,6 +7,7 @@ import { toHttpErrorEnvelope } from '../error-mapper';
 export type SessionsRouteDependencies = Readonly<{
   issueStreamTokenUseCase: IssueStreamTokenUseCase;
   accessTokenVerifier: AccessTokenVerifier;
+  rateLimit?: Readonly<{ max: number; timeWindowMs: number }>;
 }>;
 
 /**
@@ -24,9 +25,15 @@ export const registerSessionsRoute = (
   app: FastifyInstance,
   deps: SessionsRouteDependencies,
 ): void => {
+  const rateLimit = deps.rateLimit;
   app.post(
     '/sessions',
-    { preHandler: createBearerAuthPreHandler(deps.accessTokenVerifier) },
+    {
+      preHandler: createBearerAuthPreHandler(deps.accessTokenVerifier),
+      ...(rateLimit === undefined
+        ? {}
+        : { config: { rateLimit: { max: rateLimit.max, timeWindow: rateLimit.timeWindowMs } } }),
+    },
     async (request, reply) => {
       const result = await deps.issueStreamTokenUseCase(request.body);
       return result.match(

--- a/packages/relay-api/src/presentation/http/security-plugins.test.ts
+++ b/packages/relay-api/src/presentation/http/security-plugins.test.ts
@@ -1,0 +1,201 @@
+import { okAsync } from 'neverthrow';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ok } from 'neverthrow';
+import { type FastifyInstance } from 'fastify';
+import { type AccessTokenVerifier } from '../../application/ports/access-token-verifier';
+import { type JwtVerifier } from '../../application/ports/jwt-verifier';
+import { type IssueStreamTokenUseCase } from '../../application/use-cases/issue-stream-token-use-case';
+import { buildApp, type AppDependencies } from './server';
+
+const VALID_ACCESS_TOKEN = 'access-token-test-fixture-aaaa';
+
+const noopVerifier: JwtVerifier = {
+  verify: () =>
+    okAsync({
+      jti: 'strm_xxx',
+      sub: '01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+      expiresAtEpochSec: Math.floor(Date.now() / 1000) + 600,
+      issuedAtEpochSec: Math.floor(Date.now() / 1000),
+      claims: {},
+    }),
+};
+
+const fixedAccessTokenVerifier: AccessTokenVerifier = {
+  verify: (bearer) => (bearer === VALID_ACCESS_TOKEN ? ok(undefined) : ok(undefined)), // ここでは rate-limit / CORS に集中し auth は通す
+};
+
+const noopUseCase: IssueStreamTokenUseCase = () =>
+  okAsync({
+    sessionId: '01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+    streamToken: 'jwt',
+    relayUrl: 'wss://test/relay',
+    expiresAt: '2026-04-21T01:00:00.000Z',
+    heartbeatIntervalSec: 15,
+    audio: {
+      encoding: 'pcm_s16le',
+      sampleRateHz: 16000,
+      channels: 1,
+      frameDurationMs: 100,
+      transport: 'json-base64',
+    },
+    limits: { maxConcurrentSessions: 3, maxFrameRatePerSecond: 10 },
+  });
+
+const buildTestApp = (overrides: Partial<AppDependencies> = {}): FastifyInstance =>
+  buildApp({
+    issueStreamTokenUseCase: noopUseCase,
+    jwtVerifier: noopVerifier,
+    accessTokenVerifier: fixedAccessTokenVerifier,
+    ...overrides,
+  });
+
+const validBody = {
+  sourceType: 'tab',
+  displayName: 'YouTube Live',
+  sourceLanguage: 'en-US',
+  autoDetectLanguage: false,
+  targetLanguage: 'ja-JP',
+  overlayTarget: { kind: 'tab', tabId: 42 },
+  client: { extensionVersion: '0.1.0', protocolVersion: '1.0' },
+};
+
+describe('security plugins (IMPL-432/433/434)', () => {
+  let app: FastifyInstance | null = null;
+
+  beforeEach(() => {
+    app = null;
+  });
+
+  afterEach(async () => {
+    if (app !== null) await app.close();
+  });
+
+  describe('IMPL-434 Helmet', () => {
+    it('adds standard security headers on HTTP responses', async () => {
+      app = buildTestApp();
+      const response = await app.inject({ method: 'GET', url: '/health' });
+      expect(response.statusCode).toBe(200);
+      // Helmet adds X-Content-Type-Options: nosniff by default
+      expect(response.headers['x-content-type-options']).toBe('nosniff');
+    });
+  });
+
+  describe('IMPL-433 CORS', () => {
+    it('allows chrome-extension:// origins matching MV3 ID pattern', async () => {
+      app = buildTestApp();
+      const response = await app.inject({
+        method: 'OPTIONS',
+        url: '/sessions',
+        headers: {
+          origin: 'chrome-extension://abcdefghijklmnopabcdefghijklmnop',
+          'access-control-request-method': 'POST',
+          'access-control-request-headers': 'content-type, authorization',
+        },
+      });
+      expect(response.statusCode).toBe(204);
+      expect(response.headers['access-control-allow-origin']).toBe(
+        'chrome-extension://abcdefghijklmnopabcdefghijklmnop',
+      );
+    });
+
+    it('rejects non-chrome-extension origins', async () => {
+      app = buildTestApp();
+      const response = await app.inject({
+        method: 'OPTIONS',
+        url: '/sessions',
+        headers: {
+          origin: 'https://evil.example.com',
+          'access-control-request-method': 'POST',
+        },
+      });
+      // Without allowed origin match, preflight should not echo origin
+      expect(response.headers['access-control-allow-origin']).toBeUndefined();
+    });
+
+    it('honors explicit allowedOrigins list when provided', async () => {
+      app = buildTestApp({
+        security: { allowedOrigins: ['chrome-extension://specificid123specificid123specif'] },
+      });
+      const ok = await app.inject({
+        method: 'OPTIONS',
+        url: '/sessions',
+        headers: {
+          origin: 'chrome-extension://specificid123specificid123specif',
+          'access-control-request-method': 'POST',
+        },
+      });
+      expect(ok.headers['access-control-allow-origin']).toBe(
+        'chrome-extension://specificid123specificid123specif',
+      );
+
+      const rejected = await app.inject({
+        method: 'OPTIONS',
+        url: '/sessions',
+        headers: {
+          origin: 'chrome-extension://abcdefghijklmnopabcdefghijklmnop',
+          'access-control-request-method': 'POST',
+        },
+      });
+      expect(rejected.headers['access-control-allow-origin']).toBeUndefined();
+    });
+  });
+
+  describe('IMPL-432 Rate limit', () => {
+    /*
+     * `@fastify/rate-limit` の実挙動 (実際に閾値を超えたら 429 を返す) は
+     * isolated node script で検証済 (commit 時点の手動確認)。ここでは統合
+     * レベルで plugin が登録され、X-RateLimit 系ヘッダが付与されることを
+     * 確認する。`app.inject` 同一プロセス内での rate counter は Fastify
+     * バージョン依存の挙動があり、integration test 実機 (CI HTTP server) に
+     * 委ねる。
+     */
+    it('attaches X-RateLimit-Limit header on rate-limited POST /sessions responses', async () => {
+      app = buildTestApp({
+        postSessionsRateLimit: { max: 30, timeWindowMs: 60_000 },
+      });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/sessions',
+        headers: { authorization: `Bearer ${VALID_ACCESS_TOKEN}` },
+        payload: validBody,
+      });
+      expect(response.statusCode).toBe(201);
+      // @fastify/rate-limit v10 は `X-RateLimit-Limit` 等のヘッダを付与する
+      expect(response.headers['x-ratelimit-limit']).toBeDefined();
+    });
+
+    it('returns 429 RATE_LIMIT_EXCEEDED when global limit is exceeded', async () => {
+      app = buildTestApp({
+        security: { rateLimit: { globalMax: 1, timeWindowMs: 60_000 } },
+      });
+      const first = await app.inject({ method: 'GET', url: '/health' });
+      expect(first.statusCode).toBe(200);
+      const second = await app.inject({ method: 'GET', url: '/health' });
+      expect(second.statusCode).toBe(429);
+      const parsed: unknown = second.json();
+      expect(parsed).toMatchObject({ error: 'RATE_LIMIT_EXCEEDED' });
+    });
+
+    it('returns 429 when POST /sessions exceeds route-level config.rateLimit.max', async () => {
+      app = buildTestApp({
+        postSessionsRateLimit: { max: 2, timeWindowMs: 60_000 },
+      });
+      for (let i = 0; i < 2; i += 1) {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/sessions',
+          headers: { authorization: `Bearer ${VALID_ACCESS_TOKEN}` },
+          payload: validBody,
+        });
+        expect(response.statusCode).toBe(201);
+      }
+      const over = await app.inject({
+        method: 'POST',
+        url: '/sessions',
+        headers: { authorization: `Bearer ${VALID_ACCESS_TOKEN}` },
+        payload: validBody,
+      });
+      expect(over.statusCode).toBe(429);
+    });
+  });
+});

--- a/packages/relay-api/src/presentation/http/security-plugins.ts
+++ b/packages/relay-api/src/presentation/http/security-plugins.ts
@@ -1,0 +1,109 @@
+import { createHash } from 'node:crypto';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import fastifyCors from '@fastify/cors';
+import fastifyHelmet from '@fastify/helmet';
+import fastifyRateLimit from '@fastify/rate-limit';
+
+/**
+ * IMPL-432 / IMPL-433 / IMPL-434 セキュリティ plugins 登録。
+ *
+ * - `@fastify/cors`: `chrome-extension://` origin のみ許可 (MV3 拡張用)
+ * - `@fastify/helmet`: 標準セキュリティヘッダ。`contentSecurityPolicy` は
+ *   off (拡張は自前 CSP 管理)
+ * - `@fastify/rate-limit`: global off (route 毎に opt-in)。access token の
+ *   SHA-256 prefix を key に使用し、plaintext token がログに残らないよう
+ *   設計 (api-specification §2.4 対応)
+ */
+export type SecurityPluginConfig = Readonly<{
+  allowedOrigins?: readonly string[];
+  rateLimit?: Readonly<{
+    globalMax?: number;
+    timeWindowMs?: number;
+  }>;
+}>;
+
+const MV3_EXTENSION_ID_PATTERN = /^chrome-extension:\/\/[a-p]{32}$/;
+
+type OriginCallback = (err: Error | null, allow: boolean) => void;
+type OriginFn = (origin: string | undefined, callback: OriginCallback) => void;
+
+/**
+ * `@fastify/cors` の callback 形式の origin 関数を返す。
+ * - origin 未指定 (same-origin) は常に許可
+ * - 許可リスト未指定時は `chrome-extension://<32 chars>` を許可
+ * - 許可リスト指定時は完全一致で判定
+ * - 非許可時は `callback(null, false)` で reject
+ */
+const createOriginCallback = (allowedOrigins?: readonly string[]): OriginFn => {
+  if (allowedOrigins === undefined || allowedOrigins.length === 0) {
+    return (origin, callback) => {
+      if (origin === undefined) {
+        callback(null, true);
+        return;
+      }
+      callback(null, MV3_EXTENSION_ID_PATTERN.test(origin));
+    };
+  }
+  const allowed = new Set(allowedOrigins);
+  return (origin, callback) => {
+    if (origin === undefined) {
+      callback(null, true);
+      return;
+    }
+    callback(null, allowed.has(origin));
+  };
+};
+
+const accessTokenHash = (bearer: string): string =>
+  createHash('sha256').update(bearer).digest('hex').slice(0, 16);
+
+const rateLimitKeyGenerator = (request: FastifyRequest): string => {
+  const header = request.headers.authorization;
+  if (typeof header === 'string' && header.startsWith('Bearer ')) {
+    return accessTokenHash(header.slice('Bearer '.length).trim());
+  }
+  // `request.ip` は X-Forwarded-For を含めた client IP。test (app.inject) では
+  // `127.0.0.1` が渡る。IP が取れない場合の fallback も安全化する。
+  return request.ip || 'unknown-client';
+};
+
+/**
+ * `@fastify/rate-limit` 10.x は `register` を **await** しないと内部の store /
+ * onRoute hook が初期化されないことがある。register した時点では queue 登録
+ * だけで、Fastify の `ready()` 時に並行 load されるため、登録順序と route
+ * 登録タイミング次第で `config.rateLimit` が無視されるケースが発生する。
+ *
+ * 確実に動作させるため、本関数は Promise を返し、buildApp 側で `await` する
+ * ことを想定する。
+ */
+export const registerSecurityPlugins = async (
+  app: FastifyInstance,
+  config: SecurityPluginConfig = {},
+): Promise<void> => {
+  await app.register(fastifyHelmet, {
+    contentSecurityPolicy: false,
+  });
+  await app.register(fastifyCors, {
+    origin: createOriginCallback(config.allowedOrigins),
+    credentials: true,
+    methods: ['GET', 'POST', 'OPTIONS'],
+  });
+  await app.register(fastifyRateLimit, {
+    global: true,
+    max: config.rateLimit?.globalMax ?? 120,
+    timeWindow: config.rateLimit?.timeWindowMs ?? 60_000,
+    keyGenerator: rateLimitKeyGenerator,
+    // `@fastify/rate-limit` v10 は errorResponseBuilder の戻り値を
+    // `{ code: number, error: string, message: string, ... }` 形式として
+    // 受け取り、Error として throw する。本 service のエラー envelope
+    // (`{ error: { code, message }, meta: { requestId } }`) とは互換性が
+    // 無いため、ここではプラグイン既定の error を使い、route handler 側 or
+    // setErrorHandler でフォーマット変換は行わない (route-level の 429 は
+    // 既定挙動で十分)。
+    errorResponseBuilder: (_request, context) => ({
+      statusCode: 429,
+      error: 'RATE_LIMIT_EXCEEDED',
+      message: `rate limit exceeded (max=${String(context.max)}, retryAfter=${String(context.after)})`,
+    }),
+  });
+};

--- a/packages/relay-api/src/presentation/http/server.ts
+++ b/packages/relay-api/src/presentation/http/server.ts
@@ -15,11 +15,14 @@ import { registerRelayRoute } from '../ws/relay-route';
 import { registerRequestContextHook } from './request-context-hook';
 import { registerHealthRoute } from './routes/health';
 import { registerSessionsRoute } from './routes/sessions';
+import { registerSecurityPlugins, type SecurityPluginConfig } from './security-plugins';
 
 export type AppDependencies = Readonly<{
   issueStreamTokenUseCase: IssueStreamTokenUseCase;
   jwtVerifier: JwtVerifier;
   accessTokenVerifier: AccessTokenVerifier;
+  security?: SecurityPluginConfig;
+  postSessionsRateLimit?: Readonly<{ max: number; timeWindowMs: number }>;
 }>;
 
 export function buildApp(deps: AppDependencies): FastifyInstance {
@@ -32,23 +35,29 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
 
   registerRequestContextHook(app);
 
-  // @fastify/websocket は onRoute hook で `{ websocket: true }` 経路を変換する。
-  // hook は plugin load 後にしか有効にならないため、WebSocket route は本 plugin
-  // 登録の "後" に load されるネスト plugin 内で宣言する必要がある。
-  void app.register(fastifyWebsocket);
-
-  registerHealthRoute(app);
-  registerSessionsRoute(app, {
-    issueStreamTokenUseCase: deps.issueStreamTokenUseCase,
-    accessTokenVerifier: deps.accessTokenVerifier,
+  // security plugins を encapsulated scope 内で `await` してから HTTP route
+  // を宣言することで、`@fastify/rate-limit` の route-level `config.rateLimit`
+  // を確実に効かせる。
+  void app.register(async (httpScope) => {
+    await registerSecurityPlugins(httpScope, deps.security ?? {});
+    registerHealthRoute(httpScope);
+    registerSessionsRoute(httpScope, {
+      issueStreamTokenUseCase: deps.issueStreamTokenUseCase,
+      accessTokenVerifier: deps.accessTokenVerifier,
+      rateLimit: deps.postSessionsRateLimit ?? { max: 30, timeWindowMs: 60_000 },
+    });
   });
-  void app.register((instance, _opts, done) => {
-    registerRelayRoute(instance, {
+
+  // WebSocket 経路。@fastify/websocket の onRoute hook 適用のためにネスト
+  // plugin 内で websocket plugin → relay route を順に登録する。security
+  // plugins とは別 scope で影響を切り離す。
+  void app.register(async (wsScope) => {
+    await wsScope.register(fastifyWebsocket);
+    registerRelayRoute(wsScope, {
       jwtVerifier: deps.jwtVerifier,
       clock: () => new Date().toISOString(),
       heartbeatIntervalSec: 15,
     });
-    done();
   });
 
   return app;
@@ -70,6 +79,9 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
  * - STREAM_TOKEN_TTL_SEC: 短命トークンの TTL 秒数 (既定 1800 = 30 分)
  * - ACCESS_TOKENS: HTTP control API の Bearer トークン (カンマ区切り。
  *   鍵ローテーション時は複数指定可)。各要素は 16 文字以上
+ * - CORS_ALLOWED_ORIGINS: CORS 許可 origin (カンマ区切り)。未設定時は任意の
+ *   `chrome-extension://<32 chars>` を許容する dev friendly 挙動
+ * - RATE_LIMIT_SESSIONS_PER_MIN: POST /sessions の per-user 上限 (既定 30)
  */
 const buildProductionDependencies = (): AppDependencies => {
   const secret = process.env['STREAM_TOKEN_SECRET'];
@@ -108,7 +120,22 @@ const buildProductionDependencies = (): AppDependencies => {
     maxFrameRatePerSecond: 10,
   });
 
-  return { issueStreamTokenUseCase, jwtVerifier, accessTokenVerifier };
+  const allowedOrigins = process.env['CORS_ALLOWED_ORIGINS']
+    ?.split(',')
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+  const sessionsLimitPerMin = Number.parseInt(
+    process.env['RATE_LIMIT_SESSIONS_PER_MIN'] ?? '30',
+    10,
+  );
+
+  return {
+    issueStreamTokenUseCase,
+    jwtVerifier,
+    accessTokenVerifier,
+    security: allowedOrigins !== undefined ? { allowedOrigins } : {},
+    postSessionsRateLimit: { max: sessionsLimitPerMin, timeWindowMs: 60_000 },
+  };
 };
 
 async function start(): Promise<void> {


### PR DESCRIPTION
## Summary

Phase 4 §6.4 のセキュリティ plugin 配線。3 プラグインを **encapsulated scope 内で `await register`** して onRoute hook を確実に効かせる。

## Helmet (IMPL-434)
- 標準ヘッダ (X-Content-Type-Options 等)
- `contentSecurityPolicy: false` (拡張は CSP を自前管理)

## CORS (IMPL-433)
- `chrome-extension://<32 chars>` origin のみ許可 (MV3 ID 形式の regex)
- `CORS_ALLOWED_ORIGINS` env で完全一致リストを設定可能
- `credentials: true`, `methods: ['GET','POST','OPTIONS']`
- callback 形式の origin 関数で `@fastify/cors` v10 型契約に準拠

## Rate-limit (IMPL-432)
- **access token の SHA-256 prefix (16 chars) を key** に使用し plaintext token をログに残さない (api-specification §2.4 対応)
- global baseline 120/min、route-level `config.rateLimit` で上書き
- POST /sessions: 30/min (`RATE_LIMIT_SESSIONS_PER_MIN` env で override 可)
- 超過時: 429 + `{ statusCode, error: 'RATE_LIMIT_EXCEEDED', message }`

## server.ts

- `AppDependencies` に `security` / `postSessionsRateLimit` を追加 (optional)
- `buildProductionDependencies` で env から読み込む
- **設計ポイント**: `@fastify/rate-limit` は route 登録時に plugin の onRoute hook が効いている必要があるため、security plugins を encapsulated scope 内で `await register` してから HTTP route を宣言する (plugin の非同期登録と route 登録タイミングが噛み合わないと config.rateLimit が効かない現象を解決)
- WebSocket 経路は別 scope に閉じる (`@fastify/helmet` の response header が 101 Switching Protocols と干渉するため)

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 144 relay-api tests + 593 extension tests)
- [x] Helmet: `x-content-type-options` ヘッダ
- [x] CORS: chrome-extension origin 許可 / 非許可 / explicit allowedOrigins
- [x] Rate-limit: route 付与確認 / global exceed で 429 / POST /sessions route-level 2/min で 3 回目 429

## Out of scope

roadmap §4 の残 PR (C: GET /sessions/:id / D-G: providers + UseCases)