### PR TITLE
feat(relay-api): IMPL-412 GET /sessions/:sessionId (stateless)

### DIFF
--- a/packages/relay-api/src/presentation/http/routes/get-session.test.ts
+++ b/packages/relay-api/src/presentation/http/routes/get-session.test.ts
@@ -1,0 +1,157 @@
+import { errAsync, ok, okAsync } from 'neverthrow';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type FastifyInstance } from 'fastify';
+import { type AccessTokenVerifier } from '../../../application/ports/access-token-verifier';
+import { type JwtVerifiedPayload, type JwtVerifier } from '../../../application/ports/jwt-verifier';
+import { type IssueStreamTokenUseCase } from '../../../application/use-cases/issue-stream-token-use-case';
+import { invariantViolationError, type DomainError } from '../../../domain/shared/errors';
+import { buildApp } from '../server';
+
+const ACCESS_TOKEN = 'access-token-test-fixture-xxxx';
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const OTHER_SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7XX';
+const STREAM_TOKEN = 'header.payload.signature';
+
+const accessTokenVerifier: AccessTokenVerifier = {
+  verify: () => ok(undefined),
+};
+
+const buildOkJwtVerifier = (sub: string): JwtVerifier => ({
+  verify: () =>
+    okAsync<JwtVerifiedPayload, DomainError>({
+      jti: 'strm_01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+      sub,
+      expiresAtEpochSec: Math.floor(Date.now() / 1000) + 600,
+      issuedAtEpochSec: Math.floor(Date.now() / 1000) - 10,
+      claims: {
+        sourceType: 'tab',
+        displayName: 'YouTube Live',
+        sourceLanguage: 'en-US',
+        autoDetectLanguage: false,
+        targetLanguage: 'ja-JP',
+        overlayTarget: { kind: 'tab', tabId: 42 },
+        client: { extensionVersion: '0.1.0', protocolVersion: '1.0' },
+        createdAt: '2026-04-21T00:00:00.000Z',
+      },
+    }),
+});
+
+const failingJwtVerifier: JwtVerifier = {
+  verify: () =>
+    errAsync<JwtVerifiedPayload, DomainError>(
+      invariantViolationError({ invariant: 'jwt-verification-failed', details: 'expired' }),
+    ),
+};
+
+const noopUseCase: IssueStreamTokenUseCase = () =>
+  okAsync({
+    sessionId: SESSION_ID,
+    streamToken: 'jwt',
+    relayUrl: 'wss://test/relay',
+    expiresAt: '2026-04-21T01:00:00.000Z',
+    heartbeatIntervalSec: 15,
+    audio: {
+      encoding: 'pcm_s16le',
+      sampleRateHz: 16000,
+      channels: 1,
+      frameDurationMs: 100,
+      transport: 'json-base64',
+    },
+    limits: { maxConcurrentSessions: 3, maxFrameRatePerSecond: 10 },
+  });
+
+const buildTestApp = (jwtVerifier: JwtVerifier) =>
+  buildApp({
+    issueStreamTokenUseCase: noopUseCase,
+    jwtVerifier,
+    accessTokenVerifier,
+  });
+
+describe('GET /sessions/:sessionId (IMPL-412 stateless)', () => {
+  let app: FastifyInstance | null = null;
+
+  beforeEach(() => {
+    app = null;
+  });
+
+  afterEach(async () => {
+    if (app !== null) await app.close();
+  });
+
+  it('returns 200 with session metadata decoded from stream token claims', async () => {
+    app = buildTestApp(buildOkJwtVerifier(SESSION_ID));
+    const response = await app.inject({
+      method: 'GET',
+      url: `/sessions/${SESSION_ID}`,
+      headers: {
+        authorization: `Bearer ${ACCESS_TOKEN}`,
+        'x-stream-token': STREAM_TOKEN,
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    const parsed: unknown = response.json();
+    expect(parsed).toMatchObject({
+      data: {
+        sessionId: SESSION_ID,
+        state: 'capturing',
+        sourceType: 'tab',
+        displayName: 'YouTube Live',
+        sourceLanguage: 'en-US',
+        targetLanguage: 'ja-JP',
+        startedAt: '2026-04-21T00:00:00.000Z',
+        lastEventAt: null,
+        lastErrorCode: null,
+      },
+    });
+  });
+
+  it('returns 401 when access token is missing', async () => {
+    app = buildTestApp(buildOkJwtVerifier(SESSION_ID));
+    const response = await app.inject({
+      method: 'GET',
+      url: `/sessions/${SESSION_ID}`,
+      headers: { 'x-stream-token': STREAM_TOKEN },
+    });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('returns 400 VALIDATION_ERROR when X-Stream-Token is missing', async () => {
+    app = buildTestApp(buildOkJwtVerifier(SESSION_ID));
+    const response = await app.inject({
+      method: 'GET',
+      url: `/sessions/${SESSION_ID}`,
+      headers: { authorization: `Bearer ${ACCESS_TOKEN}` },
+    });
+    expect(response.statusCode).toBe(400);
+    const parsed: unknown = response.json();
+    expect(parsed).toMatchObject({ error: { code: 'VALIDATION_ERROR' } });
+  });
+
+  it('returns 401 UNAUTHORIZED when stream token fails verification', async () => {
+    app = buildTestApp(failingJwtVerifier);
+    const response = await app.inject({
+      method: 'GET',
+      url: `/sessions/${SESSION_ID}`,
+      headers: {
+        authorization: `Bearer ${ACCESS_TOKEN}`,
+        'x-stream-token': STREAM_TOKEN,
+      },
+    });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('returns 400 when sessionId path does not match stream token sub', async () => {
+    app = buildTestApp(buildOkJwtVerifier(OTHER_SESSION_ID));
+    const response = await app.inject({
+      method: 'GET',
+      url: `/sessions/${SESSION_ID}`,
+      headers: {
+        authorization: `Bearer ${ACCESS_TOKEN}`,
+        'x-stream-token': STREAM_TOKEN,
+      },
+    });
+    expect(response.statusCode).toBe(400);
+    const parsed: unknown = response.json();
+    expect(parsed).toMatchObject({ error: { code: 'VALIDATION_ERROR' } });
+  });
+});

--- a/packages/relay-api/src/presentation/http/routes/get-session.ts
+++ b/packages/relay-api/src/presentation/http/routes/get-session.ts
@@ -1,0 +1,96 @@
+import type { FastifyInstance } from 'fastify';
+import { type AccessTokenVerifier } from '../../../application/ports/access-token-verifier';
+import { type JwtVerifier } from '../../../application/ports/jwt-verifier';
+import { createBearerAuthPreHandler } from '../access-token-hook';
+
+export type GetSessionRouteDependencies = Readonly<{
+  accessTokenVerifier: AccessTokenVerifier;
+  jwtVerifier: JwtVerifier;
+}>;
+
+type Params = Readonly<{ sessionId: string }>;
+type Headers = Readonly<{ 'x-stream-token'?: string }>;
+
+/**
+ * IMPL-412 `GET /sessions/:sessionId` HTTP route。
+ *
+ * **stateless 設計の制約**: 本 Relay API は session の動的状態を中央保持しない
+ * (PR #30 以降)。そのため api-specification §4.3 で定義される `state` /
+ * `lastEventAt` / `lastErrorCode` のような "現在状態" を厳密に返せない。
+ *
+ * 本実装:
+ * - access token (IMPL-430 preHandler) で caller を認証
+ * - JWT は `X-Stream-Token` header で受け取る (POST /sessions 応答で拡張が
+ *   保持する stream token をそのまま送信する想定)
+ * - JWT を verify してから claims (sourceType / language / displayName 等) を
+ *   response に展開する
+ * - 動的 state は `'capturing'` 固定 (JWT が有効な間は active と見なす)
+ * - `lastEventAt` / `lastErrorCode` は常に `null`
+ *
+ * JWT 未提示 / sub mismatch / 署名不正 / 期限切れ は全て 400 / 401 を返す。
+ */
+export const registerGetSessionRoute = (
+  app: FastifyInstance,
+  deps: GetSessionRouteDependencies,
+): void => {
+  app.get<{ Params: Params; Headers: Headers }>(
+    '/sessions/:sessionId',
+    {
+      preHandler: createBearerAuthPreHandler(deps.accessTokenVerifier),
+    },
+    async (request, reply) => {
+      const { sessionId } = request.params;
+      const streamToken = request.headers['x-stream-token'];
+      if (typeof streamToken !== 'string' || streamToken.length === 0) {
+        reply.code(400);
+        return {
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'X-Stream-Token header is required to resolve session metadata',
+          },
+          meta: { requestId: request.id },
+        };
+      }
+      const verified = await deps.jwtVerifier.verify(streamToken);
+      if (verified.isErr()) {
+        reply.code(401);
+        return {
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'stream token verification failed',
+          },
+          meta: { requestId: request.id },
+        };
+      }
+      const payload = verified.value;
+      if (payload.sub !== sessionId) {
+        reply.code(400);
+        return {
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: `sessionId path (${sessionId}) does not match stream token sub (${payload.sub})`,
+          },
+          meta: { requestId: request.id },
+        };
+      }
+      const claims = payload.claims;
+      const read = (key: string): unknown => claims[key];
+      const asString = (value: unknown): string | null =>
+        typeof value === 'string' ? value : null;
+      return {
+        data: {
+          sessionId,
+          state: 'capturing',
+          sourceType: asString(read('sourceType')),
+          displayName: asString(read('displayName')),
+          sourceLanguage: asString(read('sourceLanguage')),
+          targetLanguage: asString(read('targetLanguage')),
+          startedAt: asString(read('createdAt')),
+          lastEventAt: null,
+          lastErrorCode: null,
+        },
+        meta: { requestId: request.id },
+      };
+    },
+  );
+};

--- a/packages/relay-api/src/presentation/http/server.ts
+++ b/packages/relay-api/src/presentation/http/server.ts
@@ -13,6 +13,7 @@ import { createStaticAccessTokenVerifier } from '../../infrastructure/auth/stati
 import { loggerOptions } from '../../infrastructure/logging/logger';
 import { registerRelayRoute } from '../ws/relay-route';
 import { registerRequestContextHook } from './request-context-hook';
+import { registerGetSessionRoute } from './routes/get-session';
 import { registerHealthRoute } from './routes/health';
 import { registerSessionsRoute } from './routes/sessions';
 import { registerSecurityPlugins, type SecurityPluginConfig } from './security-plugins';
@@ -45,6 +46,10 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
       issueStreamTokenUseCase: deps.issueStreamTokenUseCase,
       accessTokenVerifier: deps.accessTokenVerifier,
       rateLimit: deps.postSessionsRateLimit ?? { max: 30, timeWindowMs: 60_000 },
+    });
+    registerGetSessionRoute(httpScope, {
+      accessTokenVerifier: deps.accessTokenVerifier,
+      jwtVerifier: deps.jwtVerifier,
     });
   });
 


### PR DESCRIPTION
## Summary

Phase 4 §6.2 API-003 セッション状態参照。stateless 設計 (PR #30) に従い、中央セッションストアを持たないまま session meta を返す。

## 設計上の制約

- Relay API は session の動的状態 (capturing/paused/error 等) を中央保持しないため、api-specification §4.3 で定義された "current state" を厳密に返せない
- クライアント (拡張) は `POST /sessions` 応答で取得した stream token (JWT) を保持している前提で、**`X-Stream-Token` header として提示する**
- Relay API は JWT claims (sourceType / displayName / languages / createdAt 等) を decode して返す
- `state` は JWT が有効な間 `'capturing'` 固定、`lastEventAt` / `lastErrorCode` は常に `null`

## ルート

- `GET /sessions/:sessionId`
- preHandler: IMPL-430 access token Bearer 検証
- Requires `X-Stream-Token` header (JWT)
- `sessionId` path ↔ JWT `sub` 一致検証

## 失敗モード

- 401 access token 不正/欠落
- 400 X-Stream-Token 欠落 (`VALIDATION_ERROR`)
- 401 stream token 検証失敗 (`UNAUTHORIZED`)
- 400 sessionId ↔ sub 不一致 (`VALIDATION_ERROR`)

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 149 relay-api tests + 593 extension tests)
- [x] 5 cases: 200 正常系 / 401 access token なし / 400 stream token なし / 401 JWT 検証失敗 / 400 sub mismatch

## Out of scope

roadmap §4 の残 PR (D-G: providers + UseCases + WS wiring)