### PR TITLE
feat(relay-api): IMPL-440/441/402/403 STT/Translation ports + UseCases

### DIFF
--- a/packages/relay-api/src/application/ports/stt-port.test.ts
+++ b/packages/relay-api/src/application/ports/stt-port.test.ts
@@ -1,0 +1,62 @@
+import { ok, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { type DomainError } from '../../domain/shared/errors';
+import { type SttPort, type SttStreamHandle, type TranscriptEvent } from './stt-port';
+
+describe('SttPort contract', () => {
+  it('can be implemented with ok/AsyncIterable for test purposes', async () => {
+    const events: TranscriptEvent[] = [
+      {
+        type: 'partial',
+        segmentId: 'seg_1',
+        revision: 1,
+        text: 'hello',
+        language: 'en',
+        startOffsetMs: 0,
+        endOffsetMs: 100,
+      },
+      {
+        type: 'final',
+        segmentId: 'seg_1',
+        text: 'hello',
+        language: 'en',
+        startOffsetMs: 0,
+        endOffsetMs: 200,
+        finalizedAt: '2026-04-21T00:00:00.000Z',
+      },
+    ];
+    const handle: SttStreamHandle = {
+      sendFrame: () => ok(undefined),
+      close: () => okAsync<void, DomainError>(undefined),
+      events: {
+        [Symbol.asyncIterator]: () => {
+          let index = 0;
+          return {
+            next: (): Promise<IteratorResult<TranscriptEvent>> => {
+              if (index >= events.length) {
+                return Promise.resolve({ done: true, value: undefined });
+              }
+              const event = events[index];
+              index += 1;
+              if (event === undefined) {
+                return Promise.resolve({ done: true, value: undefined });
+              }
+              return Promise.resolve({ done: false, value: event });
+            },
+          };
+        },
+      },
+    };
+    const port: SttPort = {
+      openStream: () => okAsync<SttStreamHandle, DomainError>(handle),
+    };
+    const opened = await port.openStream({ sourceLanguage: 'en-US', autoDetectLanguage: false });
+    expect(opened.isOk()).toBe(true);
+    if (!opened.isOk()) return;
+    const collected: TranscriptEvent[] = [];
+    for await (const event of opened.value.events) collected.push(event);
+    expect(collected).toHaveLength(2);
+    expect(collected[0]?.type).toBe('partial');
+    expect(collected[1]?.type).toBe('final');
+  });
+});

--- a/packages/relay-api/src/application/ports/stt-port.ts
+++ b/packages/relay-api/src/application/ports/stt-port.ts
@@ -1,0 +1,58 @@
+import { type Result, type ResultAsync } from 'neverthrow';
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * STT ストリーム配信の transcript イベント (DD-402)。
+ *
+ * - `partial`: 暫定字幕。同一 `segmentId` で複数回発行され、`revision` は
+ *   単調増加。`text` は最新全文を表す (差分ではなく累積)
+ * - `final`: 確定字幕。1 つの `segmentId` につき 1 回発行される
+ */
+export type TranscriptEvent =
+  | Readonly<{
+      type: 'partial';
+      segmentId: string;
+      revision: number;
+      text: string;
+      language: string | null;
+      startOffsetMs: number;
+      endOffsetMs: number;
+    }>
+  | Readonly<{
+      type: 'final';
+      segmentId: string;
+      text: string;
+      language: string | null;
+      startOffsetMs: number;
+      endOffsetMs: number;
+      finalizedAt: string;
+    }>;
+
+/**
+ * STT プロバイダに接続中のストリームハンドル。
+ *
+ * `sendFrame` は WebSocket 経由で受信した PCM フレームをプロバイダへ転送する。
+ * `events` は AsyncIterable で transcript.* イベントを受け取る。`close` で
+ * graceful close を行い、`events` の async iteration も終了する。
+ *
+ * 本 port の実装 (DD-412 StreamingSttProviderAdapter) はプロバイダごとに
+ * 異なる wire format (WebSocket / gRPC) を隠蔽する。
+ */
+export type SttStreamHandle = Readonly<{
+  sendFrame: (params: { audioBase64: string; chunkId: string }) => Result<void, DomainError>;
+  close: () => ResultAsync<void, DomainError>;
+  events: AsyncIterable<TranscriptEvent>;
+}>;
+
+/**
+ * STT プロバイダポート (DD-402)。
+ *
+ * 1 セッション 1 ストリーム。`openStream` で接続し、以降は `SttStreamHandle`
+ * 経由で frame 送信 / transcript 受信を行う。
+ */
+export type SttPort = Readonly<{
+  openStream: (config: {
+    sourceLanguage: string | null;
+    autoDetectLanguage: boolean;
+  }) => ResultAsync<SttStreamHandle, DomainError>;
+}>;

--- a/packages/relay-api/src/application/ports/translation-port.test.ts
+++ b/packages/relay-api/src/application/ports/translation-port.test.ts
@@ -1,0 +1,27 @@
+import { okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { type DomainError } from '../../domain/shared/errors';
+import { type TranslationPort, type TranslationResponse } from './translation-port';
+
+describe('TranslationPort contract', () => {
+  it('returns text + detectedSourceLanguage + latencyMs', async () => {
+    const port: TranslationPort = {
+      translate: (request) =>
+        okAsync<TranslationResponse, DomainError>({
+          text: `[JA] ${request.text}`,
+          detectedSourceLanguage: 'en',
+          latencyMs: 250,
+        }),
+    };
+    const result = await port.translate({
+      text: 'hello',
+      sourceLanguage: 'en-US',
+      targetLanguage: 'ja-JP',
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.text).toBe('[JA] hello');
+      expect(result.value.latencyMs).toBe(250);
+    }
+  });
+});

--- a/packages/relay-api/src/application/ports/translation-port.ts
+++ b/packages/relay-api/src/application/ports/translation-port.ts
@@ -1,0 +1,26 @@
+import { type ResultAsync } from 'neverthrow';
+import { type DomainError } from '../../domain/shared/errors';
+
+export type TranslationRequest = Readonly<{
+  text: string;
+  sourceLanguage: string | null;
+  targetLanguage: string;
+}>;
+
+export type TranslationResponse = Readonly<{
+  text: string;
+  /** プロバイダが検知した言語 (自動判定時)。判定できなければ null */
+  detectedSourceLanguage: string | null;
+  /** 翻訳 API 呼び出しから応答までの経過ミリ秒 (SLO 監視に利用) */
+  latencyMs: number;
+}>;
+
+/**
+ * 翻訳プロバイダポート (DD-403)。
+ *
+ * 1 字幕 (transcript.final) につき 1 回呼び出される。タイムアウト (800ms)・
+ * リトライ (1 回)・サーキットブレーカーは infrastructure 層で wrapper する。
+ */
+export type TranslationPort = Readonly<{
+  translate: (request: TranslationRequest) => ResultAsync<TranslationResponse, DomainError>;
+}>;

--- a/packages/relay-api/src/application/use-cases/relay-audio-frame-use-case.test.ts
+++ b/packages/relay-api/src/application/use-cases/relay-audio-frame-use-case.test.ts
@@ -1,0 +1,46 @@
+import { err, ok, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { type SttStreamHandle } from '../ports/stt-port';
+import { createRelayAudioFrameUseCase } from './relay-audio-frame-use-case';
+
+const buildHandle = (): SttStreamHandle & {
+  sendFrame: ReturnType<typeof vi.fn>;
+} => ({
+  sendFrame: vi.fn(() => ok(undefined)),
+  close: () => okAsync<void, DomainError>(undefined),
+  events: {
+    [Symbol.asyncIterator]: () => ({
+      next: () => Promise.resolve({ done: true as const, value: undefined }),
+    }),
+  },
+});
+
+describe('createRelayAudioFrameUseCase (IMPL-402)', () => {
+  it('forwards audio.frame payload to SttStreamHandle.sendFrame', () => {
+    const handle = buildHandle();
+    const useCase = createRelayAudioFrameUseCase();
+    const result = useCase(handle, { audioBase64: 'AAAA=', chunkId: 'chk_001' });
+    expect(result.isOk()).toBe(true);
+    expect(handle.sendFrame).toHaveBeenCalledWith({
+      audioBase64: 'AAAA=',
+      chunkId: 'chk_001',
+    });
+  });
+
+  it('propagates sendFrame error', () => {
+    const failingHandle: SttStreamHandle = {
+      sendFrame: () =>
+        err(invariantViolationError({ invariant: 'stt-send-failed', details: 'closed' })),
+      close: () => okAsync<void, DomainError>(undefined),
+      events: {
+        [Symbol.asyncIterator]: () => ({
+          next: () => Promise.resolve({ done: true as const, value: undefined }),
+        }),
+      },
+    };
+    const useCase = createRelayAudioFrameUseCase();
+    const result = useCase(failingHandle, { audioBase64: 'AAAA=', chunkId: 'chk_001' });
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/relay-api/src/application/use-cases/relay-audio-frame-use-case.ts
+++ b/packages/relay-api/src/application/use-cases/relay-audio-frame-use-case.ts
@@ -1,0 +1,29 @@
+import { type Result } from 'neverthrow';
+import { type DomainError } from '../../domain/shared/errors';
+import { type SttStreamHandle } from '../ports/stt-port';
+
+/**
+ * IMPL-402 RelayAudioFrameUseCase。
+ *
+ * WebSocket `audio.frame` client event を受信した際に呼び出される薄い
+ * coordinator。input (base64 PCM + chunkId) を `SttStreamHandle.sendFrame`
+ * へ転送する。
+ *
+ * 本 UseCase 自体は state を持たない pure function。stream handle は WS 接続
+ * 毎に確立され、接続スコープの map (relay-route.ts) で管理する。
+ */
+export type RelayAudioFrameInput = Readonly<{
+  audioBase64: string;
+  chunkId: string;
+}>;
+
+export type RelayAudioFrameUseCase = (
+  handle: SttStreamHandle,
+  input: RelayAudioFrameInput,
+) => Result<void, DomainError>;
+
+export const createRelayAudioFrameUseCase = (): RelayAudioFrameUseCase => (handle, input) =>
+  handle.sendFrame({
+    audioBase64: input.audioBase64,
+    chunkId: input.chunkId,
+  });

--- a/packages/relay-api/src/application/use-cases/route-transcript-to-translation-use-case.test.ts
+++ b/packages/relay-api/src/application/use-cases/route-transcript-to-translation-use-case.test.ts
@@ -1,0 +1,51 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { type TranslationPort, type TranslationResponse } from '../ports/translation-port';
+import { createRouteTranscriptToTranslationUseCase } from './route-transcript-to-translation-use-case';
+
+describe('createRouteTranscriptToTranslationUseCase (IMPL-403)', () => {
+  it('delegates to TranslationPort and returns translated text + metadata', async () => {
+    const port: TranslationPort & { translate: ReturnType<typeof vi.fn> } = {
+      translate: vi.fn(() =>
+        okAsync<TranslationResponse, DomainError>({
+          text: 'こんにちは',
+          detectedSourceLanguage: 'en',
+          latencyMs: 312,
+        }),
+      ),
+    };
+    const useCase = createRouteTranscriptToTranslationUseCase({ translationPort: port });
+    const result = await useCase({
+      text: 'hello',
+      sourceLanguage: 'en-US',
+      targetLanguage: 'ja-JP',
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.text).toBe('こんにちは');
+      expect(result.value.latencyMs).toBe(312);
+    }
+    expect(port.translate).toHaveBeenCalledWith({
+      text: 'hello',
+      sourceLanguage: 'en-US',
+      targetLanguage: 'ja-JP',
+    });
+  });
+
+  it('surfaces translation port failure', async () => {
+    const port: TranslationPort = {
+      translate: () =>
+        errAsync<TranslationResponse, DomainError>(
+          invariantViolationError({ invariant: 'translation-failed', details: 'timeout' }),
+        ),
+    };
+    const useCase = createRouteTranscriptToTranslationUseCase({ translationPort: port });
+    const result = await useCase({
+      text: 'hello',
+      sourceLanguage: 'en-US',
+      targetLanguage: 'ja-JP',
+    });
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/relay-api/src/application/use-cases/route-transcript-to-translation-use-case.ts
+++ b/packages/relay-api/src/application/use-cases/route-transcript-to-translation-use-case.ts
@@ -1,0 +1,42 @@
+import { type ResultAsync } from 'neverthrow';
+import { type DomainError } from '../../domain/shared/errors';
+import { type TranslationPort } from '../ports/translation-port';
+
+/**
+ * IMPL-403 RouteTranscriptToTranslationUseCase。
+ *
+ * 確定字幕 (`transcript.final`) が Relay に到達した際に呼び出される coordinator。
+ * `TranslationPort.translate` に投げて翻訳結果を得る。タイムアウト / リトライ /
+ * サーキットブレーカーは infrastructure 層の wrap で実現する (IMPL-446)。
+ *
+ * 本 UseCase は薄い delegate。WebSocket への emission (`translation.final` 送信)
+ * は呼び出し側 (relay-route) が result.isOk() 時に行う。
+ */
+export type RouteTranscriptToTranslationInput = Readonly<{
+  text: string;
+  sourceLanguage: string | null;
+  targetLanguage: string;
+}>;
+
+export type RouteTranscriptToTranslationOutput = Readonly<{
+  text: string;
+  detectedSourceLanguage: string | null;
+  latencyMs: number;
+}>;
+
+export type RouteTranscriptToTranslationUseCase = (
+  input: RouteTranscriptToTranslationInput,
+) => ResultAsync<RouteTranscriptToTranslationOutput, DomainError>;
+
+export type RouteTranscriptToTranslationDependencies = Readonly<{
+  translationPort: TranslationPort;
+}>;
+
+export const createRouteTranscriptToTranslationUseCase =
+  (deps: RouteTranscriptToTranslationDependencies): RouteTranscriptToTranslationUseCase =>
+  (input) =>
+    deps.translationPort.translate(input).map((response) => ({
+      text: response.text,
+      detectedSourceLanguage: response.detectedSourceLanguage,
+      latencyMs: response.latencyMs,
+    }));


### PR DESCRIPTION
## Summary

Phase 4 §6.1 + §6.5 の port 契約と UseCase 定義。実プロバイダ実装 (IMPL-444/445) の配線点と、WebSocket `audio.frame` / `transcript.final` event の application coordinator。

## SttPort (IMPL-440)

- `openStream({sourceLanguage, autoDetectLanguage}) → SttStreamHandle`
- `SttStreamHandle.sendFrame` / `close` / `events` (AsyncIterable<TranscriptEvent>)
- `TranscriptEvent` discriminated union (`partial` | `final`)
- プロバイダ固有 wire format (Deepgram WS / Google gRPC 等) は adapter が隠蔽

## TranslationPort (IMPL-441)

- `translate({text, sourceLanguage, targetLanguage}) → TranslationResponse`
- `TranslationResponse`: `text` + `detectedSourceLanguage` + `latencyMs` (SLO 監視)
- timeout / retry / circuit breaker は IMPL-446 で wrap

## RelayAudioFrameUseCase (IMPL-402)

- WebSocket `audio.frame` event → `SttStreamHandle.sendFrame` に転送
- pure coordinator (state なし)

## RouteTranscriptToTranslationUseCase (IMPL-403)

- `transcript.final` → `TranslationPort.translate` → translated text を返す
- relay-route 側が `result.isOk()` 時に `translation.final` を WS 送信

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 155 relay-api tests + 593 extension tests)
- [x] SttPort contract (AsyncIterable で transcript 受信)
- [x] TranslationPort contract (text + latencyMs)
- [x] RelayAudioFrameUseCase 正常系 / 失敗伝播
- [x] RouteTranscriptToTranslationUseCase 正常系 / 失敗伝播

## Out of scope

- IMPL-446 resilience utils (PR E で追加)
- IMPL-444/445 Deepgram/DeepL adapter (PR F)
- IMPL-421/422 残 WS wiring (PR G で audio.frame → STT → transcript 経路接続)