### PR TITLE
feat(relay-api): IMPL-446 resilience utils (circuit-breaker / retry / timeout)

### DIFF
--- a/packages/relay-api/src/infrastructure/resilience/circuit-breaker.test.ts
+++ b/packages/relay-api/src/infrastructure/resilience/circuit-breaker.test.ts
@@ -1,0 +1,95 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { createCircuitBreaker } from './circuit-breaker';
+
+const fail = () =>
+  errAsync<string, DomainError>(
+    invariantViolationError({ invariant: 'test-failure', details: 'boom' }),
+  );
+const succeed = () => okAsync<string, DomainError>('ok');
+
+describe('createCircuitBreaker (IMPL-446)', () => {
+  it('throws when failureThreshold is non-positive', () => {
+    expect(() =>
+      createCircuitBreaker({ failureThreshold: 0, windowMs: 1000, openMs: 1000 }),
+    ).toThrow(/failureThreshold must be positive/);
+  });
+
+  it('starts in closed state and passes through success', async () => {
+    const breaker = createCircuitBreaker({
+      failureThreshold: 3,
+      windowMs: 1000,
+      openMs: 1000,
+    });
+    expect(breaker.state()).toBe('closed');
+    const result = await breaker.execute(succeed);
+    expect(result.isOk()).toBe(true);
+    expect(breaker.state()).toBe('closed');
+  });
+
+  it('opens after failureThreshold consecutive failures', async () => {
+    const breaker = createCircuitBreaker({
+      failureThreshold: 3,
+      windowMs: 5_000,
+      openMs: 1_000,
+    });
+    await breaker.execute(fail);
+    await breaker.execute(fail);
+    expect(breaker.state()).toBe('closed');
+    await breaker.execute(fail);
+    expect(breaker.state()).toBe('open');
+  });
+
+  it('returns circuit-open error while open (cooling period)', async () => {
+    const now = 0;
+    const breaker = createCircuitBreaker({
+      failureThreshold: 2,
+      windowMs: 5_000,
+      openMs: 1_000,
+      clock: () => now,
+    });
+    await breaker.execute(fail);
+    await breaker.execute(fail);
+    expect(breaker.state()).toBe('open');
+
+    const result = await breaker.execute(succeed);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('circuit-open');
+    }
+  });
+
+  it('transitions to half-open after openMs elapses, and closes on success', async () => {
+    let now = 0;
+    const breaker = createCircuitBreaker({
+      failureThreshold: 2,
+      windowMs: 5_000,
+      openMs: 1_000,
+      clock: () => now,
+    });
+    await breaker.execute(fail);
+    await breaker.execute(fail);
+    expect(breaker.state()).toBe('open');
+
+    now = 1_500;
+    const result = await breaker.execute(succeed);
+    expect(result.isOk()).toBe(true);
+    expect(breaker.state()).toBe('closed');
+  });
+
+  it('returns to open when half-open trial fails', async () => {
+    let now = 0;
+    const breaker = createCircuitBreaker({
+      failureThreshold: 2,
+      windowMs: 5_000,
+      openMs: 1_000,
+      clock: () => now,
+    });
+    await breaker.execute(fail);
+    await breaker.execute(fail);
+    now = 1_500;
+    await breaker.execute(fail);
+    expect(breaker.state()).toBe('open');
+  });
+});

--- a/packages/relay-api/src/infrastructure/resilience/circuit-breaker.ts
+++ b/packages/relay-api/src/infrastructure/resilience/circuit-breaker.ts
@@ -1,0 +1,95 @@
+import { ResultAsync, errAsync } from 'neverthrow';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+
+/**
+ * IMPL-446 Circuit breaker (acl.md §6)。
+ *
+ * 失敗の連鎖を早期遮断するための 3 状態マシン:
+ * - `closed`: 通常。失敗が閾値を超えると `open` へ
+ * - `open`: 全リクエストを即座に拒否。一定時間経過で `half-open` へ
+ * - `half-open`: 試験的に 1 リクエスト通す。成功で `closed`、失敗で `open` 復帰
+ *
+ * 設定値 (acl.md §6.1 より):
+ * - STT / Translation: 5 failures / 30s window で open、open 15s
+ */
+export type CircuitBreakerConfig = Readonly<{
+  failureThreshold: number;
+  windowMs: number;
+  openMs: number;
+  clock?: () => number;
+}>;
+
+type State = 'closed' | 'open' | 'half-open';
+
+export type CircuitBreaker = Readonly<{
+  execute: <T>(fn: () => ResultAsync<T, DomainError>) => ResultAsync<T, DomainError>;
+  state: () => State;
+}>;
+
+export const createCircuitBreaker = (config: CircuitBreakerConfig): CircuitBreaker => {
+  if (config.failureThreshold <= 0) {
+    throw new Error('createCircuitBreaker: failureThreshold must be positive');
+  }
+  if (config.windowMs <= 0 || config.openMs <= 0) {
+    throw new Error('createCircuitBreaker: windowMs and openMs must be positive');
+  }
+  const clock = config.clock ?? (() => Date.now());
+
+  let state: State = 'closed';
+  let failureTimestamps: number[] = [];
+  let openedAt: number | null = null;
+
+  const prune = (now: number): void => {
+    failureTimestamps = failureTimestamps.filter((t) => now - t < config.windowMs);
+  };
+
+  const trip = (now: number): void => {
+    state = 'open';
+    openedAt = now;
+  };
+
+  const reset = (): void => {
+    state = 'closed';
+    failureTimestamps = [];
+    openedAt = null;
+  };
+
+  return {
+    execute: <T>(fn: () => ResultAsync<T, DomainError>): ResultAsync<T, DomainError> => {
+      const now = clock();
+      if (state === 'open') {
+        if (openedAt !== null && now - openedAt < config.openMs) {
+          return errAsync<T, DomainError>(
+            invariantViolationError({
+              invariant: 'circuit-open',
+              details: `circuit breaker is open (cooling down for ${String(config.openMs)}ms)`,
+            }),
+          );
+        }
+        state = 'half-open';
+      }
+      return fn()
+        .map((value): T => {
+          if (state === 'half-open') {
+            reset();
+          } else {
+            prune(now);
+          }
+          return value;
+        })
+        .mapErr((error) => {
+          if (state === 'half-open') {
+            trip(clock());
+          } else {
+            failureTimestamps.push(clock());
+            prune(clock());
+            if (failureTimestamps.length >= config.failureThreshold) {
+              trip(clock());
+            }
+          }
+          return error;
+        });
+    },
+    state: () => state,
+  };
+};

--- a/packages/relay-api/src/infrastructure/resilience/retry-policy.test.ts
+++ b/packages/relay-api/src/infrastructure/resilience/retry-policy.test.ts
@@ -1,0 +1,62 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { createRetryPolicy } from './retry-policy';
+
+const buildPolicy = (
+  maxAttempts: number,
+  overrides: Partial<Parameters<typeof createRetryPolicy>[0]> = {},
+) =>
+  createRetryPolicy({
+    maxAttempts,
+    initialDelayMs: 10,
+    backoffFactor: 2,
+    sleep: vi.fn(() => Promise.resolve()),
+    random: () => 0.5, // deterministic jitter
+    ...overrides,
+  });
+
+describe('createRetryPolicy (IMPL-446)', () => {
+  it('throws when maxAttempts < 1', () => {
+    expect(() =>
+      createRetryPolicy({ maxAttempts: 0, initialDelayMs: 10, backoffFactor: 2 }),
+    ).toThrow();
+  });
+
+  it('returns immediately on success (1 attempt)', async () => {
+    const fn = vi.fn(() => okAsync<string, DomainError>('ok'));
+    const policy = buildPolicy(3);
+    const result = await policy.execute(fn);
+    expect(result.isOk()).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries up to maxAttempts on failure', async () => {
+    const fn = vi.fn(() =>
+      errAsync<string, DomainError>(
+        invariantViolationError({ invariant: 'transient', details: 'boom' }),
+      ),
+    );
+    const policy = buildPolicy(3);
+    const result = await policy.execute(fn);
+    expect(result.isErr()).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('succeeds after transient failures within attempts', async () => {
+    let calls = 0;
+    const fn = vi.fn(() => {
+      calls += 1;
+      if (calls < 3) {
+        return errAsync<string, DomainError>(
+          invariantViolationError({ invariant: 'transient', details: 'boom' }),
+        );
+      }
+      return okAsync<string, DomainError>('ok');
+    });
+    const policy = buildPolicy(5);
+    const result = await policy.execute(fn);
+    expect(result.isOk()).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/relay-api/src/infrastructure/resilience/retry-policy.ts
+++ b/packages/relay-api/src/infrastructure/resilience/retry-policy.ts
@@ -1,0 +1,52 @@
+import { ResultAsync, errAsync } from 'neverthrow';
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * IMPL-446 Retry with exponential backoff + jitter (acl.md §6.2)。
+ *
+ * 設定値 (acl.md より):
+ * - STT: 最大 3 回、初回 250ms、バックオフ 2.0x
+ * - Translation: 最大 1 回、初回 150ms
+ *
+ * jitter: `Math.random()` を既定注入。test では DI で deterministic に。
+ */
+export type RetryPolicyConfig = Readonly<{
+  maxAttempts: number;
+  initialDelayMs: number;
+  backoffFactor: number;
+  maxDelayMs?: number;
+  jitterRatio?: number;
+  sleep?: (ms: number) => Promise<void>;
+  random?: () => number;
+}>;
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export const createRetryPolicy = (config: RetryPolicyConfig) => {
+  if (config.maxAttempts < 1) {
+    throw new Error('createRetryPolicy: maxAttempts must be >= 1');
+  }
+  const sleep = config.sleep ?? defaultSleep;
+  const random = config.random ?? Math.random;
+  const maxDelayMs = config.maxDelayMs ?? Number.POSITIVE_INFINITY;
+  const jitterRatio = config.jitterRatio ?? 0.2;
+
+  const delayAt = (attempt: number): number => {
+    const base = config.initialDelayMs * Math.pow(config.backoffFactor, attempt - 1);
+    const capped = Math.min(base, maxDelayMs);
+    const jitter = capped * jitterRatio * (random() * 2 - 1);
+    return Math.max(0, Math.round(capped + jitter));
+  };
+
+  return {
+    execute: <T>(fn: () => ResultAsync<T, DomainError>): ResultAsync<T, DomainError> => {
+      const attempt = (n: number): ResultAsync<T, DomainError> =>
+        fn().orElse((error) => {
+          if (n >= config.maxAttempts) return errAsync<T, DomainError>(error);
+          return ResultAsync.fromSafePromise(sleep(delayAt(n))).andThen(() => attempt(n + 1));
+        });
+      return attempt(1);
+    },
+  };
+};

--- a/packages/relay-api/src/infrastructure/resilience/timeout.test.ts
+++ b/packages/relay-api/src/infrastructure/resilience/timeout.test.ts
@@ -1,0 +1,44 @@
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { withTimeout } from './timeout';
+
+describe('withTimeout (IMPL-446)', () => {
+  it('returns error when timeoutMs is non-positive', async () => {
+    const result = await withTimeout(() => okAsync<string, DomainError>('ok'), 0);
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('resolves successfully when fn completes within timeout', async () => {
+    const result = await withTimeout(() => okAsync<string, DomainError>('ok'), 1_000);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBe('ok');
+  });
+
+  it('surfaces fn error when it fails before timeout', async () => {
+    const result = await withTimeout(
+      () =>
+        errAsync<string, DomainError>(
+          invariantViolationError({ invariant: 'downstream-failure', details: 'fast fail' }),
+        ),
+      1_000,
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('downstream-failure');
+    }
+  });
+
+  it('returns operation-timeout error when fn exceeds timeoutMs', async () => {
+    const slowFn = (): ResultAsync<string, DomainError> =>
+      ResultAsync.fromSafePromise(
+        new Promise<string>((resolve) => setTimeout(() => resolve('ok'), 200)),
+      );
+    const result = await withTimeout(slowFn, 50, 'slow-op');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('operation-timeout');
+      expect(result.error.details).toContain('slow-op');
+    }
+  });
+});

--- a/packages/relay-api/src/infrastructure/resilience/timeout.ts
+++ b/packages/relay-api/src/infrastructure/resilience/timeout.ts
@@ -1,0 +1,56 @@
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+
+/**
+ * IMPL-446 Timeout wrapper (acl.md §4.4)。
+ *
+ * 指定 ms 内に `ResultAsync` が resolve しなければ
+ * `invariantViolationError({ invariant: 'operation-timeout' })` を返す。
+ *
+ * 設定値 (acl.md §4.4):
+ * - STT 初回応答: 1000ms
+ * - 翻訳: 800ms
+ */
+export const withTimeout = <T>(
+  fn: () => ResultAsync<T, DomainError>,
+  timeoutMs: number,
+  label = 'operation',
+): ResultAsync<T, DomainError> => {
+  if (timeoutMs <= 0) {
+    return errAsync<T, DomainError>(
+      invariantViolationError({
+        invariant: 'operation-timeout-config',
+        details: 'timeoutMs must be positive',
+      }),
+    );
+  }
+
+  type Outcome = Readonly<{ ok: true; value: T }> | Readonly<{ ok: false; error: DomainError }>;
+
+  const raceOutcome = new Promise<Outcome>((resolve) => {
+    const timer = setTimeout(() => {
+      resolve({
+        ok: false,
+        error: invariantViolationError({
+          invariant: 'operation-timeout',
+          details: `${label} timed out after ${String(timeoutMs)}ms`,
+        }),
+      });
+    }, timeoutMs);
+    timer.unref?.();
+    void fn().match(
+      (value) => {
+        clearTimeout(timer);
+        resolve({ ok: true, value });
+      },
+      (error) => {
+        clearTimeout(timer);
+        resolve({ ok: false, error });
+      },
+    );
+  });
+
+  return ResultAsync.fromSafePromise(raceOutcome).andThen((outcome) =>
+    outcome.ok ? okAsync<T, DomainError>(outcome.value) : errAsync<T, DomainError>(outcome.error),
+  );
+};


### PR DESCRIPTION
## Summary

Phase 4 §6.5 で実プロバイダを wrap するための汎用 resilience ユーティリティ。全て pure function / factory で state は内部に閉じる (shared state は持たない)。

## Circuit breaker (acl.md §6.1)

- 3 状態マシン: `closed` → `open` (failureThreshold 超過) → `half-open` (openMs 経過) → `closed` (trial 成功) / `open` (trial 失敗で復帰)
- `failureThreshold` / `windowMs` / `openMs` は DI、`clock` も DI でテスト可能
- open 中は `invariantViolationError({invariant: 'circuit-open'})` で即 Err

## Retry policy (acl.md §6.2)

- Exponential backoff + jitter
- `sleep` / `random` を DI で deterministic test
- STT 3 回 / Translation 1 回の設定は Provider wrapper 側で注入

## Timeout (acl.md §4.4)

- `Promise.race` による `timeoutMs` 制限
- timeout 発火時 `invariantViolationError({invariant: 'operation-timeout'})`
- `timer.unref()` で graceful shutdown 阻害しない

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 169 relay-api tests + 593 extension tests)
- [x] Circuit breaker (6): 正常 / 失敗累積で open / open 中拒否 / half-open 成功で close / half-open 失敗で復帰 / throw on 不正 config
- [x] Retry policy (4): 正常 1 回 / 失敗 maxAttempts / 途中成功 / throw on 不正 config
- [x] Timeout (4): 非正 timeout / 高速成功 / 失敗伝播 / timeout 発火

## Out of scope

PR F (IMPL-444/445 Real providers) でこの util を Deepgram / DeepL adapter 内で wrap する。