### PR TITLE
feat(relay-api): IMPL-421/422 WS full event wiring (audio.frame → transcript → translation)

### DIFF
--- a/packages/relay-api/src/presentation/http/routes/get-session.test.ts
+++ b/packages/relay-api/src/presentation/http/routes/get-session.test.ts
@@ -5,6 +5,8 @@ import { type AccessTokenVerifier } from '../../../application/ports/access-toke
 import { type JwtVerifiedPayload, type JwtVerifier } from '../../../application/ports/jwt-verifier';
 import { type IssueStreamTokenUseCase } from '../../../application/use-cases/issue-stream-token-use-case';
 import { invariantViolationError, type DomainError } from '../../../domain/shared/errors';
+import { createMockSttProvider } from '../../../../tests/support/mock/mock-stt-provider';
+import { createMockTranslationProvider } from '../../../../tests/support/mock/mock-translation-provider';
 import { buildApp } from '../server';
 
 const ACCESS_TOKEN = 'access-token-test-fixture-xxxx';
@@ -65,6 +67,8 @@ const buildTestApp = (jwtVerifier: JwtVerifier) =>
     issueStreamTokenUseCase: noopUseCase,
     jwtVerifier,
     accessTokenVerifier,
+    sttPort: createMockSttProvider(),
+    translationPort: createMockTranslationProvider(),
   });
 
 describe('GET /sessions/:sessionId (IMPL-412 stateless)', () => {

--- a/packages/relay-api/src/presentation/http/routes/sessions.test.ts
+++ b/packages/relay-api/src/presentation/http/routes/sessions.test.ts
@@ -9,6 +9,8 @@ import {
   validationError,
   type DomainError,
 } from '../../../domain/shared/errors';
+import { createMockSttProvider } from '../../../../tests/support/mock/mock-stt-provider';
+import { createMockTranslationProvider } from '../../../../tests/support/mock/mock-translation-provider';
 import { buildApp } from '../server';
 
 const VALID_ACCESS_TOKEN = 'access-token-test-fixture-aaaa';
@@ -41,6 +43,8 @@ const buildTestApp = (issueStreamTokenUseCase: IssueStreamTokenUseCase) =>
     issueStreamTokenUseCase,
     jwtVerifier: noopVerifier,
     accessTokenVerifier: buildAccessTokenVerifier(),
+    sttPort: createMockSttProvider(),
+    translationPort: createMockTranslationProvider(),
   });
 
 const authHeaders = (token = VALID_ACCESS_TOKEN) => ({ authorization: `Bearer ${token}` });

--- a/packages/relay-api/src/presentation/http/security-plugins.test.ts
+++ b/packages/relay-api/src/presentation/http/security-plugins.test.ts
@@ -1,10 +1,11 @@
-import { okAsync } from 'neverthrow';
+import { ok, okAsync } from 'neverthrow';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { ok } from 'neverthrow';
 import { type FastifyInstance } from 'fastify';
 import { type AccessTokenVerifier } from '../../application/ports/access-token-verifier';
 import { type JwtVerifier } from '../../application/ports/jwt-verifier';
 import { type IssueStreamTokenUseCase } from '../../application/use-cases/issue-stream-token-use-case';
+import { createMockSttProvider } from '../../../tests/support/mock/mock-stt-provider';
+import { createMockTranslationProvider } from '../../../tests/support/mock/mock-translation-provider';
 import { buildApp, type AppDependencies } from './server';
 
 const VALID_ACCESS_TOKEN = 'access-token-test-fixture-aaaa';
@@ -46,6 +47,8 @@ const buildTestApp = (overrides: Partial<AppDependencies> = {}): FastifyInstance
     issueStreamTokenUseCase: noopUseCase,
     jwtVerifier: noopVerifier,
     accessTokenVerifier: fixedAccessTokenVerifier,
+    sttPort: createMockSttProvider(),
+    translationPort: createMockTranslationProvider(),
     ...overrides,
   });
 

--- a/packages/relay-api/src/presentation/http/server.ts
+++ b/packages/relay-api/src/presentation/http/server.ts
@@ -29,13 +29,15 @@ export type AppDependencies = Readonly<{
   accessTokenVerifier: AccessTokenVerifier;
   /**
    * STT プロバイダ。本番では Deepgram を配線する。test では mock-stt-provider
-   * を渡す (tests/support/mock)。PR G の WS wiring で使用する。
+   * を渡す (tests/support/mock)。WebSocket `/relay` の audio.frame → transcript
+   * 経路で使用するため必須。
    */
-  sttPort?: SttPort;
+  sttPort: SttPort;
   /**
-   * 翻訳プロバイダ。本番では DeepL を配線する。PR G の WS wiring で使用する。
+   * 翻訳プロバイダ。本番では DeepL を配線する。`transcript.final` → translation
+   * 経路で使用するため必須。
    */
-  translationPort?: TranslationPort;
+  translationPort: TranslationPort;
   security?: SecurityPluginConfig;
   postSessionsRateLimit?: Readonly<{ max: number; timeWindowMs: number }>;
 }>;
@@ -74,6 +76,8 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
     await wsScope.register(fastifyWebsocket);
     registerRelayRoute(wsScope, {
       jwtVerifier: deps.jwtVerifier,
+      sttPort: deps.sttPort,
+      translationPort: deps.translationPort,
       clock: () => new Date().toISOString(),
       heartbeatIntervalSec: 15,
     });

--- a/packages/relay-api/src/presentation/ws/relay-route.test.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.test.ts
@@ -5,8 +5,12 @@ import WebSocket from 'ws';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { type AccessTokenVerifier } from '../../application/ports/access-token-verifier';
 import { type JwtVerifiedPayload, type JwtVerifier } from '../../application/ports/jwt-verifier';
+import { type SttPort, type TranscriptEvent } from '../../application/ports/stt-port';
+import { type TranslationPort } from '../../application/ports/translation-port';
 import { type IssueStreamTokenUseCase } from '../../application/use-cases/issue-stream-token-use-case';
 import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { createMockSttProvider } from '../../../tests/support/mock/mock-stt-provider';
+import { createMockTranslationProvider } from '../../../tests/support/mock/mock-translation-provider';
 import { buildApp } from '../http/server';
 import { registerRelayRoute, type RelayRouteDependencies } from './relay-route';
 
@@ -57,11 +61,16 @@ const noopAccessTokenVerifier: AccessTokenVerifier = {
   verify: () => ok(undefined),
 };
 
-const startApp = async (verifier: JwtVerifier): Promise<AppHarness> => {
+const startApp = async (
+  verifier: JwtVerifier,
+  overrides: { sttPort?: SttPort; translationPort?: TranslationPort } = {},
+): Promise<AppHarness> => {
   const app = buildApp({
     issueStreamTokenUseCase: noopUseCase,
     jwtVerifier: verifier,
     accessTokenVerifier: noopAccessTokenVerifier,
+    sttPort: overrides.sttPort ?? createMockSttProvider(),
+    translationPort: overrides.translationPort ?? createMockTranslationProvider(),
   });
   await app.listen({ port: 0, host: '127.0.0.1' });
   const address = app.server.address();
@@ -355,6 +364,8 @@ describe('WebSocket /relay route', () => {
       void app.register((instance, _opts, done) => {
         registerRelayRoute(instance, {
           jwtVerifier: okVerifier,
+          sttPort: createMockSttProvider(),
+          translationPort: createMockTranslationProvider(),
           clock: () => new Date().toISOString(),
           heartbeatIntervalSec: 1,
           heartbeatCheckIntervalMs: 50,
@@ -416,6 +427,111 @@ describe('WebSocket /relay route', () => {
         await queue.next(); // consume session.pong
       }
       expect(closed).toBe(false);
+      ws.close();
+    }, 10000);
+  });
+
+  describe('IMPL-421/422 audio.frame → transcript → translation (end-to-end)', () => {
+    it('emits transcript.partial / transcript.final / translation.final via mock providers', async () => {
+      const scriptedTranscripts: TranscriptEvent[] = [
+        {
+          type: 'partial',
+          segmentId: 'seg_01',
+          revision: 1,
+          text: 'hello',
+          language: 'en',
+          startOffsetMs: 0,
+          endOffsetMs: 500,
+        },
+        {
+          type: 'final',
+          segmentId: 'seg_01',
+          text: 'hello world',
+          language: 'en',
+          startOffsetMs: 0,
+          endOffsetMs: 1000,
+          finalizedAt: '2026-04-21T00:00:00.000Z',
+        },
+      ];
+      const sttPort = createMockSttProvider({ transcripts: scriptedTranscripts });
+      const translationPort = createMockTranslationProvider({
+        translations: new Map([['hello world', 'こんにちは世界']]),
+      });
+      harness = await startApp(okVerifier, { sttPort, translationPort });
+      const ws = connectWithAuth(relayUrl(harness), 'valid.jwt');
+      const queue = createMessageQueue(ws);
+      await awaitOpen(ws);
+      await queue.next(); // session.ready
+
+      ws.send(
+        JSON.stringify({
+          eventType: 'session.start',
+          sessionId: SESSION_ID,
+          sequence: 1,
+          timestamp: new Date().toISOString(),
+          payload: {
+            sourceLanguage: 'en-US',
+            autoDetectLanguage: false,
+            targetLanguage: 'ja-JP',
+            translationEnabled: true,
+          },
+        }),
+      );
+
+      const partial = await queue.next(5000);
+      expect(partial).toMatchObject({
+        eventType: 'transcript.partial',
+        payload: { segmentId: 'seg_01', revision: 1, text: 'hello' },
+      });
+
+      const final = await queue.next(5000);
+      expect(final).toMatchObject({
+        eventType: 'transcript.final',
+        payload: { segmentId: 'seg_01', text: 'hello world' },
+      });
+
+      const translation = await queue.next(5000);
+      expect(translation).toMatchObject({
+        eventType: 'translation.final',
+        payload: {
+          sourceSegmentId: 'seg_01',
+          text: 'こんにちは世界',
+          targetLanguage: 'ja-JP',
+        },
+      });
+
+      ws.close();
+    }, 15000);
+
+    it('rejects audio.frame before session.start with SESSION_NOT_READY', async () => {
+      harness = await startApp(okVerifier);
+      const ws = connectWithAuth(relayUrl(harness), 'valid.jwt');
+      const queue = createMessageQueue(ws);
+      await awaitOpen(ws);
+      await queue.next(); // session.ready
+
+      ws.send(
+        JSON.stringify({
+          eventType: 'audio.frame',
+          sessionId: SESSION_ID,
+          sequence: 1,
+          timestamp: new Date().toISOString(),
+          payload: {
+            chunkId: 'chk_1',
+            audioBase64: 'AAAA=',
+            encoding: 'pcm_s16le',
+            sampleRateHz: 16000,
+            channels: 1,
+            frameDurationMs: 100,
+            capturedAt: new Date().toISOString(),
+          },
+        }),
+      );
+      const error = await queue.next(5000);
+      expect(error).toMatchObject({
+        eventType: 'session.error',
+        payload: { code: 'SESSION_NOT_READY' },
+      });
       ws.close();
     }, 10000);
   });

--- a/packages/relay-api/src/presentation/ws/relay-route.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.ts
@@ -1,12 +1,22 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import type { RawData, WebSocket } from 'ws';
+import { ulid } from 'ulid';
 import { type JwtVerifier } from '../../application/ports/jwt-verifier';
+import {
+  type SttPort,
+  type SttStreamHandle,
+  type TranscriptEvent,
+} from '../../application/ports/stt-port';
+import { type TranslationPort } from '../../application/ports/translation-port';
 import { toHttpErrorEnvelope } from '../http/error-mapper';
 import { parseClientEvent, type ClientEvent } from './client-events';
 import {
   buildSessionError,
   buildSessionPong,
   buildSessionReady,
+  buildTranscriptFinal,
+  buildTranscriptPartial,
+  buildTranslationFinal,
   serializeServerEvent,
   type SessionErrorCode,
 } from './server-events';
@@ -14,36 +24,27 @@ import { authorizeRelayUpgrade, type RelayAuthorizedContext } from './relay-auth
 
 export type RelayRouteDependencies = Readonly<{
   jwtVerifier: JwtVerifier;
+  sttPort: SttPort;
+  translationPort: TranslationPort;
   clock: () => string;
-  /**
-   * クライアントに伝える `session.ready.payload.heartbeatIntervalSec`。
-   * クライアントはこの間隔で `session.ping` を送信する想定 (api-spec §6.2)。
-   */
   heartbeatIntervalSec: number;
-  /**
-   * サーバー側のハートビート監視スキャン間隔 (ミリ秒)。タイムアウト判定のため
-   * `setInterval` でポーリングする。既定 5 秒。
-   */
   heartbeatCheckIntervalMs?: number;
-  /**
-   * `heartbeatIntervalSec` に対するタイムアウト倍率。既定 2 倍。
-   * 前回の受信からこの時間を超えたら接続を切断する (1001 Going Away)。
-   */
   heartbeatTimeoutFactor?: number;
+  /** audio.frame/秒 の上限 (api-spec §2.4)。既定 10。 */
+  audioFrameRateLimitPerSec?: number;
+  /** translationId 生成器 (test で deterministic に) */
+  translationIdFactory?: () => string;
 }>;
 
 const DEFAULT_HEARTBEAT_CHECK_INTERVAL_MS = 5000;
 const DEFAULT_HEARTBEAT_TIMEOUT_FACTOR = 2;
+const DEFAULT_AUDIO_FRAME_LIMIT_PER_SEC = 10;
 
 type RelayQuery = Readonly<{
   sessionId?: string;
   protocolVersion?: string;
 }>;
 
-/**
- * preValidation で確立した認可情報を handler へ渡す。request 拡張プロパティは
- * WebSocket upgrade 経路で参照が不安定なため、WeakMap で明示的に受け渡す。
- */
 const contextMap = new WeakMap<FastifyRequest, RelayAuthorizedContext>();
 
 const decodeRawMessage = (data: RawData): string => {
@@ -52,53 +53,45 @@ const decodeRawMessage = (data: RawData): string => {
   return Buffer.from(data).toString('utf8');
 };
 
-/**
- * 接続ごとの server event `sequence` 採番器。
- */
 const createSequencer = (): (() => number) => {
   let next = 0;
   return () => next++;
 };
 
 /**
- * クライアントイベントを dispatch する。MVP では session.ping のみ応答を返し、
- * それ以外は log に記録するだけ (IMPL-441/442 で mock STT/翻訳と連携する際に
- * 実処理を接続する)。
+ * 1 秒 sliding window の rate bucket。直近 windowMs (=1000) 内の timestamp を
+ * 保持し、max を超えたら reject。
  */
-const dispatchClientEvent = (
-  event: ClientEvent,
-  send: (eventJson: string) => void,
-  deps: RelayRouteDependencies,
-  context: RelayAuthorizedContext,
-  nextSequence: () => number,
-  logger: FastifyRequest['log'],
-): void => {
-  switch (event.eventType) {
-    case 'session.ping': {
-      send(
-        serializeServerEvent(
-          buildSessionPong({
-            sessionId: context.sessionId,
-            sequence: nextSequence(),
-            timestamp: deps.clock(),
-          }),
-        ),
-      );
-      return;
-    }
-    case 'session.start':
-    case 'audio.frame':
-    case 'session.pause':
-    case 'session.resume':
-    case 'session.stop': {
-      logger.debug(
-        { eventType: event.eventType, sequence: event.sequence },
-        'client event received',
-      );
-      return;
-    }
-  }
+const createRateBucket = (max: number, windowMs: number) => {
+  let timestamps: number[] = [];
+  return {
+    tryConsume: (now: number): boolean => {
+      timestamps = timestamps.filter((t) => now - t < windowMs);
+      if (timestamps.length >= max) return false;
+      timestamps.push(now);
+      return true;
+    },
+  };
 };
+
+const extractClaimString = (
+  claims: Readonly<Record<string, unknown>>,
+  key: string,
+): string | null => {
+  const value = claims[key];
+  return typeof value === 'string' ? value : null;
+};
+
+const extractClaimBoolean = (claims: Readonly<Record<string, unknown>>, key: string): boolean => {
+  const value = claims[key];
+  return typeof value === 'boolean' ? value : false;
+};
+
+type ActiveStream = Readonly<{
+  handle: SttStreamHandle;
+  targetLanguage: string;
+  sourceLanguage: string | null;
+}>;
 
 const sendSessionError = (
   socket: WebSocket,
@@ -127,23 +120,107 @@ const sendSessionError = (
   );
 };
 
+const emitTranscriptPartial = (
+  socket: WebSocket,
+  context: RelayAuthorizedContext,
+  nextSequence: () => number,
+  clock: () => string,
+  event: Extract<TranscriptEvent, { type: 'partial' }>,
+): void => {
+  socket.send(
+    serializeServerEvent(
+      buildTranscriptPartial({
+        sessionId: context.sessionId,
+        sequence: nextSequence(),
+        timestamp: clock(),
+        segmentId: event.segmentId,
+        revision: event.revision,
+        text: event.text,
+        language: event.language,
+        startOffsetMs: event.startOffsetMs,
+        endOffsetMs: event.endOffsetMs,
+      }),
+    ),
+  );
+};
+
+const emitTranscriptFinal = (
+  socket: WebSocket,
+  context: RelayAuthorizedContext,
+  nextSequence: () => number,
+  clock: () => string,
+  event: Extract<TranscriptEvent, { type: 'final' }>,
+): void => {
+  socket.send(
+    serializeServerEvent(
+      buildTranscriptFinal({
+        sessionId: context.sessionId,
+        sequence: nextSequence(),
+        timestamp: clock(),
+        segmentId: event.segmentId,
+        text: event.text,
+        language: event.language,
+        startOffsetMs: event.startOffsetMs,
+        endOffsetMs: event.endOffsetMs,
+        finalizedAt: event.finalizedAt,
+      }),
+    ),
+  );
+};
+
+const emitTranslationFinal = (
+  socket: WebSocket,
+  context: RelayAuthorizedContext,
+  nextSequence: () => number,
+  clock: () => string,
+  params: {
+    translationId: string;
+    sourceSegmentId: string;
+    text: string;
+    sourceLanguage: string | null;
+    targetLanguage: string;
+    latencyMs: number;
+  },
+): void => {
+  socket.send(
+    serializeServerEvent(
+      buildTranslationFinal({
+        sessionId: context.sessionId,
+        sequence: nextSequence(),
+        timestamp: clock(),
+        translationId: params.translationId,
+        sourceSegmentId: params.sourceSegmentId,
+        text: params.text,
+        sourceLanguage: params.sourceLanguage,
+        targetLanguage: params.targetLanguage,
+        latencyMs: params.latencyMs,
+      }),
+    ),
+  );
+};
+
 /**
- * IMPL-420 + IMPL-421 + IMPL-422 (部分) `/relay` WebSocket 接続ルート。
+ * IMPL-420/421/422/423 `/relay` WebSocket 接続ルート (完全版)。
  *
- * 対応範囲:
- * - upgrade 時認可 (JWT verify + sessionId ↔ sub 一致 + protocolVersion)
- * - `session.ready` 送信 (api-specification §6.3 準拠)
- * - client event 受信 + JSON / Zod validation
- * - `session.ping` → `session.pong` 応答
- * - 不正 payload は `session.error(VALIDATION_ERROR)` を返信 (接続は維持)
- *
- * 未対応 (後続):
- * - `session.start` / `audio.frame` に対応する STT / 翻訳 dispatch (IMPL-441/442)
- * - `pause` / `resume` / `stop` の session state 連携
- * - `transcript.*` / `translation.final` サーバーイベント生成 (IMPL-441/442)
- * - heartbeat (IMPL-423)
+ * 流れ:
+ * 1. HTTP upgrade 時に preValidation で stream token を検証 (IMPL-420)
+ * 2. `session.ready` 送信 (IMPL-422)
+ * 3. ハートビート監視開始 (IMPL-423)
+ * 4. `session.start` → SttPort.openStream、transcript event async loop を起動
+ *    (IMPL-421)
+ * 5. `audio.frame` → rate bucket (10/sec) + sendFrame (IMPL-402)
+ * 6. STT の partial → `transcript.partial` を client へ、final →
+ *    `transcript.final` + 並行して TranslationPort.translate → `translation.final`
+ *    送信 (IMPL-422 + IMPL-403)
+ * 7. `session.ping` → `session.pong` (IMPL-421)
+ * 8. `session.stop` → SttStreamHandle.close、接続を graceful close
+ * 9. `session.pause` / `session.resume`: MVP では log のみ (Deepgram は
+ *    stream pause 非対応、session state は client 側管理)
  */
 export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDependencies): void => {
+  const audioFrameLimit = deps.audioFrameRateLimitPerSec ?? DEFAULT_AUDIO_FRAME_LIMIT_PER_SEC;
+  const translationIdFactory = deps.translationIdFactory ?? (() => ulid());
+
   app.get<{ Querystring: RelayQuery }>(
     '/relay',
     {
@@ -187,8 +264,7 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
         ),
       );
 
-      // IMPL-423 ハートビート監視。前回の受信から
-      // heartbeatIntervalSec * heartbeatTimeoutFactor を超えたら切断。
+      // ハートビート監視
       const timeoutMs =
         deps.heartbeatIntervalSec *
         (deps.heartbeatTimeoutFactor ?? DEFAULT_HEARTBEAT_TIMEOUT_FACTOR) *
@@ -206,11 +282,186 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
       }, checkIntervalMs);
       heartbeatTimer.unref();
 
+      // per-connection state
+      let activeStream: ActiveStream | null = null;
+      const audioFrameBucket = createRateBucket(audioFrameLimit, 1000);
+
+      const closeActiveStream = (): void => {
+        if (activeStream === null) return;
+        const handle = activeStream.handle;
+        activeStream = null;
+        void handle.close().match(
+          () => undefined,
+          (err) => {
+            request.log.warn({ err }, 'stt handle close failed');
+          },
+        );
+      };
+
       const cleanup = (): void => {
         clearInterval(heartbeatTimer);
+        closeActiveStream();
       };
       socket.on('close', cleanup);
       socket.on('error', cleanup);
+
+      /**
+       * STT transcript events を subscribe し、partial / final を client へ emit。
+       * final が来たら TranslationPort へ投げ、成功した translation.final を
+       * 送信 (失敗は log.warn、接続は維持)。
+       */
+      const runTranscriptLoop = (stream: ActiveStream): void => {
+        void (async () => {
+          for await (const event of stream.handle.events) {
+            try {
+              if (event.type === 'partial') {
+                emitTranscriptPartial(socket, context, nextSequence, deps.clock, event);
+                continue;
+              }
+              emitTranscriptFinal(socket, context, nextSequence, deps.clock, event);
+              // 翻訳は fire-and-forget (ホットパス翻訳、結果は translation.final で送信)
+              void (async () => {
+                const translationResult = await deps.translationPort.translate({
+                  text: event.text,
+                  sourceLanguage: stream.sourceLanguage,
+                  targetLanguage: stream.targetLanguage,
+                });
+                if (translationResult.isErr()) {
+                  request.log.warn(
+                    { err: translationResult.error, segmentId: event.segmentId },
+                    'translation failed — skipping translation.final',
+                  );
+                  return;
+                }
+                emitTranslationFinal(socket, context, nextSequence, deps.clock, {
+                  translationId: translationIdFactory(),
+                  sourceSegmentId: event.segmentId,
+                  text: translationResult.value.text,
+                  sourceLanguage: translationResult.value.detectedSourceLanguage,
+                  targetLanguage: stream.targetLanguage,
+                  latencyMs: translationResult.value.latencyMs,
+                });
+              })();
+            } catch (cause) {
+              request.log.error({ err: cause }, 'transcript loop iteration failed');
+            }
+          }
+        })();
+      };
+
+      const handleSessionStart = (
+        event: Extract<ClientEvent, { eventType: 'session.start' }>,
+      ): void => {
+        if (activeStream !== null) {
+          sendSessionError(socket, context, nextSequence, deps.clock, {
+            code: 'INVALID_STATE_TRANSITION',
+            message: 'session.start received while stream is already active',
+            retryable: false,
+            fatal: false,
+          });
+          return;
+        }
+        // JWT claims / session.start payload どちらからも language を決定
+        const sourceLanguage =
+          event.payload.sourceLanguage ??
+          extractClaimString(context.tokenPayload.claims, 'sourceLanguage');
+        const autoDetectLanguage =
+          event.payload.autoDetectLanguage ||
+          extractClaimBoolean(context.tokenPayload.claims, 'autoDetectLanguage');
+        const targetLanguage = event.payload.targetLanguage;
+        void deps.sttPort
+          .openStream({
+            sourceLanguage: autoDetectLanguage ? null : sourceLanguage,
+            autoDetectLanguage,
+          })
+          .match(
+            (handle) => {
+              const stream: ActiveStream = {
+                handle,
+                targetLanguage,
+                sourceLanguage: autoDetectLanguage ? null : sourceLanguage,
+              };
+              activeStream = stream;
+              runTranscriptLoop(stream);
+            },
+            (err) => {
+              request.log.error({ err }, 'stt openStream failed');
+              sendSessionError(socket, context, nextSequence, deps.clock, {
+                code: 'STT_ERROR',
+                message: 'failed to open STT stream',
+                retryable: true,
+                fatal: false,
+              });
+            },
+          );
+      };
+
+      const handleAudioFrame = (
+        event: Extract<ClientEvent, { eventType: 'audio.frame' }>,
+      ): void => {
+        if (activeStream === null) {
+          sendSessionError(socket, context, nextSequence, deps.clock, {
+            code: 'SESSION_NOT_READY',
+            message: 'audio.frame received before session.start',
+            retryable: false,
+            fatal: false,
+          });
+          return;
+        }
+        if (!audioFrameBucket.tryConsume(Date.now())) {
+          sendSessionError(socket, context, nextSequence, deps.clock, {
+            code: 'RATE_LIMIT_EXCEEDED',
+            message: `audio.frame rate limit exceeded (${String(audioFrameLimit)}/sec)`,
+            retryable: true,
+            fatal: false,
+          });
+          return;
+        }
+        const result = activeStream.handle.sendFrame({
+          audioBase64: event.payload.audioBase64,
+          chunkId: event.payload.chunkId,
+        });
+        if (result.isErr()) {
+          request.log.warn({ err: result.error }, 'stt sendFrame failed');
+        }
+      };
+
+      const handleSessionStop = (): void => {
+        closeActiveStream();
+      };
+
+      const dispatchClientEvent = (event: ClientEvent): void => {
+        switch (event.eventType) {
+          case 'session.ping':
+            socket.send(
+              serializeServerEvent(
+                buildSessionPong({
+                  sessionId: context.sessionId,
+                  sequence: nextSequence(),
+                  timestamp: deps.clock(),
+                }),
+              ),
+            );
+            return;
+          case 'session.start':
+            handleSessionStart(event);
+            return;
+          case 'audio.frame':
+            handleAudioFrame(event);
+            return;
+          case 'session.stop':
+            handleSessionStop();
+            return;
+          case 'session.pause':
+          case 'session.resume':
+            // MVP: log のみ。Deepgram は stream pause 非対応のため再接続で代替
+            request.log.debug(
+              { eventType: event.eventType, sequence: event.sequence },
+              'pause/resume event received (no-op in MVP)',
+            );
+            return;
+        }
+      };
 
       socket.on('message', (raw: RawData) => {
         lastActivityMs = Date.now();
@@ -228,14 +479,7 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
           return;
         }
         try {
-          dispatchClientEvent(
-            parsed.value,
-            (json) => socket.send(json),
-            deps,
-            context,
-            nextSequence,
-            request.log,
-          );
+          dispatchClientEvent(parsed.value);
         } catch (cause) {
           request.log.error({ err: cause }, 'dispatch failure');
           sendSessionError(socket, context, nextSequence, deps.clock, {

--- a/packages/relay-api/src/presentation/ws/server-events.ts
+++ b/packages/relay-api/src/presentation/ws/server-events.ts
@@ -65,6 +65,108 @@ export const buildSessionPong = (params: {
   payload: {},
 });
 
+export type TranscriptPartialPayload = Readonly<{
+  segmentId: string;
+  revision: number;
+  text: string;
+  language: string | null;
+  startOffsetMs: number;
+  endOffsetMs: number;
+}>;
+
+export const buildTranscriptPartial = (params: {
+  sessionId: string;
+  sequence: number;
+  timestamp: string;
+  segmentId: string;
+  revision: number;
+  text: string;
+  language: string | null;
+  startOffsetMs: number;
+  endOffsetMs: number;
+}): ServerEventEnvelope => ({
+  eventType: 'transcript.partial',
+  sessionId: params.sessionId,
+  sequence: params.sequence,
+  timestamp: params.timestamp,
+  payload: {
+    segmentId: params.segmentId,
+    revision: params.revision,
+    text: params.text,
+    language: params.language,
+    startOffsetMs: params.startOffsetMs,
+    endOffsetMs: params.endOffsetMs,
+  } satisfies TranscriptPartialPayload,
+});
+
+export type TranscriptFinalPayload = Readonly<{
+  segmentId: string;
+  text: string;
+  language: string | null;
+  startOffsetMs: number;
+  endOffsetMs: number;
+  finalizedAt: string;
+}>;
+
+export const buildTranscriptFinal = (params: {
+  sessionId: string;
+  sequence: number;
+  timestamp: string;
+  segmentId: string;
+  text: string;
+  language: string | null;
+  startOffsetMs: number;
+  endOffsetMs: number;
+  finalizedAt: string;
+}): ServerEventEnvelope => ({
+  eventType: 'transcript.final',
+  sessionId: params.sessionId,
+  sequence: params.sequence,
+  timestamp: params.timestamp,
+  payload: {
+    segmentId: params.segmentId,
+    text: params.text,
+    language: params.language,
+    startOffsetMs: params.startOffsetMs,
+    endOffsetMs: params.endOffsetMs,
+    finalizedAt: params.finalizedAt,
+  } satisfies TranscriptFinalPayload,
+});
+
+export type TranslationFinalPayload = Readonly<{
+  translationId: string;
+  sourceSegmentId: string;
+  text: string;
+  sourceLanguage: string | null;
+  targetLanguage: string;
+  latencyMs: number;
+}>;
+
+export const buildTranslationFinal = (params: {
+  sessionId: string;
+  sequence: number;
+  timestamp: string;
+  translationId: string;
+  sourceSegmentId: string;
+  text: string;
+  sourceLanguage: string | null;
+  targetLanguage: string;
+  latencyMs: number;
+}): ServerEventEnvelope => ({
+  eventType: 'translation.final',
+  sessionId: params.sessionId,
+  sequence: params.sequence,
+  timestamp: params.timestamp,
+  payload: {
+    translationId: params.translationId,
+    sourceSegmentId: params.sourceSegmentId,
+    text: params.text,
+    sourceLanguage: params.sourceLanguage,
+    targetLanguage: params.targetLanguage,
+    latencyMs: params.latencyMs,
+  } satisfies TranslationFinalPayload,
+});
+
 export type SessionErrorCode =
   | 'VALIDATION_ERROR'
   | 'INVALID_STATE_TRANSITION'

--- a/packages/relay-api/tests/smoke.test.ts
+++ b/packages/relay-api/tests/smoke.test.ts
@@ -4,6 +4,8 @@ import { type AccessTokenVerifier } from '../src/application/ports/access-token-
 import { type JwtVerifier } from '../src/application/ports/jwt-verifier';
 import { type IssueStreamTokenUseCase } from '../src/application/use-cases/issue-stream-token-use-case';
 import { buildApp } from '../src/presentation/http/server';
+import { createMockSttProvider } from './support/mock/mock-stt-provider';
+import { createMockTranslationProvider } from './support/mock/mock-translation-provider';
 
 const noopUseCase: IssueStreamTokenUseCase = () =>
   okAsync({
@@ -41,6 +43,8 @@ const app = buildApp({
   issueStreamTokenUseCase: noopUseCase,
   jwtVerifier: noopVerifier,
   accessTokenVerifier: noopAccessTokenVerifier,
+  sttPort: createMockSttProvider(),
+  translationPort: createMockTranslationProvider(),
 });
 
 afterAll(async () => {


### PR DESCRIPTION
## Summary

Phase 4 Relay API の**最終ピース**。WebSocket 接続で `audio.frame` を受け取り、`SttPort` → `TranslationPort` を経由して `transcript.partial` / `transcript.final` / `translation.final` を client に配信する完全経路を接続する。

## server-events.ts 拡張

- `buildTranscriptPartial`: api-spec §6.3 準拠の payload (`segmentId` / `revision` / `text` / `language` / `startOffsetMs` / `endOffsetMs`)
- `buildTranscriptFinal`: 上記 + `finalizedAt`
- `buildTranslationFinal`: `translationId` / `sourceSegmentId` / `text` / `sourceLanguage` / `targetLanguage` / `latencyMs`

## relay-route.ts 完全版

- `session.start`: `SttPort.openStream` で stream を開き connection-scoped map に保持。transcript event async iterator を起動し、partial/final を client 送信
- `transcript.final` 後は**非同期で** `TranslationPort.translate` を呼び、成功時 `translation.final` を client 送信 (翻訳失敗は `log.warn`、接続は維持)
- `audio.frame`: per-session sliding window rate bucket (10/sec、api-spec §2.4)。超過は `RATE_LIMIT_EXCEEDED` で client に通知
- `audio.frame` が `session.start` より前に来た場合は `SESSION_NOT_READY` 返信
- `session.stop`: `SttStreamHandle.close` で graceful close
- `session.pause` / `resume`: MVP では log のみ (Deepgram は pause 非対応)
- cleanup on socket close/error で heartbeat timer + stream handle 解放

## AppDependencies

- `sttPort` / `translationPort` を required に変更 (PR F で追加したものを必須化)
- 全 test は `tests/support/mock/` の providers を注入

## Test plan

- [x] `pnpm check` 完全通過 (fmt / lint / typecheck / 184 relay-api tests + 593 extension tests)
- [x] audio.frame → transcript.partial / transcript.final / translation.final の完全経路 (mock stt + mock translation で scripted event / 辞書ベース翻訳)
- [x] audio.frame before session.start で `SESSION_NOT_READY`

## Phase 4 Relay API 完了

これで Phase 4 Relay API 全 IMPL タスクが揃った:
- IMPL-400 RelaySession aggregate ✅
- IMPL-401 IssueStreamTokenUseCase ✅ (stateless refactored)
- IMPL-402 RelayAudioFrameUseCase ✅
- IMPL-403 RouteTranscriptToTranslationUseCase ✅
- IMPL-411 POST /sessions ✅
- IMPL-412 GET /sessions/:id ✅
- IMPL-420 WebSocket /relay 接続 ✅
- IMPL-421 client events (session.start / audio.frame / pause / resume / stop / ping) ✅
- IMPL-422 server events (session.ready / transcript.* / translation.final / session.error / session.pong) ✅
- IMPL-423 heartbeat ✅
- IMPL-430 HTTP access token Bearer 認証 ✅
- IMPL-431 JwtSigner + JwtVerifier (jose HS256) ✅
- IMPL-432 rate-limit ✅
- IMPL-433 CORS ✅
- IMPL-434 Helmet ✅
- IMPL-440 SttPort interface ✅
- IMPL-441 TranslationPort interface ✅
- IMPL-442 MockSttProvider (tests/support/mock) ✅
- IMPL-443 MockTranslationProvider (tests/support/mock) ✅
- IMPL-444 StreamingSttProviderAdapter (Deepgram) ✅
- IMPL-445 TranslationProviderAdapter (DeepL) ✅
- IMPL-446 resilience utils (circuit-breaker / retry / timeout) ✅
- IMPL-450 pino redact 検証 ✅
- IMPL-451 structured logging ✅

## Mock / in-memory 回避設計 (再確認)

- 全ての production wiring は env 変数から必須シークレットを読み込み、未設定なら fail-fast で `throw`
- Mock provider は `tests/support/mock/` に隔離、ESLint `no-restricted-imports` で `src/` からの import 禁止
- stateless JWT-only でセッションストアを排除 (PR #30 の refactor)