### PR TITLE
feat(extension): IMPL-140〜143 domain repository infrastructure adapters

### DIFF
--- a/packages/extension/src/infrastructure/storage/chrome-local-extension-profile-repository.test.ts
+++ b/packages/extension/src/infrastructure/storage/chrome-local-extension-profile-repository.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createExtensionProfile } from '../../domain/profile/extension-profile';
+import { createOverlaySettings } from '../../domain/profile/overlay-settings';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import { type ChromeStorageAdapter } from './chrome-local-settings-store';
+import { createChromeLocalExtensionProfileRepository } from './chrome-local-extension-profile-repository';
+
+const PROFILE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
+
+const createFakeStorage = (): ChromeStorageAdapter => {
+  const store = new Map<string, unknown>();
+  return {
+    get: (keys) => {
+      const result: Record<string, unknown> = {};
+      for (const key of keys) {
+        if (store.has(key)) result[key] = store.get(key);
+      }
+      return Promise.resolve(result);
+    },
+    set: (items) => {
+      for (const [key, value] of Object.entries(items)) {
+        store.set(key, value);
+      }
+      return Promise.resolve();
+    },
+  };
+};
+
+const buildProfile = () =>
+  createExtensionProfile({
+    profileIdentifier: PROFILE_ID,
+    defaultLanguagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    defaultOverlaySettings: createOverlaySettings({
+      positionPreset: 'bottom',
+      opacity: 0.8,
+      maxLines: 2,
+      fontScale: 1,
+      showOriginalText: true,
+      showTranslatedText: true,
+    })._unsafeUnwrap(),
+    autoDetectEnabled: false,
+  })._unsafeUnwrap();
+
+describe('createChromeLocalExtensionProfileRepository (IMPL-142, DD-262 / DD-107)', () => {
+  let storage: ChromeStorageAdapter;
+
+  beforeEach(() => {
+    storage = createFakeStorage();
+  });
+
+  describe('getDefault', () => {
+    it('returns notFound when storage is empty', async () => {
+      const repo = createChromeLocalExtensionProfileRepository(storage);
+      const result = await repo.getDefault();
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe('not-found');
+        if (result.error.kind === 'not-found') {
+          expect(result.error.resourceType).toBe('ExtensionProfile');
+          expect(result.error.identifier).toBe('default');
+        }
+      }
+    });
+
+    it('returns notFound when profile identifier key is missing but other keys exist', async () => {
+      await storage.set({
+        'settings.language.defaultLanguagePair': { source: 'en-US', target: 'ja-JP' },
+        'settings.overlay.defaultOverlaySettings': {
+          positionPreset: 'bottom',
+          opacity: 0.8,
+          maxLines: 2,
+          fontScale: 1,
+          showOriginalText: true,
+          showTranslatedText: true,
+        },
+        'settings.language.autoDetectEnabled': false,
+      });
+      const repo = createChromeLocalExtensionProfileRepository(storage);
+      const result = await repo.getDefault();
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) expect(result.error.kind).toBe('not-found');
+    });
+  });
+
+  describe('save + getDefault round trip', () => {
+    it('persists and retrieves the aggregate', async () => {
+      const repo = createChromeLocalExtensionProfileRepository(storage);
+      const profile = buildProfile();
+      const saveResult = await repo.save(profile);
+      expect(saveResult.isOk()).toBe(true);
+
+      const getResult = await repo.getDefault();
+      expect(getResult.isOk()).toBe(true);
+      if (getResult.isOk()) {
+        expect(getResult.value.profileIdentifier).toBe(PROFILE_ID);
+        expect(getResult.value.defaultLanguagePair.source).toBe('en-US');
+        expect(getResult.value.defaultLanguagePair.target).toBe('ja-JP');
+        expect(getResult.value.defaultOverlaySettings.opacity).toBe(0.8);
+        expect(getResult.value.autoDetectEnabled).toBe(false);
+      }
+    });
+
+    it('upserts when save is called twice', async () => {
+      const repo = createChromeLocalExtensionProfileRepository(storage);
+      await repo.save(buildProfile());
+
+      const updated = createExtensionProfile({
+        profileIdentifier: PROFILE_ID,
+        defaultLanguagePair: createLanguagePair({
+          source: 'en-US',
+          target: 'ja-JP',
+        })._unsafeUnwrap(),
+        defaultOverlaySettings: createOverlaySettings({
+          positionPreset: 'top',
+          opacity: 0.5,
+          maxLines: 3,
+          fontScale: 1.2,
+          showOriginalText: false,
+          showTranslatedText: true,
+        })._unsafeUnwrap(),
+        autoDetectEnabled: true,
+      })._unsafeUnwrap();
+      await repo.save(updated);
+
+      const result = await repo.getDefault();
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.defaultOverlaySettings.positionPreset).toBe('top');
+        expect(result.value.defaultOverlaySettings.maxLines).toBe(3);
+        expect(result.value.autoDetectEnabled).toBe(true);
+      }
+    });
+  });
+
+  describe('interop with ChromeLocalSettingsStore keys', () => {
+    it('writes keys that ChromeLocalSettingsStore can read back', async () => {
+      const repo = createChromeLocalExtensionProfileRepository(storage);
+      await repo.save(buildProfile());
+      // Verify the individual keys are present in the same shape
+      // ChromeLocalSettingsStore expects.
+      const raw = await storage.get([
+        'settings.language.defaultLanguagePair',
+        'settings.overlay.defaultOverlaySettings',
+        'settings.language.autoDetectEnabled',
+        'settings.profile.identifier',
+      ]);
+      expect(raw['settings.language.defaultLanguagePair']).toEqual({
+        source: 'en-US',
+        target: 'ja-JP',
+      });
+      expect(raw['settings.language.autoDetectEnabled']).toBe(false);
+      expect(raw['settings.profile.identifier']).toBe(PROFILE_ID);
+      expect(raw['settings.overlay.defaultOverlaySettings']).toMatchObject({
+        positionPreset: 'bottom',
+        opacity: 0.8,
+      });
+    });
+  });
+});

--- a/packages/extension/src/infrastructure/storage/chrome-local-extension-profile-repository.ts
+++ b/packages/extension/src/infrastructure/storage/chrome-local-extension-profile-repository.ts
@@ -1,0 +1,127 @@
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+import {
+  createExtensionProfile,
+  type ExtensionProfile,
+} from '../../domain/profile/extension-profile';
+import { createOverlaySettings } from '../../domain/profile/overlay-settings';
+import { type ExtensionProfileRepository } from '../../domain/repositories/extension-profile-repository';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import {
+  invariantViolationError,
+  notFoundError,
+  type DomainError,
+} from '../../domain/shared/errors';
+import { type ChromeStorageAdapter } from './chrome-local-settings-store';
+
+/**
+ * Profile aggregate を chrome.storage.local の flat key 群にマッピングする際の
+ * キー定数。既存 `ChromeLocalSettingsStore` が使用するキーと一致させることで、
+ * settings-level API (個別フィールド単位) と profile-level API (aggregate 単位)
+ * が同一データを読み書きする (DD-107)。
+ *
+ * `settings.profile.identifier` のみ profile repository 固有。
+ */
+const LANGUAGE_KEY = 'settings.language.defaultLanguagePair';
+const OVERLAY_KEY = 'settings.overlay.defaultOverlaySettings';
+const AUTO_DETECT_KEY = 'settings.language.autoDetectEnabled';
+const PROFILE_ID_KEY = 'settings.profile.identifier';
+
+const REQUIRED_KEYS = [LANGUAGE_KEY, OVERLAY_KEY, AUTO_DETECT_KEY, PROFILE_ID_KEY] as const;
+
+const toPersistenceError =
+  (scope: string) =>
+  (cause: unknown): DomainError =>
+    invariantViolationError({
+      invariant: 'profile-persistence',
+      details: `${scope}: ${cause instanceof Error ? cause.message : 'unknown error'}`,
+    });
+
+/**
+ * IMPL-142 ChromeLocalExtensionProfileRepository (DD-262, DD-107, DB-005)。
+ *
+ * `ExtensionProfile` 集約を `chrome.storage.local` に単一プロファイル
+ * (シングルトン "default") として永続化する adapter。MVP では profile は 1 つ
+ * のみ想定 (`getDefault` / `save` のみ公開、複数プロファイル運用は Phase 6 以降)。
+ *
+ * 既存 `ChromeLocalSettingsStore` と同じ key 体系を再利用するため、片方で
+ * 書いた値をもう片方で読むことができる (settings-level の個別更新と
+ * profile-level の aggregate 更新の両立)。
+ *
+ * エラー:
+ * - いずれかの必須キー不在: `notFoundError({ resourceType: 'ExtensionProfile', identifier: 'default' })`
+ * - Zod バリデーション失敗 (domain 値オブジェクト factory 経由): propagate
+ * - chrome.storage I/O 失敗: `invariantViolationError({ invariant: 'profile-persistence' })`
+ */
+export const createChromeLocalExtensionProfileRepository = (
+  adapter: ChromeStorageAdapter,
+): ExtensionProfileRepository => ({
+  getDefault: () =>
+    ResultAsync.fromPromise(
+      adapter.get([...REQUIRED_KEYS]),
+      toPersistenceError('getDefault'),
+    ).andThen((raw): ResultAsync<ExtensionProfile, DomainError> => {
+      const missing = REQUIRED_KEYS.some((key) => raw[key] === undefined);
+      if (missing) {
+        return errAsync<ExtensionProfile, DomainError>(
+          notFoundError({ resourceType: 'ExtensionProfile', identifier: 'default' }),
+        );
+      }
+      const languageResult = createLanguagePair(raw[LANGUAGE_KEY]);
+      if (languageResult.isErr()) {
+        return errAsync<ExtensionProfile, DomainError>(languageResult.error);
+      }
+      const overlayResult = createOverlaySettings(raw[OVERLAY_KEY]);
+      if (overlayResult.isErr()) {
+        return errAsync<ExtensionProfile, DomainError>(overlayResult.error);
+      }
+      const autoDetect = raw[AUTO_DETECT_KEY];
+      if (typeof autoDetect !== 'boolean') {
+        return errAsync<ExtensionProfile, DomainError>(
+          invariantViolationError({
+            invariant: 'profile-persistence',
+            details: `${AUTO_DETECT_KEY} must be boolean`,
+          }),
+        );
+      }
+      const profileId = raw[PROFILE_ID_KEY];
+      if (typeof profileId !== 'string') {
+        return errAsync<ExtensionProfile, DomainError>(
+          invariantViolationError({
+            invariant: 'profile-persistence',
+            details: `${PROFILE_ID_KEY} must be string`,
+          }),
+        );
+      }
+      const profileResult = createExtensionProfile({
+        profileIdentifier: profileId,
+        defaultLanguagePair: languageResult.value,
+        defaultOverlaySettings: overlayResult.value,
+        autoDetectEnabled: autoDetect,
+      });
+      if (profileResult.isErr()) {
+        return errAsync<ExtensionProfile, DomainError>(profileResult.error);
+      }
+      return okAsync<ExtensionProfile, DomainError>(profileResult.value);
+    }),
+
+  save: (profile) =>
+    ResultAsync.fromPromise(
+      adapter.set({
+        [PROFILE_ID_KEY]: profile.profileIdentifier,
+        [LANGUAGE_KEY]: {
+          source: profile.defaultLanguagePair.source,
+          target: profile.defaultLanguagePair.target,
+        },
+        [OVERLAY_KEY]: {
+          positionPreset: profile.defaultOverlaySettings.positionPreset,
+          opacity: profile.defaultOverlaySettings.opacity,
+          maxLines: profile.defaultOverlaySettings.maxLines,
+          fontScale: profile.defaultOverlaySettings.fontScale,
+          showOriginalText: profile.defaultOverlaySettings.showOriginalText,
+          showTranslatedText: profile.defaultOverlaySettings.showTranslatedText,
+        },
+        [AUTO_DETECT_KEY]: profile.autoDetectEnabled,
+      }),
+      toPersistenceError('save'),
+    ),
+});

--- a/packages/extension/src/infrastructure/storage/index.ts
+++ b/packages/extension/src/infrastructure/storage/index.ts
@@ -1,11 +1,36 @@
-export { createChromeLocalSettingsStore, describeDomainError } from './chrome-local-settings-store';
+export {
+  createChromeLocalSettingsStore,
+  defaultChromeStorageAdapter,
+  describeDomainError,
+  type ChromeStorageAdapter,
+} from './chrome-local-settings-store';
+export { createChromeLocalExtensionProfileRepository } from './chrome-local-extension-profile-repository';
+export {
+  createIndexedDbExportRecordRepository,
+  type CloseableExportRecordRepository,
+  type IndexedDbExportRecordRepositoryOptions,
+} from './indexed-db-export-record-repository';
 export {
   createIndexedDbSessionStore,
-  INDEXED_DB_NAME,
-  INDEXED_DB_VERSION,
   type CloseableSessionStore,
   type IndexedDbSessionStoreOptions,
 } from './indexed-db-session-store';
+export {
+  createIndexedDbSourceSessionRepository,
+  type CloseableSourceSessionRepository,
+  type IndexedDbSourceSessionRepositoryOptions,
+} from './indexed-db-source-session-repository';
+export {
+  createIndexedDbTranscriptStreamRepository,
+  type CloseableTranscriptStreamRepository,
+  type IndexedDbTranscriptStreamRepositoryOptions,
+} from './indexed-db-transcript-stream-repository';
+export {
+  INDEXED_DB_NAME,
+  INDEXED_DB_VERSION,
+  type PeraperaDbHandle,
+  type PeraperaSchema,
+} from './open-perapera-db';
 export {
   exportRecordFromRecord,
   exportRecordToRecord,
@@ -20,3 +45,4 @@ export {
   type TranscriptSegmentRow,
   type TranslationSegmentRow,
 } from './records';
+export { assembleTranscriptStream } from './transcript-stream-assembler';

--- a/packages/extension/src/infrastructure/storage/indexed-db-export-record-repository.test.ts
+++ b/packages/extension/src/infrastructure/storage/indexed-db-export-record-repository.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createExportRecord, type ExportRecord } from '../../domain/export/export-record';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { INDEXED_DB_NAME } from './open-perapera-db';
+import {
+  createIndexedDbExportRecordRepository,
+  type CloseableExportRecordRepository,
+} from './indexed-db-export-record-repository';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const OTHER_SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+const EXPORT_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7F1';
+const EXPORT_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7F2';
+const EXPORT_ID_3 = '01HZX8Y1R8M7D3Q2P4T5V6W7F3';
+
+const identifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+const otherIdentifier: SessionIdentifier = parseSessionIdentifier(OTHER_SESSION_ID)._unsafeUnwrap();
+
+const buildRecord = (
+  exportId: string,
+  sessionId: string = SESSION_ID,
+  format: 'txt' | 'json' = 'txt',
+  createdAt = '2026-04-21T00:00:00.000Z',
+): ExportRecord =>
+  createExportRecord({
+    exportIdentifier: exportId,
+    sessionIdentifier: sessionId,
+    format,
+    includeOriginal: true,
+    includeTranslation: true,
+    createdAt,
+  })._unsafeUnwrap();
+
+describe('createIndexedDbExportRecordRepository (IMPL-143, DD-263)', () => {
+  let repo: CloseableExportRecordRepository;
+  let databaseName: string;
+
+  beforeEach(() => {
+    databaseName = `${INDEXED_DB_NAME}-test-${String(Math.random()).slice(2)}`;
+    repo = createIndexedDbExportRecordRepository({ databaseName });
+  });
+
+  afterEach(async () => {
+    await repo.close();
+  });
+
+  describe('save', () => {
+    it('persists a new export record', async () => {
+      const result = await repo.save(buildRecord(EXPORT_ID_1));
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('upserts on identical exportIdentifier', async () => {
+      await repo.save(buildRecord(EXPORT_ID_1, SESSION_ID, 'txt'));
+      const updated = buildRecord(EXPORT_ID_1, SESSION_ID, 'json');
+      const result = await repo.save(updated);
+      expect(result.isOk()).toBe(true);
+
+      const lookup = await repo.findBySessionId(identifier);
+      expect(lookup.isOk()).toBe(true);
+      if (lookup.isOk()) {
+        expect(lookup.value.length).toBe(1);
+        expect(lookup.value[0]?.format).toBe('json');
+      }
+    });
+  });
+
+  describe('findBySessionId', () => {
+    it('returns ok([]) when the session has no export records', async () => {
+      const result = await repo.findBySessionId(identifier);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toEqual([]);
+      }
+    });
+
+    it('returns all records for the session', async () => {
+      await repo.save(buildRecord(EXPORT_ID_1, SESSION_ID, 'txt', '2026-04-21T00:00:00.000Z'));
+      await repo.save(buildRecord(EXPORT_ID_2, SESSION_ID, 'json', '2026-04-21T00:05:00.000Z'));
+      await repo.save(buildRecord(EXPORT_ID_3, OTHER_SESSION_ID, 'txt'));
+
+      const result = await repo.findBySessionId(identifier);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const ids = result.value.map((record) => record.exportIdentifier).sort();
+        expect(ids).toEqual([EXPORT_ID_1, EXPORT_ID_2].sort());
+      }
+    });
+
+    it('isolates records by sessionId', async () => {
+      await repo.save(buildRecord(EXPORT_ID_1, SESSION_ID));
+      await repo.save(buildRecord(EXPORT_ID_3, OTHER_SESSION_ID));
+
+      const a = await repo.findBySessionId(identifier);
+      const b = await repo.findBySessionId(otherIdentifier);
+      expect(a.isOk() && a.value.length).toBe(1);
+      expect(b.isOk() && b.value.length).toBe(1);
+    });
+  });
+});

--- a/packages/extension/src/infrastructure/storage/indexed-db-export-record-repository.ts
+++ b/packages/extension/src/infrastructure/storage/indexed-db-export-record-repository.ts
@@ -1,0 +1,76 @@
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+import { type ExportRecord } from '../../domain/export/export-record';
+import { type ExportRecordRepository } from '../../domain/repositories/export-record-repository';
+import { type DomainError, invariantViolationError } from '../../domain/shared/errors';
+import { EXPORT_STORE, INDEXED_DB_NAME, createPeraperaDbHandle } from './open-perapera-db';
+import { exportRecordFromRecord, exportRecordToRecord } from './records';
+
+/**
+ * 拡張インタフェース。`ExportRecordRepository` に加えてテスト cleanup や
+ * Service Worker シャットダウン用の `close()` を公開する。
+ */
+export type CloseableExportRecordRepository = ExportRecordRepository & {
+  close: () => Promise<void>;
+};
+
+export type IndexedDbExportRecordRepositoryOptions = Readonly<{
+  /** Override for tests. Production should omit to use the default. */
+  databaseName?: string;
+}>;
+
+const toPersistenceError =
+  (scope: string) =>
+  (cause: unknown): DomainError =>
+    invariantViolationError({
+      invariant: 'export-persistence',
+      details: `${scope}: ${cause instanceof Error ? cause.message : 'unknown error'}`,
+    });
+
+/**
+ * IMPL-143 IndexedDbExportRecordRepository (DD-263, DB-004)。
+ *
+ * `export_records` object store を介した `ExportRecord` エンティティの
+ * 永続化 adapter。`by-sessionId` index で検索する。
+ *
+ * - `save`: upsert。失敗は `invariantViolationError({ invariant: 'export-persistence' })`
+ * - `findBySessionId`: `by-sessionId` index で全行取得。0 件は `ok([])`
+ *   (`ExportRecordRepository.findBySessionId` の契約 — 空履歴は正常)
+ */
+export const createIndexedDbExportRecordRepository = (
+  options: IndexedDbExportRecordRepositoryOptions = {},
+): CloseableExportRecordRepository => {
+  const databaseName = options.databaseName ?? INDEXED_DB_NAME;
+  const handle = createPeraperaDbHandle(databaseName);
+
+  return {
+    save: (record) =>
+      ResultAsync.fromPromise(
+        (async () => {
+          const connection = await handle.get();
+          await connection.put(EXPORT_STORE, exportRecordToRecord(record));
+        })(),
+        toPersistenceError('save'),
+      ),
+
+    findBySessionId: (sessionIdentifier) =>
+      ResultAsync.fromPromise(
+        (async () => {
+          const connection = await handle.get();
+          return connection.getAllFromIndex(EXPORT_STORE, 'by-sessionId', sessionIdentifier);
+        })(),
+        toPersistenceError('findBySessionId'),
+      ).andThen((rows): ResultAsync<readonly ExportRecord[], DomainError> => {
+        const records: ExportRecord[] = [];
+        for (const row of rows) {
+          const parsed = exportRecordFromRecord(row);
+          if (parsed.isErr()) {
+            return errAsync<readonly ExportRecord[], DomainError>(parsed.error);
+          }
+          records.push(parsed.value);
+        }
+        return okAsync<readonly ExportRecord[], DomainError>(records);
+      }),
+
+    close: handle.close,
+  };
+};

--- a/packages/extension/src/infrastructure/storage/indexed-db-session-store.ts
+++ b/packages/extension/src/infrastructure/storage/indexed-db-session-store.ts
@@ -1,92 +1,21 @@
-import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
-import { ResultAsync, err, errAsync, ok, okAsync, type Result } from 'neverthrow';
-import {
-  invariantViolationError,
-  notFoundError,
-  type DomainError,
-} from '../../domain/shared/errors';
-import { type SessionIdentifier } from '../../domain/session/session-identifier';
-import { type TranscriptSegment } from '../../domain/transcript/transcript-segment';
-import { type TranscriptStream } from '../../domain/transcript/transcript-stream';
-import { type TranslationSegment } from '../../domain/transcript/translation-segment';
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+import { notFoundError, type DomainError } from '../../domain/shared/errors';
 import { type ExportBundle, type SessionStore } from '../../application/ports/session-store';
+import {
+  INDEXED_DB_NAME,
+  SESSIONS_STORE,
+  TRANSCRIPT_STORE,
+  TRANSLATION_STORE,
+  createPeraperaDbHandle,
+  toPersistenceError,
+} from './open-perapera-db';
 import {
   sessionFromRecord,
   sessionToRecord,
-  transcriptSegmentFromRecord,
   transcriptSegmentToRecord,
-  translationSegmentFromRecord,
   translationSegmentToRecord,
-  type SessionRow,
-  type TranscriptSegmentRow,
-  type TranslationSegmentRow,
 } from './records';
-
-export const INDEXED_DB_NAME = 'perapera';
-export const INDEXED_DB_VERSION = 1;
-
-const SESSIONS_STORE = 'sessions';
-const TRANSCRIPT_STORE = 'transcript_segments';
-const TRANSLATION_STORE = 'translation_segments';
-const EXPORT_STORE = 'export_records';
-
-interface PeraperaSchema extends DBSchema {
-  sessions: {
-    key: string;
-    value: SessionRow;
-  };
-  transcript_segments: {
-    key: string;
-    value: TranscriptSegmentRow;
-    indexes: { 'by-sessionId': string };
-  };
-  translation_segments: {
-    key: string;
-    value: TranslationSegmentRow;
-    indexes: { 'by-sessionId': string };
-  };
-  export_records: {
-    key: string;
-    value: {
-      exportId: string;
-      sessionId: string;
-      format: 'txt' | 'json';
-      includeOriginal: boolean;
-      includeTranslation: boolean;
-      createdAt: string;
-    };
-    indexes: { 'by-sessionId': string };
-  };
-}
-
-const openPeraperaDb = (databaseName: string): Promise<IDBPDatabase<PeraperaSchema>> =>
-  openDB<PeraperaSchema>(databaseName, INDEXED_DB_VERSION, {
-    upgrade(db) {
-      if (!db.objectStoreNames.contains(SESSIONS_STORE)) {
-        db.createObjectStore(SESSIONS_STORE, { keyPath: 'sessionId' });
-      }
-      if (!db.objectStoreNames.contains(TRANSCRIPT_STORE)) {
-        const store = db.createObjectStore(TRANSCRIPT_STORE, { keyPath: 'segmentId' });
-        store.createIndex('by-sessionId', 'sessionId');
-      }
-      if (!db.objectStoreNames.contains(TRANSLATION_STORE)) {
-        const store = db.createObjectStore(TRANSLATION_STORE, { keyPath: 'translationId' });
-        store.createIndex('by-sessionId', 'sessionId');
-      }
-      if (!db.objectStoreNames.contains(EXPORT_STORE)) {
-        const store = db.createObjectStore(EXPORT_STORE, { keyPath: 'exportId' });
-        store.createIndex('by-sessionId', 'sessionId');
-      }
-    },
-  });
-
-const toPersistenceError =
-  (scope: string) =>
-  (cause: unknown): DomainError =>
-    invariantViolationError({
-      invariant: 'session-persistence',
-      details: `${scope}: ${cause instanceof Error ? cause.message : 'unknown error'}`,
-    });
+import { assembleTranscriptStream } from './transcript-stream-assembler';
 
 /**
  * IndexedDB session store の拡張 interface。
@@ -113,6 +42,10 @@ export type CloseableSessionStore = SessionStore & {
  * 非同期 append-only 設計 (CLAUDE.md §データ保存方針)。ホットパスから
  * fire-and-forget で呼ばれる想定で、書き込み失敗は UseCase 層で WARN ログ
  * に留める。
+ *
+ * DB 共通定義 (schema / 定数 / open helper) は `open-perapera-db.ts` に集約し、
+ * domain Repository adapter 群 (`indexed-db-source-session-repository.ts` など)
+ * と共有する。
  */
 export type IndexedDbSessionStoreOptions = Readonly<{
   /** Override for tests. Production should omit this to use the default. */
@@ -123,42 +56,13 @@ export const createIndexedDbSessionStore = (
   options: IndexedDbSessionStoreOptions = {},
 ): CloseableSessionStore => {
   const databaseName = options.databaseName ?? INDEXED_DB_NAME;
-  let dbPromise: Promise<IDBPDatabase<PeraperaSchema>> | null = null;
-  const db = (): Promise<IDBPDatabase<PeraperaSchema>> => {
-    dbPromise ??= openPeraperaDb(databaseName);
-    return dbPromise;
-  };
-
-  const buildStream = (
-    sessionIdentifier: SessionIdentifier,
-    transcripts: readonly TranscriptSegmentRow[],
-    translations: readonly TranslationSegmentRow[],
-  ): Result<TranscriptStream, DomainError> => {
-    const segments = new Map<string, TranscriptSegment>();
-    for (const row of transcripts) {
-      const result = transcriptSegmentFromRecord(row);
-      if (result.isErr()) return err(result.error);
-      segments.set(result.value.segmentIdentifier, result.value);
-    }
-    const translationMap = new Map<string, TranslationSegment>();
-    for (const row of translations) {
-      const result = translationSegmentFromRecord(row);
-      if (result.isErr()) return err(result.error);
-      translationMap.set(result.value.segmentIdentifier, result.value);
-    }
-    const stream: TranscriptStream = {
-      sessionIdentifier,
-      segments,
-      translations: translationMap,
-    };
-    return ok(stream);
-  };
+  const handle = createPeraperaDbHandle(databaseName);
 
   return {
     saveSession: (session) =>
       ResultAsync.fromPromise(
         (async () => {
-          const connection = await db();
+          const connection = await handle.get();
           await connection.put(SESSIONS_STORE, sessionToRecord(session));
         })(),
         toPersistenceError('saveSession'),
@@ -167,7 +71,7 @@ export const createIndexedDbSessionStore = (
     appendTranscript: (sessionIdentifier, segment) =>
       ResultAsync.fromPromise(
         (async () => {
-          const connection = await db();
+          const connection = await handle.get();
           await connection.put(
             TRANSCRIPT_STORE,
             transcriptSegmentToRecord(sessionIdentifier, segment),
@@ -179,7 +83,7 @@ export const createIndexedDbSessionStore = (
     appendTranslation: (sessionIdentifier, translation) =>
       ResultAsync.fromPromise(
         (async () => {
-          const connection = await db();
+          const connection = await handle.get();
           await connection.put(
             TRANSLATION_STORE,
             translationSegmentToRecord(sessionIdentifier, translation),
@@ -191,7 +95,7 @@ export const createIndexedDbSessionStore = (
     loadExportBundle: (sessionIdentifier) =>
       ResultAsync.fromPromise(
         (async () => {
-          const connection = await db();
+          const connection = await handle.get();
           const sessionRow = await connection.get(SESSIONS_STORE, sessionIdentifier);
           if (sessionRow === undefined) return null;
           const transcripts = await connection.getAllFromIndex(
@@ -217,7 +121,11 @@ export const createIndexedDbSessionStore = (
         if (sessionResult.isErr()) {
           return errAsync<ExportBundle, DomainError>(sessionResult.error);
         }
-        const streamResult = buildStream(sessionIdentifier, raw.transcripts, raw.translations);
+        const streamResult = assembleTranscriptStream(
+          sessionIdentifier,
+          raw.transcripts,
+          raw.translations,
+        );
         if (streamResult.isErr()) {
           return errAsync<ExportBundle, DomainError>(streamResult.error);
         }
@@ -227,12 +135,8 @@ export const createIndexedDbSessionStore = (
         });
       }),
 
-    close: async () => {
-      if (dbPromise !== null) {
-        const connection = await dbPromise;
-        connection.close();
-        dbPromise = null;
-      }
-    },
+    close: handle.close,
   };
 };
+
+export { INDEXED_DB_NAME, INDEXED_DB_VERSION } from './open-perapera-db';

--- a/packages/extension/src/infrastructure/storage/indexed-db-source-session-repository.test.ts
+++ b/packages/extension/src/infrastructure/storage/indexed-db-source-session-repository.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import {
+  createSourceSession,
+  stopSourceSession,
+  type SourceSession,
+} from '../../domain/session/source-session';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { INDEXED_DB_NAME } from './open-perapera-db';
+import {
+  createIndexedDbSourceSessionRepository,
+  type CloseableSourceSessionRepository,
+} from './indexed-db-source-session-repository';
+
+const SESSION_ID_A = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SESSION_ID_B = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+const SESSION_ID_C = '01HZX8Y1R8M7D3Q2P4T5V6W7A3';
+const SOURCE_ID_A = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const SOURCE_ID_B = '01HZX8Y1R8M7D3Q2P4T5V6W7B2';
+const SOURCE_ID_C = '01HZX8Y1R8M7D3Q2P4T5V6W7B3';
+
+const identifierA: SessionIdentifier = parseSessionIdentifier(SESSION_ID_A)._unsafeUnwrap();
+const identifierB: SessionIdentifier = parseSessionIdentifier(SESSION_ID_B)._unsafeUnwrap();
+const identifierC: SessionIdentifier = parseSessionIdentifier(SESSION_ID_C)._unsafeUnwrap();
+
+const buildSession = (
+  sessionId: string,
+  sourceId: string,
+  startedAt = '2026-04-21T00:00:00.000Z',
+): SourceSession =>
+  createSourceSession({
+    sessionIdentifier: sessionId,
+    sourceIdentifier: sourceId,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt,
+  })._unsafeUnwrap();
+
+const stoppedSession = (session: SourceSession): SourceSession =>
+  stopSourceSession(session, { stoppedAt: '2026-04-21T00:10:00.000Z' })._unsafeUnwrap();
+
+describe('createIndexedDbSourceSessionRepository (IMPL-140, DD-260)', () => {
+  let repo: CloseableSourceSessionRepository;
+  let databaseName: string;
+
+  beforeEach(() => {
+    databaseName = `${INDEXED_DB_NAME}-test-${String(Math.random()).slice(2)}`;
+    repo = createIndexedDbSourceSessionRepository({ databaseName });
+  });
+
+  afterEach(async () => {
+    await repo.close();
+  });
+
+  describe('save + findById', () => {
+    it('persists a session and retrieves it by identifier', async () => {
+      const saveResult = await repo.save(buildSession(SESSION_ID_A, SOURCE_ID_A));
+      expect(saveResult.isOk()).toBe(true);
+
+      const findResult = await repo.findById(identifierA);
+      expect(findResult.isOk()).toBe(true);
+      if (findResult.isOk()) {
+        expect(findResult.value.sessionIdentifier).toBe(SESSION_ID_A);
+        expect(findResult.value.sourceIdentifier).toBe(SOURCE_ID_A);
+        expect(findResult.value.state).toBe('idle');
+      }
+    });
+
+    it('upserts (save overwrites existing session)', async () => {
+      const initial = buildSession(SESSION_ID_A, SOURCE_ID_A);
+      await repo.save(initial);
+      const updated = stoppedSession(initial);
+      await repo.save(updated);
+
+      const findResult = await repo.findById(identifierA);
+      expect(findResult.isOk()).toBe(true);
+      if (findResult.isOk()) {
+        expect(findResult.value.state).toBe('stopped');
+        expect(findResult.value.stoppedAt).toBe('2026-04-21T00:10:00.000Z');
+      }
+    });
+  });
+
+  describe('findById — missing', () => {
+    it('returns notFound error when the session does not exist', async () => {
+      const result = await repo.findById(identifierA);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe('not-found');
+        if (result.error.kind === 'not-found') {
+          expect(result.error.resourceType).toBe('SourceSession');
+          expect(result.error.identifier).toBe(SESSION_ID_A);
+        }
+      }
+    });
+  });
+
+  describe('findActiveSessions', () => {
+    it('returns ok([]) when there are no sessions', async () => {
+      const result = await repo.findActiveSessions();
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toEqual([]);
+      }
+    });
+
+    it('returns only non-stopped sessions', async () => {
+      const active = buildSession(SESSION_ID_A, SOURCE_ID_A, '2026-04-21T00:00:00.000Z');
+      const activeB = buildSession(SESSION_ID_B, SOURCE_ID_B, '2026-04-21T00:01:00.000Z');
+      const stopped = stoppedSession(buildSession(SESSION_ID_C, SOURCE_ID_C));
+      await repo.save(active);
+      await repo.save(activeB);
+      await repo.save(stopped);
+
+      const result = await repo.findActiveSessions();
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const ids = result.value.map((session) => session.sessionIdentifier).sort();
+        expect(ids).toEqual([SESSION_ID_A, SESSION_ID_B].sort());
+      }
+    });
+
+    it('excludes a session once its state transitions to stopped', async () => {
+      const session = buildSession(SESSION_ID_A, SOURCE_ID_A);
+      await repo.save(session);
+      const beforeStop = await repo.findActiveSessions();
+      expect(beforeStop.isOk() && beforeStop.value.length).toBe(1);
+
+      await repo.save(stoppedSession(session));
+      const afterStop = await repo.findActiveSessions();
+      expect(afterStop.isOk() && afterStop.value.length).toBe(0);
+    });
+  });
+
+  it('does not leak sessions across database instances', async () => {
+    await repo.save(buildSession(SESSION_ID_A, SOURCE_ID_A));
+
+    const otherDatabase = `${INDEXED_DB_NAME}-test-${String(Math.random()).slice(2)}`;
+    const otherRepo = createIndexedDbSourceSessionRepository({ databaseName: otherDatabase });
+    const result = await otherRepo.findById(identifierA);
+    expect(result.isErr()).toBe(true);
+    await otherRepo.close();
+
+    void identifierB;
+    void identifierC;
+  });
+});

--- a/packages/extension/src/infrastructure/storage/indexed-db-source-session-repository.ts
+++ b/packages/extension/src/infrastructure/storage/indexed-db-source-session-repository.ts
@@ -1,0 +1,105 @@
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+import { type SourceSessionRepository } from '../../domain/repositories/source-session-repository';
+import { type SourceSession } from '../../domain/session/source-session';
+import { notFoundError, type DomainError } from '../../domain/shared/errors';
+import { isActiveSession } from '../../domain/specifications/concurrent-session-limit-specification';
+import {
+  INDEXED_DB_NAME,
+  SESSIONS_STORE,
+  createPeraperaDbHandle,
+  toPersistenceError,
+} from './open-perapera-db';
+import { sessionFromRecord, sessionToRecord } from './records';
+
+/**
+ * 拡張インタフェース。`SourceSessionRepository` に加えてテストおよび
+ * Service Worker シャットダウン時に `IDBPDatabase` を明示 close するための
+ * `close()` を公開する。
+ */
+export type CloseableSourceSessionRepository = SourceSessionRepository & {
+  close: () => Promise<void>;
+};
+
+export type IndexedDbSourceSessionRepositoryOptions = Readonly<{
+  /** Override for tests. Production should omit to use the default. */
+  databaseName?: string;
+}>;
+
+/**
+ * IMPL-140 IndexedDbSourceSessionRepository (DD-260, DB-001)。
+ *
+ * `sessions` object store を介した `SourceSession` 集約の永続化 adapter。
+ * `IndexedDbSessionStore` (DD-106 / application SessionStore) と同じ IndexedDB
+ * (`open-perapera-db.ts` の schema / 定数) を共有する。
+ *
+ * - `findById`: `get(SESSIONS_STORE, id)` → 未検出で `notFoundError`
+ * - `findActiveSessions`: 全件取得 → `isActiveSession` でフィルタ。0 件は `ok([])`
+ *   (MVP では同時 3 セッション前提で full-scan で十分、index は DB v2 で検討)
+ * - `save`: `put` による upsert
+ *
+ * エラー型:
+ * - 永続化 I/O 失敗: `invariantViolationError({ invariant: 'session-persistence' })`
+ *   (`toPersistenceError` 共通 factory 経由)
+ * - 行データからの aggregate 復元失敗: `sessionFromRecord` が返す DomainError
+ *   (Zod / branded type バリデーション)
+ */
+export const createIndexedDbSourceSessionRepository = (
+  options: IndexedDbSourceSessionRepositoryOptions = {},
+): CloseableSourceSessionRepository => {
+  const databaseName = options.databaseName ?? INDEXED_DB_NAME;
+  const handle = createPeraperaDbHandle(databaseName);
+
+  return {
+    findById: (sessionIdentifier) =>
+      ResultAsync.fromPromise(
+        (async () => {
+          const connection = await handle.get();
+          return connection.get(SESSIONS_STORE, sessionIdentifier);
+        })(),
+        toPersistenceError('findById'),
+      ).andThen((row): ResultAsync<SourceSession, DomainError> => {
+        if (row === undefined) {
+          return errAsync<SourceSession, DomainError>(
+            notFoundError({ resourceType: 'SourceSession', identifier: sessionIdentifier }),
+          );
+        }
+        const parsed = sessionFromRecord(row);
+        if (parsed.isErr()) {
+          return errAsync<SourceSession, DomainError>(parsed.error);
+        }
+        return okAsync<SourceSession, DomainError>(parsed.value);
+      }),
+
+    findActiveSessions: () =>
+      ResultAsync.fromPromise(
+        (async () => {
+          const connection = await handle.get();
+          return connection.getAll(SESSIONS_STORE);
+        })(),
+        toPersistenceError('findActiveSessions'),
+      ).andThen((rows): ResultAsync<readonly SourceSession[], DomainError> => {
+        const sessions: SourceSession[] = [];
+        for (const row of rows) {
+          const parsed = sessionFromRecord(row);
+          if (parsed.isErr()) {
+            return errAsync<readonly SourceSession[], DomainError>(parsed.error);
+          }
+          if (isActiveSession(parsed.value)) {
+            sessions.push(parsed.value);
+          }
+        }
+        return okAsync<readonly SourceSession[], DomainError>(sessions);
+      }),
+
+    save: (session) =>
+      ResultAsync.fromPromise(
+        (async () => {
+          const connection = await handle.get();
+          await connection.put(SESSIONS_STORE, sessionToRecord(session));
+        })(),
+        toPersistenceError('save'),
+      ),
+
+    close: handle.close,
+  };
+};

--- a/packages/extension/src/infrastructure/storage/indexed-db-transcript-stream-repository.test.ts
+++ b/packages/extension/src/infrastructure/storage/indexed-db-transcript-stream-repository.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { createTimestampRange } from '../../domain/transcript/timestamp-range';
+import {
+  createPartialTranscriptSegment,
+  finalizeTranscriptSegment,
+  type TranscriptSegment,
+} from '../../domain/transcript/transcript-segment';
+import {
+  createCompletedTranslationSegment,
+  createFailedTranslationSegment,
+  type TranslationSegment,
+} from '../../domain/transcript/translation-segment';
+import { INDEXED_DB_NAME } from './open-perapera-db';
+import {
+  createIndexedDbTranscriptStreamRepository,
+  type CloseableTranscriptStreamRepository,
+} from './indexed-db-transcript-stream-repository';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SESSION_ID_OTHER = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+const SEGMENT_ID_1 = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+const SEGMENT_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7D2';
+const TRANSLATION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7E1';
+const TRANSLATION_ID_2 = '01HZX8Y1R8M7D3Q2P4T5V6W7E2';
+
+const identifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+const otherIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID_OTHER)._unsafeUnwrap();
+
+const buildPartial = (segmentId: string, revision = 1): TranscriptSegment =>
+  createPartialTranscriptSegment({
+    segmentIdentifier: segmentId,
+    revision,
+    text: 'hello',
+    timeRange: createTimestampRange({ startMs: 0, endMs: 1000 })._unsafeUnwrap(),
+  })._unsafeUnwrap();
+
+const finalize = (partial: TranscriptSegment): TranscriptSegment =>
+  finalizeTranscriptSegment(partial, {})._unsafeUnwrap();
+
+const buildCompletedTranslation = (segmentId: string, translationId: string): TranslationSegment =>
+  createCompletedTranslationSegment({
+    translationIdentifier: translationId,
+    segmentIdentifier: segmentId,
+    targetLanguage: 'ja-JP',
+    text: 'こんにちは',
+  })._unsafeUnwrap();
+
+describe('createIndexedDbTranscriptStreamRepository (IMPL-141, DD-261)', () => {
+  let repo: CloseableTranscriptStreamRepository;
+  let databaseName: string;
+
+  beforeEach(() => {
+    databaseName = `${INDEXED_DB_NAME}-test-${String(Math.random()).slice(2)}`;
+    repo = createIndexedDbTranscriptStreamRepository({ databaseName });
+  });
+
+  afterEach(async () => {
+    await repo.close();
+  });
+
+  describe('findBySessionId', () => {
+    it('returns notFound when no segments or translations exist', async () => {
+      const result = await repo.findBySessionId(identifier);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe('not-found');
+        if (result.error.kind === 'not-found') {
+          expect(result.error.resourceType).toBe('TranscriptStream');
+          expect(result.error.identifier).toBe(SESSION_ID);
+        }
+      }
+    });
+
+    it('returns the stream with appended partial segments', async () => {
+      await repo.appendPartial(identifier, buildPartial(SEGMENT_ID_1));
+      const result = await repo.findBySessionId(identifier);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.sessionIdentifier).toBe(SESSION_ID);
+        expect(result.value.segments.size).toBe(1);
+        expect(result.value.segments.get(SEGMENT_ID_1)?.isFinal).toBe(false);
+      }
+    });
+
+    it('isolates segments per sessionId', async () => {
+      await repo.appendPartial(identifier, buildPartial(SEGMENT_ID_1));
+      await repo.appendPartial(otherIdentifier, buildPartial(SEGMENT_ID_2));
+
+      const a = await repo.findBySessionId(identifier);
+      const b = await repo.findBySessionId(otherIdentifier);
+      expect(a.isOk() && a.value.segments.size).toBe(1);
+      expect(b.isOk() && b.value.segments.size).toBe(1);
+      if (a.isOk()) {
+        expect(a.value.segments.has(SEGMENT_ID_1)).toBe(true);
+        expect(a.value.segments.has(SEGMENT_ID_2)).toBe(false);
+      }
+    });
+  });
+
+  describe('appendPartial', () => {
+    it('stores a partial segment without guards', async () => {
+      const result = await repo.appendPartial(identifier, buildPartial(SEGMENT_ID_1));
+      expect(result.isOk()).toBe(true);
+    });
+  });
+
+  describe('appendFinal — defensive guard', () => {
+    it('rejects when segment.isFinal is false with append-final-requires-final-segment', async () => {
+      const partial = buildPartial(SEGMENT_ID_1);
+      const result = await repo.appendFinal(identifier, partial);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe('invariant-violation');
+        if (result.error.kind === 'invariant-violation') {
+          expect(result.error.invariant).toBe('append-final-requires-final-segment');
+        }
+      }
+    });
+
+    it('stores a final segment when isFinal=true', async () => {
+      const final = finalize(buildPartial(SEGMENT_ID_1));
+      const result = await repo.appendFinal(identifier, final);
+      expect(result.isOk()).toBe(true);
+
+      const bundle = await repo.findBySessionId(identifier);
+      expect(bundle.isOk()).toBe(true);
+      if (bundle.isOk()) {
+        expect(bundle.value.segments.get(SEGMENT_ID_1)?.isFinal).toBe(true);
+      }
+    });
+  });
+
+  describe('appendTranslation — defensive guard', () => {
+    it('rejects when no final segment exists with translation-requires-final-segment', async () => {
+      const translation = buildCompletedTranslation(SEGMENT_ID_1, TRANSLATION_ID);
+      const result = await repo.appendTranslation(identifier, translation);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe('invariant-violation');
+        if (result.error.kind === 'invariant-violation') {
+          expect(result.error.invariant).toBe('translation-requires-final-segment');
+        }
+      }
+    });
+
+    it('rejects when only a partial (non-final) segment exists for the session', async () => {
+      await repo.appendPartial(identifier, buildPartial(SEGMENT_ID_1));
+      const translation = buildCompletedTranslation(SEGMENT_ID_1, TRANSLATION_ID);
+      const result = await repo.appendTranslation(identifier, translation);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe('invariant-violation');
+      }
+    });
+
+    it('accepts a translation after the corresponding final segment is present', async () => {
+      const final = finalize(buildPartial(SEGMENT_ID_1));
+      await repo.appendFinal(identifier, final);
+      const translation = buildCompletedTranslation(SEGMENT_ID_1, TRANSLATION_ID);
+      const result = await repo.appendTranslation(identifier, translation);
+      expect(result.isOk()).toBe(true);
+
+      const bundle = await repo.findBySessionId(identifier);
+      expect(bundle.isOk()).toBe(true);
+      if (bundle.isOk()) {
+        const t = bundle.value.translations.get(SEGMENT_ID_1);
+        expect(t?.status).toBe('completed');
+      }
+    });
+
+    it('accepts a failed translation once the matching final segment is present', async () => {
+      const final = finalize(buildPartial(SEGMENT_ID_1));
+      await repo.appendFinal(identifier, final);
+      const failed = createFailedTranslationSegment({
+        translationIdentifier: TRANSLATION_ID_2,
+        segmentIdentifier: SEGMENT_ID_1,
+        targetLanguage: 'ja-JP',
+      })._unsafeUnwrap();
+      const result = await repo.appendTranslation(identifier, failed);
+      expect(result.isOk()).toBe(true);
+    });
+  });
+});

--- a/packages/extension/src/infrastructure/storage/indexed-db-transcript-stream-repository.ts
+++ b/packages/extension/src/infrastructure/storage/indexed-db-transcript-stream-repository.ts
@@ -1,0 +1,170 @@
+import { ResultAsync, errAsync } from 'neverthrow';
+import { type TranscriptStreamRepository } from '../../domain/repositories/transcript-stream-repository';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import {
+  invariantViolationError,
+  notFoundError,
+  type DomainError,
+} from '../../domain/shared/errors';
+import { type TranscriptStream } from '../../domain/transcript/transcript-stream';
+import {
+  INDEXED_DB_NAME,
+  TRANSCRIPT_STORE,
+  TRANSLATION_STORE,
+  createPeraperaDbHandle,
+  toPersistenceError,
+} from './open-perapera-db';
+import { transcriptSegmentToRecord, translationSegmentToRecord } from './records';
+import { assembleTranscriptStream } from './transcript-stream-assembler';
+
+/**
+ * 拡張インタフェース。`TranscriptStreamRepository` に加えてテスト cleanup や
+ * Service Worker シャットダウン時に IndexedDB connection を閉じる `close()`
+ * を公開する。
+ */
+export type CloseableTranscriptStreamRepository = TranscriptStreamRepository & {
+  close: () => Promise<void>;
+};
+
+export type IndexedDbTranscriptStreamRepositoryOptions = Readonly<{
+  /** Override for tests. Production should omit to use the default. */
+  databaseName?: string;
+}>;
+
+/**
+ * IMPL-141 IndexedDbTranscriptStreamRepository (DD-261, DB-002 / DB-003)。
+ *
+ * `transcript_segments` / `translation_segments` 2 object store を集約単位で
+ * 操作する adapter。`IndexedDbSessionStore` と同一 IndexedDB を共有する。
+ *
+ * - `findBySessionId`: `by-sessionId` index で両 store から全行取得 →
+ *   `assembleTranscriptStream` で集約を再構築。両方とも 0 件なら
+ *   `notFoundError({ resourceType: 'TranscriptStream' })`。
+ * - `appendPartial`: そのまま upsert (isFinal=false 前提だが、防御検証は行わない
+ *   — `TranscriptSegment` factory 側で revision 単調増加などのドメイン不変条件
+ *   は既に保証されている)。
+ * - `appendFinal`: **防御検証** `segment.isFinal === true` を要求。違反時
+ *   `invariantViolationError({ invariant: 'append-final-requires-final-segment' })`。
+ * - `appendTranslation`: **防御検証** 対応する final segment
+ *   (`segmentId` 一致 & `isFinal=true`) が DB 上に存在することを要求。違反時
+ *   `invariantViolationError({ invariant: 'translation-requires-final-segment' })`。
+ *
+ * 設計書 (`transcript-stream-repository.ts:17-23`) の契約に準拠。
+ */
+export const createIndexedDbTranscriptStreamRepository = (
+  options: IndexedDbTranscriptStreamRepositoryOptions = {},
+): CloseableTranscriptStreamRepository => {
+  const databaseName = options.databaseName ?? INDEXED_DB_NAME;
+  const handle = createPeraperaDbHandle(databaseName);
+
+  const findBySessionId = (
+    sessionIdentifier: SessionIdentifier,
+  ): ResultAsync<TranscriptStream, DomainError> =>
+    ResultAsync.fromPromise(
+      (async () => {
+        const connection = await handle.get();
+        const transcripts = await connection.getAllFromIndex(
+          TRANSCRIPT_STORE,
+          'by-sessionId',
+          sessionIdentifier,
+        );
+        const translations = await connection.getAllFromIndex(
+          TRANSLATION_STORE,
+          'by-sessionId',
+          sessionIdentifier,
+        );
+        return { transcripts, translations };
+      })(),
+      toPersistenceError('findBySessionId'),
+    ).andThen((raw): ResultAsync<TranscriptStream, DomainError> => {
+      if (raw.transcripts.length === 0 && raw.translations.length === 0) {
+        return errAsync<TranscriptStream, DomainError>(
+          notFoundError({ resourceType: 'TranscriptStream', identifier: sessionIdentifier }),
+        );
+      }
+      const assembled = assembleTranscriptStream(
+        sessionIdentifier,
+        raw.transcripts,
+        raw.translations,
+      );
+      if (assembled.isErr()) {
+        return errAsync<TranscriptStream, DomainError>(assembled.error);
+      }
+      return ResultAsync.fromSafePromise(Promise.resolve(assembled.value));
+    });
+
+  return {
+    findBySessionId,
+
+    appendPartial: (sessionIdentifier, segment) =>
+      ResultAsync.fromPromise(
+        (async () => {
+          const connection = await handle.get();
+          await connection.put(
+            TRANSCRIPT_STORE,
+            transcriptSegmentToRecord(sessionIdentifier, segment),
+          );
+        })(),
+        toPersistenceError('appendPartial'),
+      ),
+
+    appendFinal: (sessionIdentifier, segment) => {
+      if (!segment.isFinal) {
+        return errAsync<void, DomainError>(
+          invariantViolationError({
+            invariant: 'append-final-requires-final-segment',
+            details: `segment ${segment.segmentIdentifier} is not finalized (isFinal=false)`,
+          }),
+        );
+      }
+      return ResultAsync.fromPromise(
+        (async () => {
+          const connection = await handle.get();
+          await connection.put(
+            TRANSCRIPT_STORE,
+            transcriptSegmentToRecord(sessionIdentifier, segment),
+          );
+        })(),
+        toPersistenceError('appendFinal'),
+      );
+    },
+
+    appendTranslation: (sessionIdentifier, translation) =>
+      ResultAsync.fromPromise(
+        (async () => {
+          const connection = await handle.get();
+          const rows = await connection.getAllFromIndex(
+            TRANSCRIPT_STORE,
+            'by-sessionId',
+            sessionIdentifier,
+          );
+          return rows;
+        })(),
+        toPersistenceError('appendTranslation/lookup'),
+      ).andThen((rows): ResultAsync<void, DomainError> => {
+        const hasFinal = rows.some(
+          (row) => row.segmentId === translation.segmentIdentifier && row.isFinal,
+        );
+        if (!hasFinal) {
+          return errAsync<void, DomainError>(
+            invariantViolationError({
+              invariant: 'translation-requires-final-segment',
+              details: `no final segment found for segmentId=${translation.segmentIdentifier} in session ${sessionIdentifier}`,
+            }),
+          );
+        }
+        return ResultAsync.fromPromise(
+          (async () => {
+            const connection = await handle.get();
+            await connection.put(
+              TRANSLATION_STORE,
+              translationSegmentToRecord(sessionIdentifier, translation),
+            );
+          })(),
+          toPersistenceError('appendTranslation/put'),
+        );
+      }),
+
+    close: handle.close,
+  };
+};

--- a/packages/extension/src/infrastructure/storage/open-perapera-db.ts
+++ b/packages/extension/src/infrastructure/storage/open-perapera-db.ts
@@ -1,0 +1,114 @@
+import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import {
+  type SessionRow,
+  type TranscriptSegmentRow,
+  type TranslationSegmentRow,
+  type ExportRecordRow,
+} from './records';
+
+/**
+ * IndexedDB open helper (DD-106, DB-001〜004)。
+ *
+ * `IndexedDbSessionStore` と `IndexedDb*Repository` adapter 群が共有する DB
+ * 定義の単一入口。`idb` v8 の `openDB` を wrap し、4 object store + index
+ * を宣言する。同一 adapter 内では一度開いた `IDBPDatabase` を使い回し、
+ * 複数 adapter 間では別の connection を張るのが既定 (test helper 越しに
+ * 共有させる場合のみ `IDBPDatabase` を直接受け取る factory を用意)。
+ *
+ * MVP の DB version は `1` 固定。設計書 (DB-001〜003) の補助 index
+ * (`idx_sessions_state` など) は現段階では追加しておらず、全スキャン +
+ * フィルタで active 検出する (active session 件数は最大 3 前提)。
+ * 運用で顕在化した場合は version bump で追加する。
+ */
+
+export const INDEXED_DB_NAME = 'perapera';
+export const INDEXED_DB_VERSION = 1;
+
+export const SESSIONS_STORE = 'sessions';
+export const TRANSCRIPT_STORE = 'transcript_segments';
+export const TRANSLATION_STORE = 'translation_segments';
+export const EXPORT_STORE = 'export_records';
+
+export interface PeraperaSchema extends DBSchema {
+  sessions: {
+    key: string;
+    value: SessionRow;
+  };
+  transcript_segments: {
+    key: string;
+    value: TranscriptSegmentRow;
+    indexes: { 'by-sessionId': string };
+  };
+  translation_segments: {
+    key: string;
+    value: TranslationSegmentRow;
+    indexes: { 'by-sessionId': string };
+  };
+  export_records: {
+    key: string;
+    value: ExportRecordRow;
+    indexes: { 'by-sessionId': string };
+  };
+}
+
+export const openPeraperaDb = (databaseName: string): Promise<IDBPDatabase<PeraperaSchema>> =>
+  openDB<PeraperaSchema>(databaseName, INDEXED_DB_VERSION, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(SESSIONS_STORE)) {
+        db.createObjectStore(SESSIONS_STORE, { keyPath: 'sessionId' });
+      }
+      if (!db.objectStoreNames.contains(TRANSCRIPT_STORE)) {
+        const store = db.createObjectStore(TRANSCRIPT_STORE, { keyPath: 'segmentId' });
+        store.createIndex('by-sessionId', 'sessionId');
+      }
+      if (!db.objectStoreNames.contains(TRANSLATION_STORE)) {
+        const store = db.createObjectStore(TRANSLATION_STORE, { keyPath: 'translationId' });
+        store.createIndex('by-sessionId', 'sessionId');
+      }
+      if (!db.objectStoreNames.contains(EXPORT_STORE)) {
+        const store = db.createObjectStore(EXPORT_STORE, { keyPath: 'exportId' });
+        store.createIndex('by-sessionId', 'sessionId');
+      }
+    },
+  });
+
+/**
+ * 永続化失敗を `invariantViolationError` に正規化する factory。adapter 側の
+ * catch ハンドラから scope 名 (例: `'saveSession'`, `'findActiveSessions'`)
+ * を付けて呼ぶ。
+ */
+export const toPersistenceError =
+  (scope: string) =>
+  (cause: unknown): DomainError =>
+    invariantViolationError({
+      invariant: 'session-persistence',
+      details: `${scope}: ${cause instanceof Error ? cause.message : 'unknown error'}`,
+    });
+
+/**
+ * 遅延初期化する DB connection holder。adapter 内部で 1 connection を
+ * 共有する用途に用いる。`close()` はすでに開いていた connection を閉じ、
+ * 次回 `get()` 呼び出し時に再 open する。
+ */
+export type PeraperaDbHandle = Readonly<{
+  get: () => Promise<IDBPDatabase<PeraperaSchema>>;
+  close: () => Promise<void>;
+}>;
+
+export const createPeraperaDbHandle = (databaseName: string): PeraperaDbHandle => {
+  let dbPromise: Promise<IDBPDatabase<PeraperaSchema>> | null = null;
+  return {
+    get: () => {
+      dbPromise ??= openPeraperaDb(databaseName);
+      return dbPromise;
+    },
+    close: async () => {
+      if (dbPromise !== null) {
+        const connection = await dbPromise;
+        connection.close();
+        dbPromise = null;
+      }
+    },
+  };
+};

--- a/packages/extension/src/infrastructure/storage/transcript-stream-assembler.ts
+++ b/packages/extension/src/infrastructure/storage/transcript-stream-assembler.ts
@@ -1,0 +1,45 @@
+import { err, ok, type Result } from 'neverthrow';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type DomainError } from '../../domain/shared/errors';
+import { type TranscriptSegment } from '../../domain/transcript/transcript-segment';
+import { type TranscriptStream } from '../../domain/transcript/transcript-stream';
+import { type TranslationSegment } from '../../domain/transcript/translation-segment';
+import {
+  transcriptSegmentFromRecord,
+  translationSegmentFromRecord,
+  type TranscriptSegmentRow,
+  type TranslationSegmentRow,
+} from './records';
+
+/**
+ * 行ロー (`TranscriptSegmentRow` / `TranslationSegmentRow`) の並びから
+ * `TranscriptStream` 集約を組み立てる共有ユーティリティ。
+ *
+ * `IndexedDbSessionStore.loadExportBundle` と `IndexedDbTranscriptStreamRepository.findBySessionId`
+ * の双方で同一ロジックが必要だったため module に切り出した (設計書 DD-106 と
+ * DD-261 の結合点)。
+ */
+export const assembleTranscriptStream = (
+  sessionIdentifier: SessionIdentifier,
+  transcripts: readonly TranscriptSegmentRow[],
+  translations: readonly TranslationSegmentRow[],
+): Result<TranscriptStream, DomainError> => {
+  const segments = new Map<string, TranscriptSegment>();
+  for (const row of transcripts) {
+    const result = transcriptSegmentFromRecord(row);
+    if (result.isErr()) return err(result.error);
+    segments.set(result.value.segmentIdentifier, result.value);
+  }
+  const translationMap = new Map<string, TranslationSegment>();
+  for (const row of translations) {
+    const result = translationSegmentFromRecord(row);
+    if (result.isErr()) return err(result.error);
+    translationMap.set(result.value.segmentIdentifier, result.value);
+  }
+  const stream: TranscriptStream = {
+    sessionIdentifier,
+    segments,
+    translations: translationMap,
+  };
+  return ok(stream);
+};


### PR DESCRIPTION
## Summary

Phase 5 拡張 presentation 層の composition root 前提として、domain repository
(`SourceSessionRepository` / `TranscriptStreamRepository` / `ExtensionProfileRepository` /
`ExportRecordRepository`) の infrastructure 実装を追加します。

### 背景

Phase 4 Relay API 完了後 (PR #37〜#44 merged) に Background service worker の
composition root を組もうとしたところ、以下の UseCase が依存する domain
repository ポートに対応する infrastructure 実装が存在しないことが判明:

| UseCase                          | 依存 repository                                      |
| -------------------------------- | ---------------------------------------------------- |
| StartSourceSessionUseCase        | SourceSessionRepository, ExtensionProfileRepository |
| StopSourceSessionUseCase         | SourceSessionRepository                              |
| UpdateSourceSettingsUseCase      | SourceSessionRepository                              |
| GetSessionMonitorStateQuery      | SourceSessionRepository, TranscriptStreamRepository  |
| HandleTranscriptPartial/Final    | TranscriptStreamRepository                            |
| ExportSessionResultUseCase       | ExportRecordRepository                                |

本 PR で 4 adapter を実装し、production entrypoint から DI 可能にします。
Mock / in-memory を production コードで使わない原則 (Phase 4 で確立) を継続。

### 変更内容

**共通基盤 (refactor)**:
- `open-perapera-db.ts` (新規): PeraperaSchema / 定数 / openDB helper /
  `createPeraperaDbHandle` / `toPersistenceError` を共通化
- `transcript-stream-assembler.ts` (新規): 行ロー → TranscriptStream 組立共有
- `indexed-db-session-store.ts`: 上記を利用する内部リファクタ (public API 無変更)

**Domain Repository adapters (新規)**:
- `IndexedDbSourceSessionRepository` (DD-260): findById / findActiveSessions / save
- `IndexedDbTranscriptStreamRepository` (DD-261): findBySessionId / appendPartial /
  appendFinal (isFinal guard) / appendTranslation (対応 final 存在 guard)
- `IndexedDbExportRecordRepository` (DD-263): save / findBySessionId
- `ChromeLocalExtensionProfileRepository` (DD-262 / DD-107): getDefault / save。
  既存 `ChromeLocalSettingsStore` と同じ key 体系を共有 (aggregate と個別 field の
  両アクセスを整合)

**barrel export**: `storage/index.ts` に 4 adapter + 共有 helper を追加。

### 設計準拠

- `SourceSessionRepository`: `isActiveSession` (`concurrent-session-limit-specification.ts`)
  を再利用
- `TranscriptStreamRepository`: 設計書 (`transcript-stream-repository.ts:17-23`) の
  防御検証 2 種 (append-final-requires-final-segment / translation-requires-final-segment)
  を実装
- `ExtensionProfileRepository`: 設計書 (`extension-profile-repository.ts:10`) の
  「chrome.storage.local にマッピング (DD-107)」に従い、既存 Settings store の
  key を再利用
- `ExportRecordRepository`: 設計書の「0 件は ok([])」契約を実装

### 設計書沈黙項目への対応

| 項目                                     | 本 PR の方針                                          |
| ---------------------------------------- | ----------------------------------------------------- |
| 複数 store atomic transaction           | 不採用 (設計書未定)。跨 store 更新はアプリ層で順序処理 |
| DB-001〜003 の補助 index (idx_sessions_state 等) | 当面不採用。MVP は active セッション件数が少なく full-scan で十分 |
| Repository vs SessionStore の重複       | 責務分離で意図的。コード重複は assembler 抽出で解消      |
| ExtensionProfileRepository と SettingsStore の共存 | 同一 key を共有 (異なる粒度で両立)                      |

### カバレッジ

本 PR で 27 新規テストを追加:
- IndexedDbSourceSessionRepository: 7 tests
- IndexedDbTranscriptStreamRepository: 10 tests (defensive guards を網羅)
- IndexedDbExportRecordRepository: 5 tests
- ChromeLocalExtensionProfileRepository: 5 tests

## Test plan

- [x] `pnpm fmt:check` — clean
- [x] `pnpm lint` — clean (root level)
- [x] `pnpm typecheck` — 両 workspace green
- [x] `pnpm --filter @perapera/extension test` — 620 / 620 pass (既存 593 + 新規 27)
- [x] `pnpm --filter @perapera/relay-api test` — 184 / 184 pass (無影響)
- [x] 既存 `IndexedDbSessionStore` / `ChromeLocalSettingsStore` public API 無変更確認