### PR TITLE
feat(extension): IMPL-500〜502 Background composition + runtime dispatcher + 3 new adapters

### DIFF
--- a/packages/extension/src/composition/extension-composition.test.ts
+++ b/packages/extension/src/composition/extension-composition.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createExtensionProfile } from '../domain/profile/extension-profile';
+import { createOverlaySettings } from '../domain/profile/overlay-settings';
+import { createLanguagePair } from '../domain/session/language-pair';
+import { type ChromeStorageAdapter } from '../infrastructure/storage/chrome-local-settings-store';
+import { createChromeLocalExtensionProfileRepository } from '../infrastructure/storage/chrome-local-extension-profile-repository';
+import { INDEXED_DB_NAME } from '../infrastructure/storage/open-perapera-db';
+import {
+  createExtensionApp,
+  type ExtensionApp,
+  type ExtensionRuntimeConfig,
+  type ExtensionRuntimePorts,
+} from './extension-composition';
+
+const PROFILE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C1';
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const TRANSLATION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7E1';
+const EXPORT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7F1';
+
+const createFakeStorage = (): ChromeStorageAdapter => {
+  const store = new Map<string, unknown>();
+  return {
+    get: (keys) => {
+      const result: Record<string, unknown> = {};
+      for (const key of keys) {
+        if (store.has(key)) result[key] = store.get(key);
+      }
+      return Promise.resolve(result);
+    },
+    set: (items) => {
+      for (const [key, value] of Object.entries(items)) {
+        store.set(key, value);
+      }
+      return Promise.resolve();
+    },
+  };
+};
+
+const createTestPorts = (overrides: Partial<ExtensionRuntimePorts> = {}): ExtensionRuntimePorts => {
+  const storage = overrides.chromeStorageAdapter ?? createFakeStorage();
+  return {
+    chromePermissionsApi: {
+      request: vi.fn(() => Promise.resolve(true)),
+    },
+    chromeStorageAdapter: storage,
+    audioContextFactory: vi.fn(() => ({
+      sampleRate: 16000,
+      audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
+      close: vi.fn(() => Promise.resolve()),
+      createMediaStreamSource: vi.fn(() => ({})),
+    })),
+    webSocketFactory: vi.fn(() => ({
+      readyState: 1,
+      send: vi.fn(),
+      close: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+    fetchImpl: vi.fn(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            sessionId: SESSION_ID,
+            streamToken: 'jwt.stream.token',
+            relayUrl: 'wss://test',
+            expiresAt: '2026-04-22T00:00:00.000Z',
+            heartbeatIntervalSec: 15,
+            audio: {
+              encoding: 'pcm_s16le',
+              sampleRateHz: 16000,
+              channels: 1,
+              frameDurationMs: 100,
+              transport: 'json-base64',
+            },
+            limits: { maxConcurrentSessions: 3, maxFrameRatePerSecond: 10 },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    ),
+    overlayMessagingBridge: { send: vi.fn(() => Promise.resolve()) },
+    tabCaptureApi: { capture: vi.fn(() => Promise.resolve(null)) },
+    userMediaApi: { getUserMedia: vi.fn(() => Promise.reject(new Error('not implemented'))) },
+    desktopCaptureApi: {
+      getDisplayMedia: vi.fn(() => Promise.reject(new Error('not implemented'))),
+    },
+    clockMs: () => 1_700_000_000_000,
+    clockIso: () => '2026-04-21T00:00:00.000Z',
+    sessionIdFactory: () => SESSION_ID,
+    sourceIdFactory: () => SOURCE_ID,
+    translationIdFactory: () => TRANSLATION_ID,
+    exportIdFactory: () => EXPORT_ID,
+    ...overrides,
+  };
+};
+
+const defaultConfig: ExtensionRuntimeConfig = {
+  relayApiBaseUrl: 'http://localhost:3001',
+  relayAccessToken: 'access-token-fixture-value',
+  extensionVersion: '0.1.0',
+  protocolVersion: '1.0',
+  workletModuleUrl: '/audio-worklet.js',
+};
+
+describe('createExtensionApp (IMPL-500)', () => {
+  let app: ExtensionApp | null = null;
+  let databaseName: string;
+  let config: ExtensionRuntimeConfig;
+
+  beforeEach(() => {
+    app = null;
+    databaseName = `${INDEXED_DB_NAME}-test-${String(Math.random()).slice(2)}`;
+    config = { ...defaultConfig, databaseName };
+  });
+
+  afterEach(async () => {
+    if (app !== null) await app.close();
+  });
+
+  it('returns all composed facades with real adapters', () => {
+    app = createExtensionApp(config, createTestPorts());
+    expect(app.sessionCommandService).toBeDefined();
+    expect(app.exportService).toBeDefined();
+    expect(app.getSessionMonitorStateQuery).toBeDefined();
+    expect(app.sessionRegistry).toBeDefined();
+    expect(app.captureOrchestrator).toBeDefined();
+    expect(app.transcriptAssembler).toBeDefined();
+    expect(app.close).toBeTypeOf('function');
+  });
+
+  it('SessionRegistry starts empty', () => {
+    app = createExtensionApp(config, createTestPorts());
+    expect(app.sessionRegistry.listAll()).toEqual([]);
+    expect(app.sessionRegistry.findActive()).toEqual([]);
+  });
+
+  it('stopSource on non-existent session returns session-not-found ApplicationError', async () => {
+    app = createExtensionApp(config, createTestPorts());
+    const result = await app.sessionCommandService.stopSource({ sessionId: SESSION_ID });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe('session-not-found');
+    }
+  });
+
+  it('getSessionMonitorStateQuery returns ok with no active sessions', async () => {
+    app = createExtensionApp(config, createTestPorts());
+    const result = await app.getSessionMonitorStateQuery({ includeOverlayState: false });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessions).toEqual([]);
+    }
+  });
+
+  it('startSource fails with permission-required when ChromePermissionsApi denies', async () => {
+    const storage = createFakeStorage();
+    // Seed a profile so startSource does not fail on ExtensionProfileRepository
+    const profile = createExtensionProfile({
+      profileIdentifier: PROFILE_ID,
+      defaultLanguagePair: createLanguagePair({
+        source: 'en-US',
+        target: 'ja-JP',
+      })._unsafeUnwrap(),
+      defaultOverlaySettings: createOverlaySettings({
+        positionPreset: 'bottom',
+        opacity: 0.8,
+        maxLines: 2,
+        fontScale: 1,
+        showOriginalText: true,
+        showTranslatedText: true,
+      })._unsafeUnwrap(),
+      autoDetectEnabled: false,
+    })._unsafeUnwrap();
+    const profileRepo = createChromeLocalExtensionProfileRepository(storage);
+    await profileRepo.save(profile);
+
+    const ports = createTestPorts({
+      chromeStorageAdapter: storage,
+      chromePermissionsApi: { request: vi.fn(() => Promise.resolve(false)) },
+    });
+    app = createExtensionApp(config, ports);
+    const result = await app.sessionCommandService.startSource({
+      sourceType: 'tab',
+      displayName: 'test',
+      autoDetectLanguage: false,
+      targetLanguage: 'ja-JP',
+      overlayTarget: { kind: 'tab', tabId: 42 },
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe('permission-required');
+    }
+  });
+
+  it('close terminates all IndexedDB connections without throwing', async () => {
+    app = createExtensionApp(config, createTestPorts());
+    await expect(app.close()).resolves.toBeUndefined();
+    app = null;
+  });
+});

--- a/packages/extension/src/composition/extension-composition.ts
+++ b/packages/extension/src/composition/extension-composition.ts
@@ -1,0 +1,345 @@
+import { ulid } from 'ulid';
+import { createExportSessionResultUseCase } from '../application/use-cases/export-session-result-use-case';
+import { createGetSessionMonitorStateQuery } from '../application/use-cases/get-session-monitor-state-query';
+import { createHandleTranscriptFinalUseCase } from '../application/use-cases/handle-transcript-final-use-case';
+import { createHandleTranscriptPartialUseCase } from '../application/use-cases/handle-transcript-partial-use-case';
+import { createStartSourceSessionUseCase } from '../application/use-cases/start-source-session-use-case';
+import { createStopSourceSessionUseCase } from '../application/use-cases/stop-source-session-use-case';
+import { createUpdateSourceSettingsUseCase } from '../application/use-cases/update-source-settings-use-case';
+import {
+  createCaptureOrchestrator,
+  type CaptureOrchestrator,
+} from '../application/services/capture-orchestrator';
+import { createExportService, type ExportService } from '../application/services/export-service';
+import {
+  createSessionCommandService,
+  type SessionCommandService,
+} from '../application/services/session-command-service';
+import {
+  createSessionRegistry,
+  type SessionRegistry,
+} from '../application/services/session-registry';
+import {
+  createTranscriptAssembler,
+  type TranscriptAssembler,
+} from '../application/services/transcript-assembler';
+import { type GetSessionMonitorStateQuery } from '../application/use-cases/get-session-monitor-state-query';
+import { type SourceSession } from '../domain/session/source-session';
+import {
+  createAudioPreprocessor,
+  defaultAudioContextFactory,
+  type AudioContextFactory,
+} from '../infrastructure/audio/audio-preprocessor';
+import {
+  createDesktopCaptureSourceAdapter,
+  defaultDesktopCaptureApi,
+  type DesktopCaptureApi,
+} from '../infrastructure/capture/desktop-capture-source-adapter';
+import { createSourceAdapterFactory } from '../infrastructure/capture/source-adapter-factory';
+import {
+  createTabCaptureSourceAdapter,
+  defaultTabCaptureApi,
+  type TabCaptureApi,
+} from '../infrastructure/capture/tab-capture-source-adapter';
+import {
+  createUserMediaSourceAdapter,
+  defaultUserMediaApi,
+  type UserMediaApi,
+} from '../infrastructure/capture/user-media-source-adapter';
+import {
+  createChromeMessagingOverlayPresenter,
+  defaultOverlayMessagingBridge,
+  type OverlayMessagingBridge,
+} from '../infrastructure/overlay/chrome-messaging-overlay-presenter';
+import {
+  createChromePermissionCoordinator,
+  defaultChromePermissionsApi,
+  type ChromePermissionsApi,
+} from '../infrastructure/permission/chrome-permission-coordinator';
+import {
+  createDefaultWsEndpointBuilder,
+  createFetchStreamTokenIssuer,
+  type OverlayTargetDescriptor,
+} from '../infrastructure/relay/fetch-stream-token-issuer';
+import { createRelayWebSocketGateway } from '../infrastructure/relay/relay-websocket-gateway';
+import {
+  createBrowserWebSocketFactory,
+  type WebSocketFactory,
+} from '../infrastructure/relay/websocket-factory';
+import {
+  createChromeLocalExtensionProfileRepository,
+  createChromeLocalSettingsStore,
+  createIndexedDbExportRecordRepository,
+  createIndexedDbSessionStore,
+  createIndexedDbSourceSessionRepository,
+  createIndexedDbTranscriptStreamRepository,
+  defaultChromeStorageAdapter,
+  type ChromeStorageAdapter,
+  type CloseableExportRecordRepository,
+  type CloseableSessionStore,
+  type CloseableSourceSessionRepository,
+  type CloseableTranscriptStreamRepository,
+} from '../infrastructure/storage';
+
+/**
+ * IMPL-500 Background Service Worker composition root。
+ *
+ * 拡張エントリポイント (`entrypoints/background.ts`) から呼び出される DI 組立
+ * factory。Phase 1〜3.5 の全 infrastructure adapter と Phase 2 UseCase /
+ * Phase 3 application service を整合性のある形で配線する。
+ *
+ * **本番実装で mock / in-memory を使わない原則**:
+ * - 全 adapter が real implementation。`createProductionRuntimePorts` で
+ *   `chrome.*` / AudioContext / fetch / WebSocket などの production default を集約
+ * - test で利用する場合は `createExtensionApp(config, testPorts)` のように
+ *   override を明示注入 (ports の各要素は optional ではなく Required)
+ *
+ * 返り値 `ExtensionApp` は 3 つの application facade + SessionRegistry +
+ * teardown 関数を公開する。Service Worker は `sessionCommandService` を
+ * runtime message dispatch の dispatch target として使う。
+ */
+export type ExtensionRuntimeConfig = Readonly<{
+  /** Relay API base URL (例: `http://localhost:3001` / `https://relay.example.com`)。末尾 / なし */
+  relayApiBaseUrl: string;
+  /** POST /sessions 用の Bearer access token。`CLAUDE.md` §データ保存方針に従い chrome.storage 管理 */
+  relayAccessToken: string;
+  /** WebSocket パス (default `/api/v1/relay`) */
+  relayWsPath?: string;
+  /** 拡張バージョン (manifest.version) */
+  extensionVersion: string;
+  /** api-specification §4.1 client.protocolVersion */
+  protocolVersion: string;
+  /** IndexedDB 名 (default `perapera`) */
+  databaseName?: string;
+  /** AudioWorklet module URL (通常 `chrome.runtime.getURL('/audio-worklet.js')`) */
+  workletModuleUrl: string;
+  /** SourceSession → displayName (default: sourceType 名) */
+  resolveDisplayName?: (session: SourceSession) => string;
+  /** SourceSession → overlayTarget (default: `{ kind: 'monitor' }`) */
+  resolveOverlayTarget?: (session: SourceSession) => OverlayTargetDescriptor;
+  /** SourceSession → autoDetectLanguage (default: `false`) */
+  resolveAutoDetectLanguage?: (session: SourceSession) => boolean;
+}>;
+
+/**
+ * Infrastructure DI port 集合。production では `createProductionRuntimePorts()` の
+ * 結果をそのまま渡す。test では `chrome.*` を fake に差し替える。
+ */
+export type ExtensionRuntimePorts = Readonly<{
+  chromePermissionsApi: ChromePermissionsApi;
+  chromeStorageAdapter: ChromeStorageAdapter;
+  audioContextFactory: AudioContextFactory;
+  webSocketFactory: WebSocketFactory;
+  fetchImpl: typeof fetch;
+  overlayMessagingBridge: OverlayMessagingBridge;
+  tabCaptureApi: TabCaptureApi;
+  userMediaApi: UserMediaApi;
+  desktopCaptureApi: DesktopCaptureApi;
+  clockMs: () => number;
+  clockIso: () => string;
+  sessionIdFactory: () => string;
+  sourceIdFactory: () => string;
+  translationIdFactory: () => string;
+  exportIdFactory: () => string;
+}>;
+
+/**
+ * 拡張 production 環境向け DI port の既定セット。Service Worker 起動時に
+ * 一度だけ生成して `createExtensionApp` に渡す。
+ *
+ * すべて Phase 3 / Phase 3.5 で作成済の `defaultXxx` を使う。DI 対象は
+ * chrome.\* / AudioContext / fetch / WebSocket / ulid などの外部境界に限る。
+ */
+export const createProductionRuntimePorts = (): ExtensionRuntimePorts => ({
+  chromePermissionsApi: defaultChromePermissionsApi,
+  chromeStorageAdapter: defaultChromeStorageAdapter,
+  audioContextFactory: defaultAudioContextFactory,
+  webSocketFactory: createBrowserWebSocketFactory(),
+  fetchImpl: fetch,
+  overlayMessagingBridge: defaultOverlayMessagingBridge,
+  tabCaptureApi: defaultTabCaptureApi,
+  userMediaApi: defaultUserMediaApi,
+  desktopCaptureApi: defaultDesktopCaptureApi,
+  clockMs: () => Date.now(),
+  clockIso: () => new Date().toISOString(),
+  sessionIdFactory: () => ulid(),
+  sourceIdFactory: () => ulid(),
+  translationIdFactory: () => ulid(),
+  exportIdFactory: () => ulid(),
+});
+
+/**
+ * Service Worker 起動時に 1 度だけ生成される拡張アプリ。複数 facade を
+ * message dispatcher や popup/sidepanel から利用する。
+ *
+ * `close()` は IndexedDB connection と chrome-storage adapter の teardown を行う。
+ * Service Worker shutdown 時に呼ぶ (chrome.runtime.onSuspend 等)。
+ */
+export type ExtensionApp = Readonly<{
+  sessionCommandService: SessionCommandService;
+  exportService: ExportService;
+  getSessionMonitorStateQuery: GetSessionMonitorStateQuery;
+  sessionRegistry: SessionRegistry;
+  captureOrchestrator: CaptureOrchestrator;
+  transcriptAssembler: TranscriptAssembler;
+  close: () => Promise<void>;
+}>;
+
+const DEFAULT_RESOLVE_DISPLAY_NAME = (session: SourceSession): string => session.sourceType;
+const DEFAULT_RESOLVE_OVERLAY_TARGET = (_session: SourceSession): OverlayTargetDescriptor => ({
+  kind: 'monitor',
+});
+const DEFAULT_RESOLVE_AUTO_DETECT = (_session: SourceSession): boolean => false;
+
+export const createExtensionApp = (
+  config: ExtensionRuntimeConfig,
+  ports: ExtensionRuntimePorts,
+): ExtensionApp => {
+  // --------------- Storage (Phase 3 / 3.5) ---------------
+  const databaseName = config.databaseName;
+  const dbOptions = databaseName !== undefined ? { databaseName } : {};
+
+  const sessionStore: CloseableSessionStore = createIndexedDbSessionStore(dbOptions);
+  const settingsStore = createChromeLocalSettingsStore(ports.chromeStorageAdapter);
+
+  const sourceSessionRepository: CloseableSourceSessionRepository =
+    createIndexedDbSourceSessionRepository(dbOptions);
+  const transcriptStreamRepository: CloseableTranscriptStreamRepository =
+    createIndexedDbTranscriptStreamRepository(dbOptions);
+  const exportRecordRepository: CloseableExportRecordRepository =
+    createIndexedDbExportRecordRepository(dbOptions);
+  const extensionProfileRepository = createChromeLocalExtensionProfileRepository(
+    ports.chromeStorageAdapter,
+  );
+
+  // --------------- Capture / Audio ---------------
+  const tabCaptureSourceAdapter = createTabCaptureSourceAdapter({
+    tabCaptureApi: ports.tabCaptureApi,
+  });
+  const userMediaSourceAdapter = createUserMediaSourceAdapter({
+    userMediaApi: ports.userMediaApi,
+  });
+  const desktopCaptureSourceAdapter = createDesktopCaptureSourceAdapter({
+    desktopCaptureApi: ports.desktopCaptureApi,
+  });
+  const sourceAdapterFactory = createSourceAdapterFactory({
+    tabCaptureSourceAdapter,
+    userMediaSourceAdapter,
+    desktopCaptureSourceAdapter,
+  });
+  const audioPreprocessor = createAudioPreprocessor({
+    audioContextFactory: ports.audioContextFactory,
+    workletModuleUrl: config.workletModuleUrl,
+    clock: ports.clockMs,
+  });
+
+  // --------------- Permission + Relay ---------------
+  const permissionCoordinator = createChromePermissionCoordinator({
+    chromePermissionsApi: ports.chromePermissionsApi,
+  });
+  const tokenIssuer = createFetchStreamTokenIssuer({
+    baseUrl: config.relayApiBaseUrl,
+    accessToken: config.relayAccessToken,
+    extensionVersion: config.extensionVersion,
+    protocolVersion: config.protocolVersion,
+    resolveDisplayName: config.resolveDisplayName ?? DEFAULT_RESOLVE_DISPLAY_NAME,
+    resolveOverlayTarget: config.resolveOverlayTarget ?? DEFAULT_RESOLVE_OVERLAY_TARGET,
+    resolveAutoDetectLanguage: config.resolveAutoDetectLanguage ?? DEFAULT_RESOLVE_AUTO_DETECT,
+    fetchImpl: ports.fetchImpl,
+  });
+  const wsEndpointBuilder = createDefaultWsEndpointBuilder({
+    baseUrl: config.relayApiBaseUrl,
+    ...(config.relayWsPath !== undefined ? { wsPath: config.relayWsPath } : {}),
+  });
+  const relayGateway = createRelayWebSocketGateway({
+    webSocketFactory: ports.webSocketFactory,
+    tokenIssuer,
+    clock: ports.clockMs,
+    wsEndpointBuilder,
+  });
+
+  // --------------- Overlay / presenter ---------------
+  const overlayPresenter = createChromeMessagingOverlayPresenter({
+    bridge: ports.overlayMessagingBridge,
+  });
+
+  // --------------- UseCases (Phase 2) ---------------
+  const startSourceSessionUseCase = createStartSourceSessionUseCase({
+    sourceSessionRepository,
+    extensionProfileRepository,
+    relayGateway,
+    permissionCoordinator,
+    clock: ports.clockIso,
+    idFactory: {
+      session: ports.sessionIdFactory,
+      source: ports.sourceIdFactory,
+    },
+  });
+  const stopSourceSessionUseCase = createStopSourceSessionUseCase({
+    sourceSessionRepository,
+    relayGateway,
+    overlayPresenter,
+    clock: ports.clockIso,
+  });
+  const updateSourceSettingsUseCase = createUpdateSourceSettingsUseCase({
+    sourceSessionRepository,
+    overlayPresenter,
+    clock: ports.clockIso,
+  });
+  const handleTranscriptPartialUseCase = createHandleTranscriptPartialUseCase({
+    transcriptStreamRepository,
+    overlayPresenter,
+    sessionStore,
+    settingsStore,
+  });
+  const handleTranscriptFinalUseCase = createHandleTranscriptFinalUseCase({
+    transcriptStreamRepository,
+    overlayPresenter,
+    sessionStore,
+    settingsStore,
+    translationIdFactory: ports.translationIdFactory,
+  });
+  const exportSessionResultUseCase = createExportSessionResultUseCase({
+    sessionStore,
+    exportRecordRepository,
+    clock: ports.clockIso,
+    exportIdFactory: ports.exportIdFactory,
+  });
+  const getSessionMonitorStateQuery = createGetSessionMonitorStateQuery({
+    sourceSessionRepository,
+    transcriptStreamRepository,
+    settingsStore,
+  });
+
+  // --------------- Application services (Phase 3) ---------------
+  const sessionCommandService = createSessionCommandService({
+    startSourceSessionUseCase,
+    stopSourceSessionUseCase,
+    updateSourceSettingsUseCase,
+    handleTranscriptPartialUseCase,
+    handleTranscriptFinalUseCase,
+    clock: ports.clockMs,
+  });
+  const exportService = createExportService({ exportSessionResultUseCase });
+  const sessionRegistry = createSessionRegistry();
+  const captureOrchestrator = createCaptureOrchestrator({
+    sourceAdapterFactory,
+    audioPreprocessor,
+  });
+  const transcriptAssembler = createTranscriptAssembler();
+
+  return {
+    sessionCommandService,
+    exportService,
+    getSessionMonitorStateQuery,
+    sessionRegistry,
+    captureOrchestrator,
+    transcriptAssembler,
+    close: async () => {
+      await sessionStore.close();
+      await sourceSessionRepository.close();
+      await transcriptStreamRepository.close();
+      await exportRecordRepository.close();
+    },
+  };
+};

--- a/packages/extension/src/composition/runtime-dispatcher.test.ts
+++ b/packages/extension/src/composition/runtime-dispatcher.test.ts
@@ -1,0 +1,133 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  permissionRequiredAppError,
+  type ApplicationError,
+} from '../application/errors/application-errors';
+import { type ExportService } from '../application/services/export-service';
+import { type SessionCommandService } from '../application/services/session-command-service';
+import { type GetSessionMonitorStateQuery } from '../application/use-cases/get-session-monitor-state-query';
+import { createRuntimeDispatcher } from './runtime-dispatcher';
+
+const buildFakeDeps = () => {
+  const sessionCommandService: SessionCommandService = {
+    startSource: vi.fn(() => okAsync({ sessionId: 's', state: 'idle', startedAt: 'now' })),
+    stopSource: vi.fn(() => okAsync({ sessionId: 's', state: 'stopped', stoppedAt: 'now' })),
+    applySourceSettings: vi.fn(() => okAsync({ sessionId: 's', appliedAt: 'now' })),
+    handleRelayEvent: vi.fn(() => okAsync<void, ApplicationError>(undefined)),
+  };
+  const exportService: ExportService = {
+    export: vi.fn(() => okAsync({ exportId: 'exp', format: 'txt' as const, bytes: 100 })),
+  };
+  const getSessionMonitorStateQuery: GetSessionMonitorStateQuery = vi.fn(() =>
+    okAsync({ sessions: [], latestSegments: [] }),
+  );
+  return { sessionCommandService, exportService, getSessionMonitorStateQuery };
+};
+
+describe('createRuntimeDispatcher (IMPL-502)', () => {
+  it('dispatches command.start-source-session to SessionCommandService.startSource', async () => {
+    const deps = buildFakeDeps();
+    const dispatch = createRuntimeDispatcher(deps);
+    const response = await dispatch({
+      type: 'command.start-source-session',
+      input: {
+        sourceType: 'tab',
+        displayName: 'x',
+        autoDetectLanguage: false,
+        targetLanguage: 'ja-JP',
+        overlayTarget: { kind: 'tab', tabId: 42 },
+      },
+    });
+    expect(response.ok).toBe(true);
+    expect(deps.sessionCommandService.startSource).toHaveBeenCalledOnce();
+    expect(deps.sessionCommandService.stopSource).not.toHaveBeenCalled();
+  });
+
+  it('dispatches command.stop-source-session to SessionCommandService.stopSource', async () => {
+    const deps = buildFakeDeps();
+    const dispatch = createRuntimeDispatcher(deps);
+    await dispatch({
+      type: 'command.stop-source-session',
+      input: { sessionId: '01HZX8Y1R8M7D3Q2P4T5V6W7A1' },
+    });
+    expect(deps.sessionCommandService.stopSource).toHaveBeenCalledOnce();
+  });
+
+  it('dispatches command.update-source-settings to applySourceSettings', async () => {
+    const deps = buildFakeDeps();
+    const dispatch = createRuntimeDispatcher(deps);
+    await dispatch({
+      type: 'command.update-source-settings',
+      input: { sessionId: '01HZX8Y1R8M7D3Q2P4T5V6W7A1' },
+    });
+    expect(deps.sessionCommandService.applySourceSettings).toHaveBeenCalledOnce();
+  });
+
+  it('dispatches command.export-session-result to ExportService.export', async () => {
+    const deps = buildFakeDeps();
+    const dispatch = createRuntimeDispatcher(deps);
+    const response = await dispatch({
+      type: 'command.export-session-result',
+      input: {
+        sessionId: '01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: true,
+      },
+    });
+    expect(response.ok).toBe(true);
+    expect(deps.exportService.export).toHaveBeenCalledOnce();
+  });
+
+  it('dispatches query.get-session-monitor-state to GetSessionMonitorStateQuery', async () => {
+    const deps = buildFakeDeps();
+    const dispatch = createRuntimeDispatcher(deps);
+    const response = await dispatch({
+      type: 'query.get-session-monitor-state',
+      input: { includeOverlayState: false },
+    });
+    expect(response.ok).toBe(true);
+    expect(deps.getSessionMonitorStateQuery).toHaveBeenCalledOnce();
+  });
+
+  it('returns validation-error when the request payload is malformed', async () => {
+    const deps = buildFakeDeps();
+    const dispatch = createRuntimeDispatcher(deps);
+    const response = await dispatch({ type: 'not-a-valid-command' });
+    expect(response.ok).toBe(false);
+    if (!response.ok) {
+      expect(response.error.type).toBe('validation');
+    }
+  });
+
+  it('propagates ApplicationError from UseCase failure', async () => {
+    const fakeError = permissionRequiredAppError({
+      sourceType: 'tab',
+      message: 'denied',
+    });
+    const deps = buildFakeDeps();
+    const depsWithFailure = {
+      ...deps,
+      sessionCommandService: {
+        ...deps.sessionCommandService,
+        startSource: vi.fn(() => errAsync(fakeError)),
+      },
+    };
+    const dispatch = createRuntimeDispatcher(depsWithFailure);
+    const response = await dispatch({
+      type: 'command.start-source-session',
+      input: {
+        sourceType: 'tab',
+        displayName: 'x',
+        autoDetectLanguage: false,
+        targetLanguage: 'ja-JP',
+        overlayTarget: { kind: 'tab', tabId: 42 },
+      },
+    });
+    expect(response.ok).toBe(false);
+    if (!response.ok) {
+      expect(response.error.type).toBe('permission-required');
+    }
+  });
+});

--- a/packages/extension/src/composition/runtime-dispatcher.ts
+++ b/packages/extension/src/composition/runtime-dispatcher.ts
@@ -1,0 +1,70 @@
+import { type ResultAsync } from 'neverthrow';
+import {
+  type ApplicationError,
+  toApplicationError,
+} from '../application/errors/application-errors';
+import { type ExportService } from '../application/services/export-service';
+import { type SessionCommandService } from '../application/services/session-command-service';
+import { type GetSessionMonitorStateQuery } from '../application/use-cases/get-session-monitor-state-query';
+import { parseBackgroundRequest, type BackgroundResponse } from './runtime-messages';
+
+/**
+ * IMPL-502 Runtime message dispatcher。
+ *
+ * chrome.runtime.onMessage に登録する handler。`BackgroundRequest` を
+ * discriminated union で分岐し、対応する application facade に dispatch する。
+ *
+ * **本番実装で mock / in-memory を使わない設計**:
+ * - `SessionCommandService` / `ExportService` / `GetSessionMonitorStateQuery`
+ *   は **必須 DI** (default なし)
+ * - production entrypoint (`background.ts`) で `createExtensionApp` が返した
+ *   全 facade を明示的に渡す
+ */
+export type RuntimeDispatcherDependencies = Readonly<{
+  sessionCommandService: SessionCommandService;
+  exportService: ExportService;
+  getSessionMonitorStateQuery: GetSessionMonitorStateQuery;
+}>;
+
+/**
+ * Response は chrome.runtime.sendMessage のペイロードとして JSON serialize
+ * されるため、dispatcher 側は UseCase output DTO をそのまま包んで返す。
+ * UI 側 (popup / sidepanel) は request.type ごとに value の shape を
+ * type-narrow する (presentation 層で改めて schema 検証)。
+ */
+export type RuntimeDispatcher = (raw: unknown) => Promise<BackgroundResponse<unknown>>;
+
+const toOk = (value: unknown): BackgroundResponse<unknown> => ({ ok: true, value });
+const toErr = (error: ApplicationError): BackgroundResponse<unknown> => ({ ok: false, error });
+
+const run = async (promise: ResultAsync<unknown, ApplicationError>) => {
+  const result = await promise;
+  return result.match(toOk, toErr);
+};
+
+/**
+ * `createRuntimeDispatcher(deps)(rawMessage)` 形式で呼び出す。
+ * return 値は単一 `BackgroundResponse<unknown>`。chrome.runtime.onMessage の
+ * sendResponse にそのまま渡せる。
+ */
+export const createRuntimeDispatcher = (deps: RuntimeDispatcherDependencies): RuntimeDispatcher => {
+  return async (raw) => {
+    const parseResult = parseBackgroundRequest(raw).mapErr(toApplicationError);
+    if (parseResult.isErr()) {
+      return toErr(parseResult.error);
+    }
+    const request = parseResult.value;
+    switch (request.type) {
+      case 'command.start-source-session':
+        return run(deps.sessionCommandService.startSource(request.input));
+      case 'command.stop-source-session':
+        return run(deps.sessionCommandService.stopSource(request.input));
+      case 'command.update-source-settings':
+        return run(deps.sessionCommandService.applySourceSettings(request.input));
+      case 'command.export-session-result':
+        return run(deps.exportService.export(request.input));
+      case 'query.get-session-monitor-state':
+        return run(deps.getSessionMonitorStateQuery(request.input));
+    }
+  };
+};

--- a/packages/extension/src/composition/runtime-messages.test.ts
+++ b/packages/extension/src/composition/runtime-messages.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { parseBackgroundRequest } from './runtime-messages';
+
+describe('parseBackgroundRequest (IMPL-501)', () => {
+  it('parses a start-source-session command', () => {
+    const result = parseBackgroundRequest({
+      type: 'command.start-source-session',
+      input: {
+        sourceType: 'tab',
+        displayName: 'YouTube Live',
+        sourceLanguage: 'en-US',
+        autoDetectLanguage: false,
+        targetLanguage: 'ja-JP',
+        overlayTarget: { kind: 'tab', tabId: 42 },
+      },
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && result.value.type === 'command.start-source-session') {
+      expect(result.value.input.sourceType).toBe('tab');
+      expect(result.value.input.overlayTarget.kind).toBe('tab');
+    }
+  });
+
+  it('parses a stop-source-session command', () => {
+    const result = parseBackgroundRequest({
+      type: 'command.stop-source-session',
+      input: { sessionId: '01HZX8Y1R8M7D3Q2P4T5V6W7A1' },
+    });
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('parses an update-source-settings command with overlaySettings', () => {
+    const result = parseBackgroundRequest({
+      type: 'command.update-source-settings',
+      input: {
+        sessionId: '01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+        overlaySettings: {
+          positionPreset: 'bottom',
+          opacity: 0.8,
+          maxLines: 2,
+          fontScale: 1,
+          showOriginalText: true,
+          showTranslatedText: true,
+        },
+      },
+    });
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('parses an export-session-result command', () => {
+    const result = parseBackgroundRequest({
+      type: 'command.export-session-result',
+      input: {
+        sessionId: '01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+        format: 'json',
+        includeOriginal: true,
+        includeTranslation: false,
+      },
+    });
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('parses a get-session-monitor-state query', () => {
+    const result = parseBackgroundRequest({
+      type: 'query.get-session-monitor-state',
+      input: {
+        includeOverlayState: true,
+        sessionIds: ['01HZX8Y1R8M7D3Q2P4T5V6W7A1'],
+      },
+    });
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects an unknown type', () => {
+    const result = parseBackgroundRequest({ type: 'command.unknown', input: {} });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('rejects malformed overlayTarget kind', () => {
+    const result = parseBackgroundRequest({
+      type: 'command.start-source-session',
+      input: {
+        sourceType: 'tab',
+        displayName: 'x',
+        autoDetectLanguage: false,
+        targetLanguage: 'ja-JP',
+        overlayTarget: { kind: 'bad-value' },
+      },
+    });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects invalid BCP-47 language code', () => {
+    const result = parseBackgroundRequest({
+      type: 'command.start-source-session',
+      input: {
+        sourceType: 'tab',
+        displayName: 'x',
+        autoDetectLanguage: false,
+        targetLanguage: 'invalid_code',
+        overlayTarget: { kind: 'tab', tabId: 42 },
+      },
+    });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects when top-level `type` is missing', () => {
+    const result = parseBackgroundRequest({ input: {} });
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/extension/src/composition/runtime-messages.ts
+++ b/packages/extension/src/composition/runtime-messages.ts
@@ -1,0 +1,129 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type ApplicationError } from '../application/errors/application-errors';
+import { validationError, type DomainError } from '../domain/shared/errors';
+
+/**
+ * IMPL-501 Runtime message schema (Popup / SidePanel ↔ Background)。
+ *
+ * chrome.runtime.onMessage ベースの Request / Response 形式。全ペイロードは
+ * Zod で validation し、不正は `validationError` として弾く。
+ *
+ * **設計メモ**:
+ * - Request と Response は常にタグ付き discriminated union
+ * - Response の `ok` フラグでエラー分岐 (Result 風)。UseCase 側の
+ *   ApplicationError をそのまま serialize して UI 側に届ける
+ * - Application 層の DTO (`StartSourceSessionInput` 等) を直接渡さず、
+ *   本層でも独立スキーマを持つ (presentation 層が application 層に直接
+ *   依存しない境界を保つ)
+ */
+
+const sourceTypeSchema = z.enum(['tab', 'microphone', 'desktop']);
+const bcp47Schema = z.string().regex(/^[a-z]{2,3}(?:-[A-Z]{2})?$/);
+
+const overlayTargetSchema = z.object({
+  kind: z.enum(['tab', 'extension-monitor']),
+  tabId: z.number().int().nonnegative().optional(),
+  pageId: z.string().min(1).optional(),
+});
+
+const startSourceSessionRequestSchema = z.object({
+  type: z.literal('command.start-source-session'),
+  input: z.object({
+    sourceType: sourceTypeSchema,
+    displayName: z.string().min(1),
+    sourceLanguage: bcp47Schema.nullable().optional(),
+    autoDetectLanguage: z.boolean(),
+    targetLanguage: bcp47Schema,
+    overlayTarget: overlayTargetSchema,
+  }),
+});
+
+const stopSourceSessionRequestSchema = z.object({
+  type: z.literal('command.stop-source-session'),
+  input: z.object({
+    sessionId: z.string().min(1),
+  }),
+});
+
+/**
+ * overlaySettings 更新は全フィールド必須 (application layer DTO 準拠)。
+ * 省略したい場合は request 自体で `overlaySettings` を undefined に。
+ */
+const overlaySettingsPayloadSchema = z.object({
+  positionPreset: z.enum(['top', 'bottom', 'floating']),
+  opacity: z.number().min(0).max(1),
+  maxLines: z.number().int().min(1),
+  fontScale: z.number().positive(),
+  showOriginalText: z.boolean(),
+  showTranslatedText: z.boolean(),
+});
+
+const updateSourceSettingsRequestSchema = z.object({
+  type: z.literal('command.update-source-settings'),
+  input: z.object({
+    sessionId: z.string().min(1),
+    sourceLanguage: bcp47Schema.nullable().optional(),
+    targetLanguage: bcp47Schema.optional(),
+    overlaySettings: overlaySettingsPayloadSchema.optional(),
+  }),
+});
+
+const exportSessionResultRequestSchema = z.object({
+  type: z.literal('command.export-session-result'),
+  input: z.object({
+    sessionId: z.string().min(1),
+    format: z.enum(['txt', 'json']),
+    includeOriginal: z.boolean(),
+    includeTranslation: z.boolean(),
+  }),
+});
+
+const getSessionMonitorStateRequestSchema = z.object({
+  type: z.literal('query.get-session-monitor-state'),
+  input: z.object({
+    sessionIds: z.array(z.string().min(1)).min(1).optional(),
+    includeOverlayState: z.boolean(),
+  }),
+});
+
+export const backgroundRequestSchema = z.discriminatedUnion('type', [
+  startSourceSessionRequestSchema,
+  stopSourceSessionRequestSchema,
+  updateSourceSettingsRequestSchema,
+  exportSessionResultRequestSchema,
+  getSessionMonitorStateRequestSchema,
+]);
+
+export type BackgroundRequest = z.infer<typeof backgroundRequestSchema>;
+
+/**
+ * 成功レスポンス (UseCase の output DTO をそのまま bundle)
+ * エラーレスポンス (`ApplicationError` の識別子・フィールドを保持)。
+ *
+ * NOTE: Popup / SidePanel 側 (presentation layer) は `ApplicationError` の
+ * 具体型を知らなくてよい。discriminator (`type`) / `message` だけで UI 判定
+ * 可能な形で渡す (`ApplicationError` の type 列挙は use case 設計書
+ * §9.2 参照)。
+ */
+export type BackgroundResponse<T> =
+  | Readonly<{ ok: true; value: T }>
+  | Readonly<{ ok: false; error: ApplicationError }>;
+
+/**
+ * Request を parse する helper。Popup 側から届いた任意 shape の unknown を
+ * 受け取り、discriminated union にマッピングする。失敗は `DomainError`
+ * (validation) で返す。
+ */
+export const parseBackgroundRequest = (raw: unknown): Result<BackgroundRequest, DomainError> => {
+  const result = backgroundRequestSchema.safeParse(raw);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'BackgroundRequest',
+        message: result.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/extension/src/entrypoints/background.ts
+++ b/packages/extension/src/entrypoints/background.ts
@@ -1,5 +1,112 @@
+import {
+  createExtensionApp,
+  createProductionRuntimePorts,
+  type ExtensionApp,
+  type ExtensionRuntimeConfig,
+} from '../composition/extension-composition';
+import { createRuntimeDispatcher, type RuntimeDispatcher } from '../composition/runtime-dispatcher';
+
+/**
+ * IMPL-500 Background Service Worker entrypoint。
+ *
+ * `createExtensionApp` で composition root を作り、`chrome.runtime.onMessage`
+ * を dispatcher に結線する。Popup / SidePanel 側は `chrome.runtime.sendMessage`
+ * で `BackgroundRequest` を送り、`BackgroundResponse<T>` を受け取る。
+ *
+ * **本番実装で mock / in-memory を使わない設計**:
+ * - `createProductionRuntimePorts()` が返す default ports は全て real
+ *   (chrome.\* / AudioContext / fetch / WebSocket / IndexedDB)
+ * - env 由来 secret (`RELAY_ACCESS_TOKEN`) が欠落した場合は本 entry で
+ *   console.error + 起動失敗 (UseCase 起動時に relay 接続が fail-fast)
+ */
+
+const RELAY_API_BASE_URL = (() => {
+  const fromDefine =
+    typeof import.meta.env.PERAPERA_RELAY_API_BASE_URL === 'string'
+      ? import.meta.env.PERAPERA_RELAY_API_BASE_URL
+      : undefined;
+  return fromDefine ?? 'http://localhost:3001';
+})();
+
+const RELAY_ACCESS_TOKEN = (() => {
+  const fromDefine =
+    typeof import.meta.env.PERAPERA_RELAY_ACCESS_TOKEN === 'string'
+      ? import.meta.env.PERAPERA_RELAY_ACCESS_TOKEN
+      : undefined;
+  return fromDefine ?? '';
+})();
+
+const EXTENSION_VERSION = (() => {
+  try {
+    const manifest = chrome.runtime.getManifest();
+    return typeof manifest.version === 'string' ? manifest.version : '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+})();
+
+const WORKLET_MODULE_URL = (() => {
+  try {
+    return chrome.runtime.getURL('/audio-worklet.js');
+  } catch {
+    return '/audio-worklet.js';
+  }
+})();
+
 export default defineBackground(() => {
-  // Service Worker: SessionCommandService の核として後続で実装
-  // 現段階は拡張が起動することの確認のみ
   console.log('[perapera] background service worker loaded');
+
+  if (RELAY_ACCESS_TOKEN.length === 0) {
+    console.error(
+      '[perapera] PERAPERA_RELAY_ACCESS_TOKEN is not configured; relay calls will fail on session start. Configure via wxt define or chrome.storage.',
+    );
+  }
+
+  const config: ExtensionRuntimeConfig = {
+    relayApiBaseUrl: RELAY_API_BASE_URL,
+    relayAccessToken: RELAY_ACCESS_TOKEN,
+    extensionVersion: EXTENSION_VERSION,
+    protocolVersion: '1.0',
+    workletModuleUrl: WORKLET_MODULE_URL,
+  };
+  const ports = createProductionRuntimePorts();
+  const app: ExtensionApp = createExtensionApp(config, ports);
+  const dispatch: RuntimeDispatcher = createRuntimeDispatcher({
+    sessionCommandService: app.sessionCommandService,
+    exportService: app.exportService,
+    getSessionMonitorStateQuery: app.getSessionMonitorStateQuery,
+  });
+
+  /**
+   * chrome.runtime.onMessage listener。`sendResponse` は Promise 連携のため
+   * `return true` で非同期応答を宣言し、dispatcher の Promise を解決したら
+   * `sendResponse` に渡す (Chrome の仕様)。
+   */
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    void dispatch(message)
+      .then((response) => {
+        sendResponse(response);
+      })
+      .catch((cause: unknown) => {
+        console.error('[perapera] runtime dispatcher threw:', cause);
+        sendResponse({
+          ok: false,
+          error: {
+            type: 'unexpected',
+            message: cause instanceof Error ? cause.message : 'unknown error',
+          },
+        });
+      });
+    return true;
+  });
+
+  /**
+   * Service Worker shutdown 時に IndexedDB connection を閉じる。
+   * chrome.runtime.onSuspend は MV3 では非決定的だが、ベストエフォートで teardown。
+   */
+  chrome.runtime.onSuspend.addListener(() => {
+    void app.close().catch((cause) => {
+      console.warn('[perapera] ExtensionApp.close failed during onSuspend:', cause);
+    });
+  });
 });

--- a/packages/extension/src/infrastructure/overlay/chrome-messaging-overlay-presenter.test.ts
+++ b/packages/extension/src/infrastructure/overlay/chrome-messaging-overlay-presenter.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { createOverlaySettings } from '../../domain/profile/overlay-settings';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { parseSegmentIdentifier } from '../../domain/transcript/segment-identifier';
+import {
+  createChromeMessagingOverlayPresenter,
+  type OverlayCommand,
+  type OverlayMessagingBridge,
+} from './chrome-messaging-overlay-presenter';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7D1';
+
+const identifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const createRecordingBridge = (
+  failOn?: OverlayCommand['type'],
+): { bridge: OverlayMessagingBridge; captured: OverlayCommand[] } => {
+  const captured: OverlayCommand[] = [];
+  return {
+    captured,
+    bridge: {
+      send: (message) => {
+        captured.push(message);
+        if (failOn !== undefined && message.type === failOn) {
+          return Promise.reject(new Error(`send failed for ${message.type}`));
+        }
+        return Promise.resolve();
+      },
+    },
+  };
+};
+
+describe('createChromeMessagingOverlayPresenter (IMPL-331)', () => {
+  it('forwards mount commands to the bridge', async () => {
+    const { bridge, captured } = createRecordingBridge();
+    const presenter = createChromeMessagingOverlayPresenter({ bridge });
+    const result = await presenter.mount(identifier);
+    expect(result.isOk()).toBe(true);
+    expect(captured).toEqual([{ type: 'overlay.mount', sessionIdentifier: identifier }]);
+  });
+
+  it('forwards render commands with the full model', async () => {
+    const { bridge, captured } = createRecordingBridge();
+    const presenter = createChromeMessagingOverlayPresenter({ bridge });
+    const segmentId = parseSegmentIdentifier(SEGMENT_ID)._unsafeUnwrap();
+    const result = await presenter.render({
+      sessionIdentifier: identifier,
+      lines: [
+        {
+          segmentIdentifier: segmentId,
+          originalText: 'hello',
+          translatedText: 'こんにちは',
+          targetLanguage: 'ja-JP',
+          isFinal: true,
+        },
+      ],
+    });
+    expect(result.isOk()).toBe(true);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.type).toBe('overlay.render');
+    if (captured[0]?.type === 'overlay.render') {
+      expect(captured[0].model.lines[0]?.translatedText).toBe('こんにちは');
+    }
+  });
+
+  it('forwards updateSettings commands', async () => {
+    const { bridge, captured } = createRecordingBridge();
+    const presenter = createChromeMessagingOverlayPresenter({ bridge });
+    const settings = createOverlaySettings({
+      positionPreset: 'bottom',
+      opacity: 0.8,
+      maxLines: 2,
+      fontScale: 1,
+      showOriginalText: true,
+      showTranslatedText: true,
+    })._unsafeUnwrap();
+    const result = await presenter.updateSettings(identifier, settings);
+    expect(result.isOk()).toBe(true);
+    expect(captured[0]?.type).toBe('overlay.update-settings');
+  });
+
+  it('forwards unmount commands', async () => {
+    const { bridge, captured } = createRecordingBridge();
+    const presenter = createChromeMessagingOverlayPresenter({ bridge });
+    const result = await presenter.unmount(identifier);
+    expect(result.isOk()).toBe(true);
+    expect(captured).toEqual([{ type: 'overlay.unmount', sessionIdentifier: identifier }]);
+  });
+
+  it('returns invariant-violation when the bridge rejects', async () => {
+    const { bridge } = createRecordingBridge('overlay.render');
+    const presenter = createChromeMessagingOverlayPresenter({ bridge });
+    const result = await presenter.render({
+      sessionIdentifier: identifier,
+      lines: [],
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.kind).toBe('invariant-violation');
+      if (result.error.kind === 'invariant-violation') {
+        expect(result.error.invariant).toBe('overlay-messaging');
+      }
+    }
+  });
+});

--- a/packages/extension/src/infrastructure/overlay/chrome-messaging-overlay-presenter.ts
+++ b/packages/extension/src/infrastructure/overlay/chrome-messaging-overlay-presenter.ts
@@ -1,0 +1,135 @@
+import { ResultAsync } from 'neverthrow';
+import { type OverlaySettings } from '../../domain/profile/overlay-settings';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import {
+  type OverlayPresenter,
+  type OverlayRenderModel,
+} from '../../application/ports/overlay-presenter';
+
+/**
+ * Overlay への chrome.* messaging 操作を隠蔽する adapter contract。
+ * production では `chrome.runtime.sendMessage` / `chrome.tabs.sendMessage` を
+ * wrap した default 実装、test では fake を注入する。
+ *
+ * **設計メモ**: Background Service Worker は DOM を直接扱えないため、
+ * 実際の Shadow DOM / React rendering は Content Script 側に置く。
+ * 本 adapter は SW 側 `OverlayPresenter` 契約を満たしつつ、描画命令を
+ * 対象タブの content script または monitor page へ message で転送するだけ。
+ */
+export type OverlayMessagingBridge = Readonly<{
+  /** content script / monitor へ overlay 描画命令を送る (fire-and-forget 可) */
+  send: (message: OverlayCommand) => Promise<void>;
+}>;
+
+/**
+ * Background → Content script / Monitor への overlay command envelope。
+ * content script 側で Zod schema で validate する想定。
+ */
+export type OverlayCommand =
+  | Readonly<{
+      type: 'overlay.mount';
+      sessionIdentifier: SessionIdentifier;
+    }>
+  | Readonly<{
+      type: 'overlay.render';
+      model: OverlayRenderModel;
+    }>
+  | Readonly<{
+      type: 'overlay.update-settings';
+      sessionIdentifier: SessionIdentifier;
+      settings: OverlaySettings;
+    }>
+  | Readonly<{
+      type: 'overlay.unmount';
+      sessionIdentifier: SessionIdentifier;
+    }>;
+
+/**
+ * Production 用 `OverlayMessagingBridge` (mock ではない)。`chrome.runtime`
+ * 越しに全 listener へブロードキャストする。content script は自身に紐づく
+ * session のみを受け取り描画する (session ownership は content script 側で判定)。
+ *
+ * 送信失敗 (受信者ゼロを含む) は resolve される。`chrome.runtime.sendMessage`
+ * の仕様上 listener 不在時に reject しないため、SW 側は常に成功として扱う。
+ */
+export const defaultOverlayMessagingBridge: OverlayMessagingBridge = {
+  send: (message) =>
+    new Promise<void>((resolve) => {
+      try {
+        // chrome.runtime.sendMessage は callback / Promise API の両方を持つ。
+        // 互換性を取るため callback API を採用し、lastError を握り潰す
+        // (受信者ゼロでも SW 側は正常終了とみなす)。
+        chrome.runtime.sendMessage(message, () => {
+          // Reset lastError implicitly by observing it once.
+          void chrome.runtime.lastError;
+          resolve();
+        });
+      } catch {
+        resolve();
+      }
+    }),
+};
+
+export type ChromeMessagingOverlayPresenterDependencies = Readonly<{
+  bridge: OverlayMessagingBridge;
+}>;
+
+const toInvariant =
+  (scope: string) =>
+  (cause: unknown): DomainError =>
+    invariantViolationError({
+      invariant: 'overlay-messaging',
+      details: `${scope}: ${cause instanceof Error ? cause.message : String(cause)}`,
+    });
+
+/**
+ * IMPL-331 ChromeMessagingOverlayPresenter (DD-108 派生)。
+ *
+ * Background Service Worker 側で `OverlayPresenter` 契約を満たす adapter。
+ * 実際の描画は chrome.runtime messaging を介して content script / monitor
+ * page に委譲する。content script 側 (Phase 5 PR 次 #4 で実装) が
+ * `OverlayCommand` を受けて `ContentScriptOverlayPresenter` (IMPL-330) を
+ * 呼ぶ構成。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - `bridge` は必須 DI。production entrypoint で
+ *   `defaultOverlayMessagingBridge` を明示的に渡す
+ * - test では fake bridge を注入
+ *
+ * エラー型: chrome.runtime.sendMessage 側の throw を捕捉した場合のみ
+ * `invariantViolationError({ invariant: 'overlay-messaging' })` を返す。
+ * 受信者不在 (content script が読み込まれていない等) はエラーではなく
+ * 正常終了 (UseCase 側で `match` により握り潰される、hot-path 停止回避)。
+ */
+export const createChromeMessagingOverlayPresenter = (
+  deps: ChromeMessagingOverlayPresenterDependencies,
+): OverlayPresenter => ({
+  mount: (sessionIdentifier) =>
+    ResultAsync.fromPromise<void, DomainError>(
+      deps.bridge.send({ type: 'overlay.mount', sessionIdentifier }),
+      toInvariant('mount'),
+    ),
+
+  render: (model) =>
+    ResultAsync.fromPromise<void, DomainError>(
+      deps.bridge.send({ type: 'overlay.render', model }),
+      toInvariant('render'),
+    ),
+
+  updateSettings: (sessionIdentifier, settings) =>
+    ResultAsync.fromPromise<void, DomainError>(
+      deps.bridge.send({
+        type: 'overlay.update-settings',
+        sessionIdentifier,
+        settings,
+      }),
+      toInvariant('updateSettings'),
+    ),
+
+  unmount: (sessionIdentifier) =>
+    ResultAsync.fromPromise<void, DomainError>(
+      deps.bridge.send({ type: 'overlay.unmount', sessionIdentifier }),
+      toInvariant('unmount'),
+    ),
+});

--- a/packages/extension/src/infrastructure/permission/chrome-permission-coordinator.test.ts
+++ b/packages/extension/src/infrastructure/permission/chrome-permission-coordinator.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createChromePermissionCoordinator,
+  type ChromePermissionsApi,
+} from './chrome-permission-coordinator';
+
+const createFakeApi = (granted: boolean | Error): ChromePermissionsApi => ({
+  request: () => (granted instanceof Error ? Promise.reject(granted) : Promise.resolve(granted)),
+});
+
+describe('createChromePermissionCoordinator (IMPL-318, DD-001)', () => {
+  it('returns granted when chrome.permissions.request resolves true for tab', async () => {
+    const coordinator = createChromePermissionCoordinator({
+      chromePermissionsApi: createFakeApi(true),
+    });
+    const result = await coordinator.requestFor('tab');
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.status).toBe('granted');
+      expect(result.value.sourceType).toBe('tab');
+    }
+  });
+
+  it('returns denied when chrome.permissions.request resolves false for desktop', async () => {
+    const coordinator = createChromePermissionCoordinator({
+      chromePermissionsApi: createFakeApi(false),
+    });
+    const result = await coordinator.requestFor('desktop');
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.status).toBe('denied');
+      expect(result.value.sourceType).toBe('desktop');
+    }
+  });
+
+  it('returns system-error DomainError when chrome.permissions.request rejects', async () => {
+    const coordinator = createChromePermissionCoordinator({
+      chromePermissionsApi: createFakeApi(new Error('permission api down')),
+    });
+    const result = await coordinator.requestFor('tab');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.kind).toBe('invariant-violation');
+      if (result.error.kind === 'invariant-violation') {
+        expect(result.error.invariant).toBe('permission-coordinator-system-error');
+      }
+    }
+  });
+
+  it('returns granted synchronously for microphone (getUserMedia UA prompt handles consent)', async () => {
+    const coordinator = createChromePermissionCoordinator({
+      chromePermissionsApi: createFakeApi(new Error('should not be called')),
+    });
+    const result = await coordinator.requestFor('microphone');
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.status).toBe('granted');
+      expect(result.value.sourceType).toBe('microphone');
+    }
+  });
+});

--- a/packages/extension/src/infrastructure/permission/chrome-permission-coordinator.ts
+++ b/packages/extension/src/infrastructure/permission/chrome-permission-coordinator.ts
@@ -1,0 +1,109 @@
+import { ResultAsync } from 'neverthrow';
+import {
+  type PermissionCoordinator,
+  type PermissionGrant,
+} from '../../application/ports/permission-coordinator';
+import { type SourceType } from '../../domain/session/source-type';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+
+/**
+ * chrome.permissions API の最小 contract。production では chrome.permissions を
+ * そのまま利用する default 実装を、test では minimal fake を注入する。
+ *
+ * MVP では `request` のみを使う ( `contains` / `remove` は将来拡張)。
+ */
+export type ChromePermissionsApi = Readonly<{
+  request: (permissions: chrome.permissions.Permissions) => Promise<boolean>;
+}>;
+
+/**
+ * Production `ChromePermissionsApi` 実装 (mock ではない)。
+ * `chrome.permissions.request` の callback API を Promise に wrap する。
+ * `chrome.runtime.lastError` は Promise reject に変換する。
+ */
+export const defaultChromePermissionsApi: ChromePermissionsApi = {
+  request: (permissions) =>
+    new Promise<boolean>((resolve, reject) => {
+      try {
+        chrome.permissions.request(permissions, (granted) => {
+          const lastError = chrome.runtime.lastError;
+          if (lastError !== undefined) {
+            reject(new Error(lastError.message ?? 'unknown chrome.permissions error'));
+            return;
+          }
+          resolve(granted);
+        });
+      } catch (cause) {
+        reject(cause instanceof Error ? cause : new Error(String(cause)));
+      }
+    }),
+};
+
+/**
+ * `SourceType` に応じた chrome.permissions request パラメータ (DD-001)。
+ *
+ * MV3 拡張では `permissions` / `host_permissions` / `audio-capture` host が
+ * manifest 側で静的宣言される一方、`desktopCapture` / `tabCapture` の runtime
+ * 許可はユーザーのアクション伴う確認が必要。ここでは MVP 範囲として
+ * optional permissions の request を通す。
+ */
+const PERMISSION_FOR_SOURCE: Readonly<Record<SourceType, chrome.permissions.Permissions>> = {
+  tab: { permissions: ['tabCapture'] },
+  microphone: { permissions: [], origins: [] }, // microphone は getUserMedia の UA prompt に依存
+  desktop: { permissions: ['desktopCapture'] },
+};
+
+/**
+ * IMPL-318 ChromePermissionCoordinator (DD-001)。
+ *
+ * `chrome.permissions.request` を介して拡張が必要とする optional permission を
+ * 要求する `PermissionCoordinator` 実装。microphone については chrome API 側で
+ * 扱わず、`getUserMedia` の UA prompt に委ねる (granted を即時返す)。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - `chromePermissionsApi` は必須 DI。production entrypoint で
+ *   `defaultChromePermissionsApi` を明示的に渡す
+ * - test では minimal fake を注入する
+ *
+ * `PermissionGrant.denied` はドメイン仕様上 DomainError ではない。
+ * chrome.permissions.request が throw / reject した場合のみ DomainError を返す。
+ */
+export type ChromePermissionCoordinatorDependencies = Readonly<{
+  chromePermissionsApi: ChromePermissionsApi;
+}>;
+
+export const createChromePermissionCoordinator = (
+  deps: ChromePermissionCoordinatorDependencies,
+): PermissionCoordinator => ({
+  requestFor: (sourceType) => {
+    const permissions = PERMISSION_FOR_SOURCE[sourceType];
+    const permissionsIsEmpty =
+      (permissions.permissions?.length ?? 0) === 0 && (permissions.origins?.length ?? 0) === 0;
+    if (permissionsIsEmpty) {
+      return ResultAsync.fromPromise<PermissionGrant, DomainError>(
+        Promise.resolve<PermissionGrant>({ status: 'granted', sourceType }),
+        () =>
+          invariantViolationError({
+            invariant: 'permission-coordinator-impossible',
+            details: 'empty permissions resolved synchronously cannot error',
+          }),
+      );
+    }
+    return ResultAsync.fromPromise<boolean, DomainError>(
+      deps.chromePermissionsApi.request(permissions),
+      (cause) =>
+        invariantViolationError({
+          invariant: 'permission-coordinator-system-error',
+          details: cause instanceof Error ? cause.message : String(cause),
+        }),
+    ).map<PermissionGrant>((granted) =>
+      granted
+        ? { status: 'granted', sourceType }
+        : {
+            status: 'denied',
+            sourceType,
+            reason: `user denied ${sourceType} permission`,
+          },
+    );
+  },
+});

--- a/packages/extension/src/infrastructure/relay/fetch-stream-token-issuer.test.ts
+++ b/packages/extension/src/infrastructure/relay/fetch-stream-token-issuer.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import { createSourceSession, type SourceSession } from '../../domain/session/source-session';
+import {
+  createDefaultWsEndpointBuilder,
+  createFetchStreamTokenIssuer,
+} from './fetch-stream-token-issuer';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+
+const buildSession = (): SourceSession =>
+  createSourceSession({
+    sessionIdentifier: SESSION_ID,
+    sourceIdentifier: SOURCE_ID,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt: '2026-04-21T00:00:00.000Z',
+  })._unsafeUnwrap();
+
+const createFakeResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('createFetchStreamTokenIssuer (IMPL-319, DD-401)', () => {
+  it('sends POST /sessions with the expected payload and returns streamToken', async () => {
+    const capturedRequests: { url: string; init: RequestInit | undefined }[] = [];
+    const normalizeUrl = (url: RequestInfo | URL): string => {
+      if (typeof url === 'string') return url;
+      if (url instanceof URL) return url.toString();
+      return url.url;
+    };
+    const issuer = createFetchStreamTokenIssuer({
+      baseUrl: 'https://relay.test',
+      accessToken: 'secret-token',
+      extensionVersion: '0.1.0',
+      protocolVersion: '1.0',
+      resolveDisplayName: () => 'Example Tab',
+      resolveOverlayTarget: () => ({ kind: 'tab', tabId: 42 }),
+      resolveAutoDetectLanguage: () => false,
+      fetchImpl: (url, init) => {
+        capturedRequests.push({
+          url: normalizeUrl(url),
+          init,
+        });
+        return Promise.resolve(
+          createFakeResponse({
+            sessionId: SESSION_ID,
+            streamToken: 'jwt.stream.token',
+            relayUrl: 'wss://relay.test/api/v1/relay',
+            expiresAt: '2026-04-21T01:00:00.000Z',
+            heartbeatIntervalSec: 15,
+            audio: {
+              encoding: 'pcm_s16le',
+              sampleRateHz: 16000,
+              channels: 1,
+              frameDurationMs: 100,
+              transport: 'json-base64',
+            },
+            limits: { maxConcurrentSessions: 3, maxFrameRatePerSecond: 10 },
+          }),
+        );
+      },
+    });
+
+    const result = await issuer(buildSession());
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe('jwt.stream.token');
+    }
+    expect(capturedRequests).toHaveLength(1);
+    const req = capturedRequests[0];
+    expect(req?.url).toBe('https://relay.test/sessions');
+    expect(req?.init?.method).toBe('POST');
+    expect(req?.init?.headers).toMatchObject({
+      authorization: 'Bearer secret-token',
+    });
+    const rawBody: unknown = req?.init?.body;
+    if (typeof rawBody !== 'string') throw new Error('body must be string');
+    const body: unknown = JSON.parse(rawBody);
+    expect(body).toMatchObject({
+      sourceType: 'tab',
+      displayName: 'Example Tab',
+      sourceLanguage: 'en-US',
+      autoDetectLanguage: false,
+      targetLanguage: 'ja-JP',
+      overlayTarget: { kind: 'tab', tabId: 42 },
+      client: { extensionVersion: '0.1.0', protocolVersion: '1.0' },
+    });
+  });
+
+  it('sends sourceLanguage=null when autoDetectLanguage is true', async () => {
+    let captured: unknown = null;
+    const issuer = createFetchStreamTokenIssuer({
+      baseUrl: 'https://relay.test',
+      accessToken: 'secret-token',
+      extensionVersion: '0.1.0',
+      protocolVersion: '1.0',
+      resolveDisplayName: () => 'n',
+      resolveOverlayTarget: () => ({ kind: 'monitor' }),
+      resolveAutoDetectLanguage: () => true,
+      fetchImpl: (_url, init) => {
+        const body: unknown = init?.body;
+        captured = typeof body === 'string' ? JSON.parse(body) : body;
+        return Promise.resolve(
+          createFakeResponse({
+            sessionId: SESSION_ID,
+            streamToken: 't',
+            relayUrl: 'w',
+            expiresAt: '2026-04-21T01:00:00.000Z',
+            heartbeatIntervalSec: 15,
+            audio: {
+              encoding: 'pcm_s16le',
+              sampleRateHz: 16000,
+              channels: 1,
+              frameDurationMs: 100,
+              transport: 'json-base64',
+            },
+            limits: { maxConcurrentSessions: 3, maxFrameRatePerSecond: 10 },
+          }),
+        );
+      },
+    });
+    await issuer(buildSession());
+    expect(captured).toMatchObject({
+      sourceLanguage: null,
+      autoDetectLanguage: true,
+    });
+  });
+
+  it('returns invariantViolationError on non-2xx response', async () => {
+    const issuer = createFetchStreamTokenIssuer({
+      baseUrl: 'https://relay.test',
+      accessToken: 'secret-token',
+      extensionVersion: '0.1.0',
+      protocolVersion: '1.0',
+      resolveDisplayName: () => 'n',
+      resolveOverlayTarget: () => ({ kind: 'monitor' }),
+      resolveAutoDetectLanguage: () => false,
+      fetchImpl: () => Promise.resolve(new Response('unauthorized', { status: 401 })),
+    });
+    const result = await issuer(buildSession());
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.kind).toBe('invariant-violation');
+      if (result.error.kind === 'invariant-violation') {
+        expect(result.error.invariant).toBe('stream-token-fetch');
+        expect(result.error.details).toMatch(/non-2xx/);
+      }
+    }
+  });
+
+  it('returns invariantViolationError on network failure', async () => {
+    const issuer = createFetchStreamTokenIssuer({
+      baseUrl: 'https://relay.test',
+      accessToken: 'secret-token',
+      extensionVersion: '0.1.0',
+      protocolVersion: '1.0',
+      resolveDisplayName: () => 'n',
+      resolveOverlayTarget: () => ({ kind: 'monitor' }),
+      resolveAutoDetectLanguage: () => false,
+      fetchImpl: () => Promise.reject(new Error('TCP reset')),
+    });
+    const result = await issuer(buildSession());
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.kind).toBe('invariant-violation');
+      if (result.error.kind === 'invariant-violation') {
+        expect(result.error.details).toMatch(/TCP reset/);
+      }
+    }
+  });
+
+  it('returns invariantViolationError when response schema is invalid', async () => {
+    const issuer = createFetchStreamTokenIssuer({
+      baseUrl: 'https://relay.test',
+      accessToken: 'secret-token',
+      extensionVersion: '0.1.0',
+      protocolVersion: '1.0',
+      resolveDisplayName: () => 'n',
+      resolveOverlayTarget: () => ({ kind: 'monitor' }),
+      resolveAutoDetectLanguage: () => false,
+      fetchImpl: () => Promise.resolve(createFakeResponse({ hello: 'world' })),
+    });
+    const result = await issuer(buildSession());
+    expect(result.isErr()).toBe(true);
+  });
+});
+
+describe('createDefaultWsEndpointBuilder', () => {
+  it('converts https base URL into wss endpoint with query parameters', () => {
+    const builder = createDefaultWsEndpointBuilder({ baseUrl: 'https://relay.test' });
+    const url = builder(SESSION_ID, 'secret-token');
+    expect(url).toBe(`wss://relay.test/api/v1/relay?token=secret-token&sessionId=${SESSION_ID}`);
+  });
+
+  it('converts http base URL into ws endpoint', () => {
+    const builder = createDefaultWsEndpointBuilder({ baseUrl: 'http://localhost:3001' });
+    const url = builder(SESSION_ID, 't');
+    expect(url.startsWith('ws://localhost:3001/api/v1/relay?')).toBe(true);
+  });
+
+  it('respects custom wsPath override', () => {
+    const builder = createDefaultWsEndpointBuilder({
+      baseUrl: 'https://relay.test',
+      wsPath: '/stream',
+    });
+    const url = builder(SESSION_ID, 't');
+    expect(url.startsWith('wss://relay.test/stream?')).toBe(true);
+  });
+
+  it('urlencodes token and sessionId', () => {
+    const builder = createDefaultWsEndpointBuilder({ baseUrl: 'https://relay.test' });
+    const url = builder('sess/ion id', 'tok&en');
+    expect(url).toContain('token=tok%26en');
+    expect(url).toContain('sessionId=sess%2Fion%20id');
+  });
+});

--- a/packages/extension/src/infrastructure/relay/fetch-stream-token-issuer.ts
+++ b/packages/extension/src/infrastructure/relay/fetch-stream-token-issuer.ts
@@ -1,0 +1,176 @@
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
+import { z } from 'zod';
+import { type SourceSession } from '../../domain/session/source-session';
+import { type SourceType } from '../../domain/session/source-type';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { type StreamTokenIssuer } from './relay-websocket-gateway';
+
+/**
+ * POST /sessions リクエストボディの shape (api-specification.md §4.1)。
+ *
+ * `displayName` / `autoDetectLanguage` / `overlayTarget` / `client` は SourceSession
+ * に含まれないため、config で解決関数を注入する。
+ */
+const postSessionsResponseSchema = z.object({
+  sessionId: z.string().min(1),
+  streamToken: z.string().min(1),
+  relayUrl: z.string().min(1),
+  expiresAt: z.string().min(1),
+  heartbeatIntervalSec: z.number().int().positive(),
+  audio: z.object({
+    encoding: z.string(),
+    sampleRateHz: z.number().int().positive(),
+    channels: z.number().int().positive(),
+    frameDurationMs: z.number().int().positive(),
+    transport: z.string(),
+  }),
+  limits: z.object({
+    maxConcurrentSessions: z.number().int().positive(),
+    maxFrameRatePerSecond: z.number().int().positive(),
+  }),
+});
+
+export type OverlayTargetDescriptor =
+  | Readonly<{ kind: 'tab'; tabId: number }>
+  | Readonly<{ kind: 'monitor' }>;
+
+export type FetchStreamTokenIssuerConfig = Readonly<{
+  /** Relay API base URL (http:// or https://、末尾 / なし) */
+  baseUrl: string;
+  /** Long-term access token for POST /sessions (Bearer) */
+  accessToken: string;
+  /** 拡張バージョン (manifest.version 由来) */
+  extensionVersion: string;
+  /** api-spec §4.1 `client.protocolVersion` */
+  protocolVersion: string;
+  /** SourceSession → displayName (UI 表示用の一時名。空不可) */
+  resolveDisplayName: (session: SourceSession) => string;
+  /** SourceSession → overlayTarget (tab id か monitor page か) */
+  resolveOverlayTarget: (session: SourceSession) => OverlayTargetDescriptor;
+  /** SourceSession → autoDetectLanguage フラグ */
+  resolveAutoDetectLanguage: (session: SourceSession) => boolean;
+  /** Production は global `fetch`、test では in-memory fake を注入 */
+  fetchImpl?: typeof fetch;
+}>;
+
+const toInvariant =
+  (scope: string) =>
+  (cause: unknown): DomainError =>
+    invariantViolationError({
+      invariant: 'stream-token-fetch',
+      details: `${scope}: ${cause instanceof Error ? cause.message : String(cause)}`,
+    });
+
+const buildRequestBody = (
+  session: SourceSession,
+  config: FetchStreamTokenIssuerConfig,
+): Record<string, unknown> => {
+  const sourceLanguage: string | null = config.resolveAutoDetectLanguage(session)
+    ? null
+    : session.languagePair.source;
+  return {
+    sourceType: session.sourceType satisfies SourceType,
+    displayName: config.resolveDisplayName(session),
+    sourceLanguage,
+    autoDetectLanguage: config.resolveAutoDetectLanguage(session),
+    targetLanguage: session.languagePair.target,
+    overlayTarget: config.resolveOverlayTarget(session),
+    client: {
+      extensionVersion: config.extensionVersion,
+      protocolVersion: config.protocolVersion,
+    },
+  };
+};
+
+/**
+ * IMPL-319 FetchStreamTokenIssuer (DD-401, api-specification.md §4.1)。
+ *
+ * `StreamTokenIssuer` の production 実装。`POST ${baseUrl}/sessions` に JSON を
+ * 送り、Relay API から短命 `streamToken` を取得する。
+ *
+ * **本番実装で mock が利用されない設計**:
+ * - 全 DI (resolve* callback 含む) が必須引数。default は持たない
+ * - production entrypoint で `resolveDisplayName` / `resolveOverlayTarget` /
+ *   `resolveAutoDetectLanguage` を明示的に渡す
+ * - `fetchImpl` のみ default (global `fetch`) を許容。これは標準 API なので
+ *   CLAUDE.md の `axios` 禁止方針と整合
+ *
+ * エラー型:
+ * - network / non-2xx / JSON parse 失敗: `invariantViolationError({ invariant: 'stream-token-fetch' })`
+ * - response schema 違反: 同上 (Zod error を details に埋める)
+ */
+export const createFetchStreamTokenIssuer = (
+  config: FetchStreamTokenIssuerConfig,
+): StreamTokenIssuer => {
+  const fetchImpl = config.fetchImpl ?? fetch;
+  const endpoint = `${config.baseUrl}/sessions`;
+
+  return (session) => {
+    const body = buildRequestBody(session, config);
+    return ResultAsync.fromPromise<Response, DomainError>(
+      fetchImpl(endpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${config.accessToken}`,
+        },
+        body: JSON.stringify(body),
+      }),
+      toInvariant('network'),
+    )
+      .andThen((response): ResultAsync<unknown, DomainError> => {
+        if (!response.ok) {
+          return errAsync<unknown, DomainError>(
+            invariantViolationError({
+              invariant: 'stream-token-fetch',
+              details: `non-2xx: status=${response.status}`,
+            }),
+          );
+        }
+        return ResultAsync.fromPromise<unknown, DomainError>(
+          response.json(),
+          toInvariant('json-parse'),
+        );
+      })
+      .andThen((raw): ResultAsync<string, DomainError> => {
+        const parsed = postSessionsResponseSchema.safeParse(raw);
+        if (!parsed.success) {
+          return errAsync<string, DomainError>(
+            invariantViolationError({
+              invariant: 'stream-token-fetch',
+              details: `response schema: ${parsed.error.issues.map((i) => i.message).join('; ')}`,
+            }),
+          );
+        }
+        return okAsync<string, DomainError>(parsed.data.streamToken);
+      });
+  };
+};
+
+/**
+ * `wsEndpointBuilder` の標準実装。Relay API の `relayUrl` を使わず、
+ * `config.baseUrl` をそのまま ws(s) に差し替える (MVP 簡易版)。
+ *
+ * 例: `https://relay.example.com` + streamToken → `wss://relay.example.com/relay?token=...&sessionId=...`
+ */
+export type WsEndpointBuilderConfig = Readonly<{
+  /** HTTP base URL (`http(s)://` prefix)。`wss://` に変換される */
+  baseUrl: string;
+  /** WebSocket パス (default `/api/v1/relay`) */
+  wsPath?: string;
+}>;
+
+export const createDefaultWsEndpointBuilder = (
+  config: WsEndpointBuilderConfig,
+): ((sessionIdentifier: string, streamToken: string) => string) => {
+  const wsPath = config.wsPath ?? '/api/v1/relay';
+  const httpPrefix = config.baseUrl.startsWith('https://')
+    ? 'https://'
+    : config.baseUrl.startsWith('http://')
+      ? 'http://'
+      : 'https://';
+  const rest = config.baseUrl.slice(httpPrefix.length);
+  const wsPrefix = httpPrefix === 'https://' ? 'wss://' : 'ws://';
+  return (sessionIdentifier, streamToken) =>
+    `${wsPrefix}${rest}${wsPath}?token=${encodeURIComponent(streamToken)}&sessionId=${encodeURIComponent(sessionIdentifier)}`;
+};


### PR DESCRIPTION
## Summary

Phase 5 最初の PR (roadmap §4 PR 次 #1)。Background Service Worker で Phase 1〜3.5 の全 infrastructure / application を production 配線し、chrome.runtime.onMessage を経由した Popup/SidePanel → UseCase の dispatch ループを閉じます。

### 背景

Phase 3.5 (PR #45) で domain repository adapter が揃い DI の前提が整った。残る 3 つの infrastructure adapter (Permission / StreamTokenIssuer / Overlay messaging bridge) を新規実装し、それらと既存 adapter 群を Background entrypoint で一括組立する。

### 新規 infrastructure adapters (本 PR 内で追加)

| ID       | Adapter                           | 概要                                                                    |
| -------- | --------------------------------- | ----------------------------------------------------------------------- |
| IMPL-318 | `ChromePermissionCoordinator`     | chrome.permissions.request wrap (tabCapture / desktopCapture)           |
| IMPL-319 | `FetchStreamTokenIssuer`          | Relay API `POST /sessions` を標準 fetch で呼び、streamToken 取得        |
| IMPL-331 | `ChromeMessagingOverlayPresenter` | SW → content script への overlay command を chrome.runtime.sendMessage で転送 |

### 新規 composition 層

| ID       | モジュール                                    | 概要                                                                                             |
| -------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| IMPL-500 | `src/composition/extension-composition.ts`    | `createExtensionApp(config, ports)` が `SessionCommandService` / `ExportService` / `GetSessionMonitorStateQuery` / `SessionRegistry` / `CaptureOrchestrator` / `TranscriptAssembler` / `close()` を返す facade |
| IMPL-501 | `src/composition/runtime-messages.ts`         | Popup/SidePanel → Background の Zod schema (5 command/query 種)                                  |
| IMPL-502 | `src/composition/runtime-dispatcher.ts`       | chrome.runtime.onMessage に登録する async dispatcher。Result を `BackgroundResponse<T>` に変換    |
| —        | `src/entrypoints/background.ts` (差し替え)    | production 配線 + runtime.onMessage / onSuspend bind                                             |

### 本番実装で mock / in-memory を使わない原則の保持

- `createProductionRuntimePorts()` が返す 14 port は全て real (`chrome.*` / AudioContext / `fetch` / `WebSocket` / `ulid`)
- すべての UseCase は Phase 3.5 の real repository + Phase 3 infra + Phase 4 で確立した stateless 設計を前提とする
- `PERAPERA_RELAY_ACCESS_TOKEN` 未設定時は console.error で警告し、POST /sessions 呼び出し時に fail-fast
- `ExtensionRuntimePorts` は全 field Required。test で override を強制注入する形 (mock 漏れ防止)

### 設計書準拠

- 詳細設計 `detailed-design.md` §2 中核クラス図: SessionCommandService を dispatch target に据える
- CLAUDE.md §ホットパス最優先原則: `HandleTranscriptPartialUseCase` の処理順序 (TranscriptAssembler → OverlayPresenter → SessionStore) を維持
- DD-108 OverlayPresenter: SW 側は `ChromeMessagingOverlayPresenter` (proxy)、content script 側は既存 `ContentScriptOverlayPresenter` (IMPL-330) が受け手となる 2 層構成
- api-specification §4.1: `POST /sessions` 契約を IMPL-319 で実装

## Test plan

- [x] `pnpm fmt:check` — clean
- [x] `pnpm lint` — root level clean (assertionStyle: 'never' 準拠)
- [x] `pnpm typecheck` — 両 workspace green
- [x] `pnpm --filter @perapera/extension test` — 660 / 660 pass (既存 620 + 新規 40)
  - ChromePermissionCoordinator: 4 tests
  - FetchStreamTokenIssuer + WsEndpointBuilder: 9 tests
  - ChromeMessagingOverlayPresenter: 5 tests
  - runtime-messages (Zod schema): 9 tests
  - runtime-dispatcher (dispatch + error propagation): 7 tests
  - extension-composition (integration with real adapters + fake chrome.*): 6 tests
- [x] `pnpm --filter @perapera/relay-api test` — 184 / 184 pass (無影響)

## 後続 PR (roadmap §4 に沿って)

- (次) #2 Popup UI 最小実装 — SessionCommandService.startSource / stopSource 呼び出し + session list
- (次) #3 Side Panel UI
- (次) #4 Content script overlay — `OverlayCommand` の受け手を実装
- (次) #5 Offscreen document + Monitor page
- (次) #6 Design system tokens / atoms