### PR TITLE
feat(extension): IMPL-533〜553 Side Panel UI (active session detail list + export)

### DIFF
--- a/packages/extension/src/entrypoints/sidepanel/App.tsx
+++ b/packages/extension/src/entrypoints/sidepanel/App.tsx
@@ -1,8 +1,31 @@
+import { useMemo } from 'react';
+import { ActiveSessionDetailList } from '../../presentation/organisms/active-session-detail-list';
+import { createBackgroundClient } from '../../presentation/infrastructure/background-client';
+import { SidePanelTemplate } from '../../presentation/templates/side-panel-template';
+
+const readVersionFromManifest = (): string | undefined => {
+  try {
+    const manifest = chrome.runtime.getManifest();
+    return typeof manifest.version === 'string' ? manifest.version : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * IMPL-553 SidePanel App entry。
+ *
+ * Background messaging client を 1 回だけ生成し、`SidePanelTemplate` に
+ * `ActiveSessionDetailList` を差し込む。Side Panel は持続表示前提のため、
+ * polling intervalMs は default (2 秒) のまま。
+ */
 export function App() {
-  return (
-    <div className="container">
-      <h1>perapera Side Panel</h1>
-      <p>音声ソース一覧と詳細管理を提供する予定の画面です。</p>
-    </div>
-  );
+  const client = useMemo(() => createBackgroundClient(), []);
+  const version = readVersionFromManifest();
+  const listSlot = <ActiveSessionDetailList client={client} />;
+
+  if (version !== undefined) {
+    return <SidePanelTemplate version={version} listSlot={listSlot} />;
+  }
+  return <SidePanelTemplate listSlot={listSlot} />;
 }

--- a/packages/extension/src/entrypoints/sidepanel/main.tsx
+++ b/packages/extension/src/entrypoints/sidepanel/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { App } from './App';
+import './sidepanel.css';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/packages/extension/src/entrypoints/sidepanel/sidepanel.css
+++ b/packages/extension/src/entrypoints/sidepanel/sidepanel.css
@@ -1,0 +1,275 @@
+/*
+ * SidePanel CSS。popup.css とトークンを共有するが Side Panel は幅を画面幅に
+ * 合わせて伸ばす (Chrome の side panel は可変幅)。単一単語 className のみ使用。
+ * Design system tokens は Phase 5 PR 次 #6 で置換予定。
+ */
+
+:root {
+  color-scheme: light;
+  --color-text: #1a1a1a;
+  --color-muted: #666;
+  --color-bg: #ffffff;
+  --color-border: #e0e0e0;
+  --color-accent: #2563eb;
+  --color-accent-fg: #ffffff;
+  --color-danger: #dc2626;
+  --color-danger-fg: #ffffff;
+  --color-active: #10b981;
+  --color-pending: #f59e0b;
+  --color-degraded: #c2410c;
+  --color-error: #dc2626;
+  --color-stopped: #6b7280;
+  --color-neutral: #9ca3af;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    'Hiragino Sans',
+    'Yu Gothic UI',
+    sans-serif;
+  font-size: 13px;
+  color: var(--color-text);
+  background: var(--color-bg);
+  min-height: 100vh;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 8px;
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.version {
+  font-size: 11px;
+  color: var(--color-muted);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+}
+
+.card > .header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border: 0;
+  padding: 0;
+}
+
+.info {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  min-width: 0;
+  flex: 1;
+}
+
+.name {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source {
+  font-size: 11px;
+  color: var(--color-muted);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-accent-fg);
+  background: var(--color-neutral);
+}
+
+.badge[data-variant='active'] {
+  background: var(--color-active);
+}
+.badge[data-variant='pending'] {
+  background: var(--color-pending);
+}
+.badge[data-variant='degraded'] {
+  background: var(--color-degraded);
+}
+.badge[data-variant='error'] {
+  background: var(--color-error);
+}
+.badge[data-variant='stopped'] {
+  background: var(--color-stopped);
+}
+.badge[data-variant='neutral'] {
+  background: var(--color-neutral);
+}
+
+.preview {
+  list-style: none;
+  margin: 0;
+  padding: 8px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.03);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.line {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.original {
+  font-size: 12px;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.translated {
+  font-size: 13px;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.exporter {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  border: 1px dashed var(--color-border);
+  border-radius: 4px;
+}
+
+.exporter > .field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.label {
+  font-size: 12px;
+  color: var(--color-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.input,
+.select {
+  padding: 6px 8px;
+  font-size: 13px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+.checkbox {
+  margin: 0;
+}
+
+.button {
+  padding: 8px 12px;
+  border: 0;
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+}
+
+.button[data-variant='secondary'] {
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
+.button[data-variant='danger'] {
+  background: var(--color-danger);
+  color: var(--color-danger-fg);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.message {
+  font-size: 12px;
+  color: var(--color-muted);
+  margin: 0;
+  padding: 6px 8px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.message[role='alert'] {
+  color: var(--color-danger);
+  background: rgba(220, 38, 38, 0.06);
+}
+
+.message[data-variant='success'] {
+  color: #065f46;
+  background: rgba(16, 185, 129, 0.1);
+}
+
+.message[data-variant='muted'] {
+  color: var(--color-muted);
+  background: transparent;
+  border: 1px dashed var(--color-border);
+}

--- a/packages/extension/src/presentation/molecules/export-controls.test.tsx
+++ b/packages/extension/src/presentation/molecules/export-controls.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ExportControls } from './export-controls';
+
+describe('ExportControls molecule (IMPL-533)', () => {
+  it('renders default settings (txt / both included)', () => {
+    render(<ExportControls sessionId="s-1" status={{ kind: 'idle' }} onExport={vi.fn()} />);
+    expect(screen.getByRole('combobox', { name: 'エクスポート形式' })).toHaveValue('txt');
+    expect(screen.getByRole('checkbox', { name: '原文を含める' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: '翻訳を含める' })).toBeChecked();
+  });
+
+  it('dispatches onExport with collected input on click', async () => {
+    const onExport = vi.fn();
+    render(<ExportControls sessionId="s-1" status={{ kind: 'idle' }} onExport={onExport} />);
+    await userEvent.selectOptions(
+      screen.getByRole('combobox', { name: 'エクスポート形式' }),
+      'JSON (.json)',
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'エクスポートを実行' }));
+    expect(onExport).toHaveBeenCalledWith({
+      sessionId: 's-1',
+      format: 'json',
+      includeOriginal: true,
+      includeTranslation: true,
+    });
+  });
+
+  it('blocks submit when neither original nor translation is selected', async () => {
+    const onExport = vi.fn();
+    render(<ExportControls sessionId="s-1" status={{ kind: 'idle' }} onExport={onExport} />);
+    await userEvent.click(screen.getByRole('checkbox', { name: '原文を含める' }));
+    await userEvent.click(screen.getByRole('checkbox', { name: '翻訳を含める' }));
+    expect(screen.getByRole('button', { name: 'エクスポートを実行' })).toBeDisabled();
+    expect(screen.getByRole('alert')).toHaveTextContent('少なくともどちらか一方');
+  });
+
+  it('shows pending state while status is pending', () => {
+    render(<ExportControls sessionId="s-1" status={{ kind: 'pending' }} onExport={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'エクスポートを実行' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'エクスポートを実行' })).toHaveTextContent('出力中…');
+  });
+
+  it('shows success message with bytes count', () => {
+    render(
+      <ExportControls
+        sessionId="s-1"
+        status={{ kind: 'success', bytes: 2048 }}
+        onExport={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('2048 バイトを出力しました。')).toBeInTheDocument();
+  });
+
+  it('shows error message on error status', () => {
+    render(
+      <ExportControls
+        sessionId="s-1"
+        status={{ kind: 'error', message: '書き込み失敗' }}
+        onExport={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('書き込み失敗');
+  });
+
+  it('disables everything when disabled prop is set', () => {
+    render(
+      <ExportControls sessionId="s-1" status={{ kind: 'idle' }} onExport={vi.fn()} disabled />,
+    );
+    expect(screen.getByRole('button', { name: 'エクスポートを実行' })).toBeDisabled();
+  });
+});

--- a/packages/extension/src/presentation/molecules/export-controls.tsx
+++ b/packages/extension/src/presentation/molecules/export-controls.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import { type ExportSessionResultInput } from '../../application/dto/export-session-result-dto';
+import { Button } from '../atoms/button';
+import { Checkbox } from '../atoms/checkbox';
+import { Label } from '../atoms/label';
+import { Select, type SelectOption } from '../atoms/select';
+
+const FORMAT_OPTIONS: readonly SelectOption[] = [
+  { value: 'txt', label: 'テキスト (.txt)' },
+  { value: 'json', label: 'JSON (.json)' },
+];
+
+export type ExportControlsStatus =
+  | Readonly<{ kind: 'idle' }>
+  | Readonly<{ kind: 'pending' }>
+  | Readonly<{ kind: 'success'; bytes: number }>
+  | Readonly<{ kind: 'error'; message: string }>;
+
+export type Props = Readonly<{
+  sessionId: string;
+  status: ExportControlsStatus;
+  onExport: (input: ExportSessionResultInput) => void;
+  disabled?: boolean;
+}>;
+
+/**
+ * IMPL-533 ExportControls molecule。
+ *
+ * エクスポート形式 (txt/json) + 原文/翻訳を含めるチェックボックス +
+ * Export ボタンをまとめた UI。`onExport` は組み立てた `ExportSessionResultInput`
+ * を返し、実際の dispatch と結果表示 (bytes / error) は caller の status prop
+ * 経由で反映する。
+ *
+ * 不変条件 (domain `ExportRecord` DD-273 準拠): `includeOriginal` と
+ * `includeTranslation` の少なくとも一方は true。両方 false の場合は submit を
+ * 無効化して UI 層で validation する (Background まで飛ばさない)。
+ */
+export function ExportControls(props: Props) {
+  const [format, setFormat] = useState<'txt' | 'json'>('txt');
+  const [includeOriginal, setIncludeOriginal] = useState(true);
+  const [includeTranslation, setIncludeTranslation] = useState(true);
+
+  const canSubmit =
+    (includeOriginal || includeTranslation) &&
+    props.disabled !== true &&
+    props.status.kind !== 'pending';
+
+  return (
+    <div className="exporter">
+      <div className="field">
+        <Label htmlFor={`export-format-${props.sessionId}`}>形式</Label>
+        <Select
+          id={`export-format-${props.sessionId}`}
+          ariaLabel="エクスポート形式"
+          value={format}
+          options={FORMAT_OPTIONS}
+          disabled={props.status.kind === 'pending'}
+          onChange={(value) => {
+            if (value === 'txt' || value === 'json') setFormat(value);
+          }}
+        />
+      </div>
+      <div className="field">
+        <Label htmlFor={`export-include-original-${props.sessionId}`}>
+          <Checkbox
+            id={`export-include-original-${props.sessionId}`}
+            ariaLabel="原文を含める"
+            checked={includeOriginal}
+            onChange={setIncludeOriginal}
+            disabled={props.status.kind === 'pending'}
+          />
+          原文を含める
+        </Label>
+      </div>
+      <div className="field">
+        <Label htmlFor={`export-include-translation-${props.sessionId}`}>
+          <Checkbox
+            id={`export-include-translation-${props.sessionId}`}
+            ariaLabel="翻訳を含める"
+            checked={includeTranslation}
+            onChange={setIncludeTranslation}
+            disabled={props.status.kind === 'pending'}
+          />
+          翻訳を含める
+        </Label>
+      </div>
+      {!includeOriginal && !includeTranslation ? (
+        <p className="message" role="alert">
+          少なくともどちらか一方を選択してください。
+        </p>
+      ) : null}
+      {props.status.kind === 'error' ? (
+        <p className="message" role="alert">
+          {props.status.message}
+        </p>
+      ) : null}
+      {props.status.kind === 'success' ? (
+        <p className="message" data-variant="success">
+          {props.status.bytes} バイトを出力しました。
+        </p>
+      ) : null}
+      <Button
+        variant="secondary"
+        disabled={!canSubmit}
+        ariaLabel="エクスポートを実行"
+        onClick={() => {
+          props.onExport({
+            sessionId: props.sessionId,
+            format,
+            includeOriginal,
+            includeTranslation,
+          });
+        }}
+      >
+        {props.status.kind === 'pending' ? '出力中…' : 'エクスポート'}
+      </Button>
+    </div>
+  );
+}

--- a/packages/extension/src/presentation/molecules/transcript-preview.test.tsx
+++ b/packages/extension/src/presentation/molecules/transcript-preview.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TranscriptPreview, type TranscriptPreviewLine } from './transcript-preview';
+
+const buildLine = (overrides: Partial<TranscriptPreviewLine>): TranscriptPreviewLine => ({
+  sessionId: 's-1',
+  segmentId: `seg-${String(Math.random()).slice(2, 8)}`,
+  ...overrides,
+});
+
+describe('TranscriptPreview molecule (IMPL-534)', () => {
+  it('renders empty message when no segments for session', () => {
+    render(<TranscriptPreview sessionId="s-1" segments={[]} />);
+    expect(screen.getByText('字幕はまだありません。')).toBeInTheDocument();
+  });
+
+  it('filters segments by sessionId', () => {
+    render(
+      <TranscriptPreview
+        sessionId="s-1"
+        segments={[
+          buildLine({ sessionId: 's-1', segmentId: 'a', originalText: 'hello' }),
+          buildLine({ sessionId: 's-2', segmentId: 'b', originalText: 'world' }),
+        ]}
+      />,
+    );
+    expect(screen.getByText('hello')).toBeInTheDocument();
+    expect(screen.queryByText('world')).toBeNull();
+  });
+
+  it('renders both original and translated lines', () => {
+    render(
+      <TranscriptPreview
+        sessionId="s-1"
+        segments={[
+          buildLine({
+            segmentId: 'seg-1',
+            originalText: 'Hello',
+            translatedText: 'こんにちは',
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('こんにちは')).toBeInTheDocument();
+  });
+
+  it('omits missing fields (no original)', () => {
+    render(
+      <TranscriptPreview
+        sessionId="s-1"
+        segments={[buildLine({ segmentId: 's', translatedText: 'only translation' })]}
+      />,
+    );
+    expect(screen.getByText('only translation')).toBeInTheDocument();
+  });
+
+  it('respects limit prop (most recent N items)', () => {
+    const segments = Array.from({ length: 5 }, (_, index) =>
+      buildLine({ segmentId: `seg-${index}`, originalText: `line${index}` }),
+    );
+    render(<TranscriptPreview sessionId="s-1" segments={segments} limit={2} />);
+    expect(screen.queryByText('line0')).toBeNull();
+    expect(screen.queryByText('line2')).toBeNull();
+    expect(screen.getByText('line3')).toBeInTheDocument();
+    expect(screen.getByText('line4')).toBeInTheDocument();
+  });
+});

--- a/packages/extension/src/presentation/molecules/transcript-preview.tsx
+++ b/packages/extension/src/presentation/molecules/transcript-preview.tsx
@@ -1,0 +1,49 @@
+export type TranscriptPreviewLine = Readonly<{
+  sessionId: string;
+  segmentId: string;
+  originalText?: string | undefined;
+  translatedText?: string | undefined;
+}>;
+
+export type Props = Readonly<{
+  sessionId: string;
+  segments: readonly TranscriptPreviewLine[];
+  /** 表示する segment の上限 (既定 3 件、新しい順) */
+  limit?: number;
+}>;
+
+/**
+ * IMPL-534 TranscriptPreview molecule。
+ *
+ * SessionMonitorState.latestSegments を source の最新 N 件分だけ抽出して表示。
+ * SidePanel で「いま何が聞き取れているか」を確認する用途。空 state は
+ * 「字幕なし」メッセージ。
+ */
+export function TranscriptPreview(props: Props) {
+  const limit = props.limit ?? 3;
+  const filtered = props.segments.filter((segment) => segment.sessionId === props.sessionId);
+  const lines = filtered.slice(Math.max(0, filtered.length - limit));
+
+  if (lines.length === 0) {
+    return (
+      <p className="message" data-variant="muted">
+        字幕はまだありません。
+      </p>
+    );
+  }
+
+  return (
+    <ul className="preview" aria-label="最新字幕">
+      {lines.map((line) => (
+        <li key={line.segmentId} className="line">
+          {line.originalText !== undefined && line.originalText.length > 0 ? (
+            <p className="original">{line.originalText}</p>
+          ) : null}
+          {line.translatedText !== undefined && line.translatedText.length > 0 ? (
+            <p className="translated">{line.translatedText}</p>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/extension/src/presentation/organisms/active-session-detail-list.test.tsx
+++ b/packages/extension/src/presentation/organisms/active-session-detail-list.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type BackgroundClient,
+  type BackgroundResponse,
+  type ExportSessionResultResult,
+  type SessionMonitorStateResult,
+  type StartSourceSessionResult,
+  type StopSourceSessionResult,
+  type UpdateSourceSettingsResult,
+} from '../infrastructure/background-client';
+import { ActiveSessionDetailList } from './active-session-detail-list';
+
+const DUMMY_START: BackgroundResponse<StartSourceSessionResult> = {
+  ok: true,
+  value: { sessionId: 's', state: 'x', startedAt: 'now' },
+};
+const DUMMY_STOP: BackgroundResponse<StopSourceSessionResult> = {
+  ok: true,
+  value: { sessionId: 's', state: 'stopped', stoppedAt: 'now' },
+};
+const DUMMY_UPDATE: BackgroundResponse<UpdateSourceSettingsResult> = {
+  ok: true,
+  value: { sessionId: 's', appliedAt: 'now' },
+};
+const DUMMY_EXPORT: BackgroundResponse<ExportSessionResultResult> = {
+  ok: true,
+  value: { exportId: 'e', format: 'txt', bytes: 0 },
+};
+
+const buildClient = (monitor: BackgroundClient['getSessionMonitorState']): BackgroundClient => ({
+  startSourceSession: vi.fn(() => Promise.resolve(DUMMY_START)),
+  stopSourceSession: vi.fn(() => Promise.resolve(DUMMY_STOP)),
+  updateSourceSettings: vi.fn(() => Promise.resolve(DUMMY_UPDATE)),
+  exportSessionResult: vi.fn(() => Promise.resolve(DUMMY_EXPORT)),
+  getSessionMonitorState: monitor,
+});
+
+describe('ActiveSessionDetailList organism (IMPL-543)', () => {
+  it('shows empty message when no sessions', async () => {
+    const client = buildClient(
+      vi.fn(() =>
+        Promise.resolve<BackgroundResponse<SessionMonitorStateResult>>({
+          ok: true,
+          value: { sessions: [], latestSegments: [] },
+        }),
+      ),
+    );
+    render(<ActiveSessionDetailList client={client} intervalMs={10000} />);
+    await waitFor(() =>
+      expect(screen.getByText('稼働中のセッションはありません。')).toBeInTheDocument(),
+    );
+  });
+
+  it('renders a SessionDetailCard per active session with latest segments', async () => {
+    const client = buildClient(
+      vi.fn(() =>
+        Promise.resolve<BackgroundResponse<SessionMonitorStateResult>>({
+          ok: true,
+          value: {
+            sessions: [
+              {
+                sessionId: 's-1',
+                displayName: 'Tab 1',
+                state: 'capturing',
+                sourceType: 'tab',
+              },
+              {
+                sessionId: 's-2',
+                displayName: 'Mic',
+                state: 'transcribing',
+                sourceType: 'microphone',
+              },
+            ],
+            latestSegments: [
+              {
+                sessionId: 's-1',
+                segmentId: 'seg-1',
+                originalText: 'Hello',
+                translatedText: 'こんにちは',
+              },
+              {
+                sessionId: 's-2',
+                segmentId: 'seg-2',
+                originalText: 'Good morning',
+              },
+            ],
+          },
+        }),
+      ),
+    );
+    render(<ActiveSessionDetailList client={client} intervalMs={10000} />);
+    await waitFor(() => expect(screen.getByText('Tab 1')).toBeInTheDocument());
+    expect(screen.getByText('Mic')).toBeInTheDocument();
+    // latestSegments が session ごとに分かれて表示される
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('こんにちは')).toBeInTheDocument();
+    expect(screen.getByText('Good morning')).toBeInTheDocument();
+  });
+
+  it('renders loading message before first fetch resolves', () => {
+    const neverResolve = new Promise<BackgroundResponse<SessionMonitorStateResult>>(() => {
+      /* never resolves during this test */
+    });
+    const client = buildClient(vi.fn(() => neverResolve));
+    render(<ActiveSessionDetailList client={client} intervalMs={10000} />);
+    expect(screen.getByText('読み込み中…')).toBeInTheDocument();
+  });
+});

--- a/packages/extension/src/presentation/organisms/active-session-detail-list.tsx
+++ b/packages/extension/src/presentation/organisms/active-session-detail-list.tsx
@@ -1,0 +1,61 @@
+import { useBackgroundQuery } from '../hooks/use-background-query';
+import { type BackgroundClient } from '../infrastructure/background-client';
+import { SessionDetailCard } from './session-detail-card';
+
+export type Props = Readonly<{
+  client: BackgroundClient;
+  /** polling 間隔 (ms)。default 2000 */
+  intervalMs?: number;
+}>;
+
+/**
+ * IMPL-543 ActiveSessionDetailList organism。
+ *
+ * SidePanel 向けのリッチ表示。`useBackgroundQuery` で
+ * GetSessionMonitorState を polling し、各アクティブセッションに対して
+ * `SessionDetailCard` を 1 つ展開する。SessionListItem (Popup 版) との違い:
+ * - 最新字幕プレビュー付き (latestSegments を session 単位にフィルタ)
+ * - Export コントロール付き
+ */
+export function ActiveSessionDetailList(props: Props) {
+  const query = useBackgroundQuery(props.client.getSessionMonitorState, {
+    input: { includeOverlayState: false },
+    intervalMs: props.intervalMs ?? 2000,
+  });
+
+  if (
+    query.state.status === 'idle' ||
+    (query.state.status === 'pending' && query.state.data === null)
+  ) {
+    return <p className="message">読み込み中…</p>;
+  }
+
+  const sessions = query.state.data?.sessions ?? [];
+  const latestSegments = query.state.data?.latestSegments ?? [];
+
+  if (sessions.length === 0) {
+    return <p className="message">稼働中のセッションはありません。</p>;
+  }
+
+  return (
+    <div className="list" role="list" aria-label="アクティブセッション詳細一覧">
+      {sessions.map((session) => (
+        <div key={session.sessionId} role="listitem">
+          <SessionDetailCard
+            client={props.client}
+            session={session}
+            latestSegments={latestSegments}
+            onStopped={() => {
+              void query.refetch();
+            }}
+          />
+        </div>
+      ))}
+      {query.state.status === 'error' && query.state.error !== null ? (
+        <p className="message" role="alert">
+          更新に失敗しました: {query.state.error.message}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/extension/src/presentation/organisms/session-detail-card.test.tsx
+++ b/packages/extension/src/presentation/organisms/session-detail-card.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type BackgroundClient,
+  type BackgroundResponse,
+  type ExportSessionResultResult,
+  type SessionMonitorStateResult,
+  type StartSourceSessionResult,
+  type StopSourceSessionResult,
+  type UpdateSourceSettingsResult,
+} from '../infrastructure/background-client';
+import { SessionDetailCard, type SessionDetailViewModel } from './session-detail-card';
+
+const DUMMY_START: BackgroundResponse<StartSourceSessionResult> = {
+  ok: true,
+  value: { sessionId: 's', state: 'x', startedAt: 'now' },
+};
+const DUMMY_UPDATE: BackgroundResponse<UpdateSourceSettingsResult> = {
+  ok: true,
+  value: { sessionId: 's', appliedAt: 'now' },
+};
+const DUMMY_MONITOR: BackgroundResponse<SessionMonitorStateResult> = {
+  ok: true,
+  value: { sessions: [], latestSegments: [] },
+};
+
+const buildClient = (overrides: {
+  stop?: BackgroundClient['stopSourceSession'];
+  exportFn?: BackgroundClient['exportSessionResult'];
+}): BackgroundClient => ({
+  startSourceSession: vi.fn(() => Promise.resolve(DUMMY_START)),
+  stopSourceSession:
+    overrides.stop ??
+    vi.fn(() =>
+      Promise.resolve<BackgroundResponse<StopSourceSessionResult>>({
+        ok: true,
+        value: { sessionId: 's', state: 'stopped', stoppedAt: 'now' },
+      }),
+    ),
+  updateSourceSettings: vi.fn(() => Promise.resolve(DUMMY_UPDATE)),
+  exportSessionResult:
+    overrides.exportFn ??
+    vi.fn(() =>
+      Promise.resolve<BackgroundResponse<ExportSessionResultResult>>({
+        ok: true,
+        value: { exportId: 'exp-1', format: 'txt', bytes: 1024 },
+      }),
+    ),
+  getSessionMonitorState: vi.fn(() => Promise.resolve(DUMMY_MONITOR)),
+});
+
+const session: SessionDetailViewModel = {
+  sessionId: 's-1',
+  displayName: 'YouTube Live',
+  state: 'capturing',
+  sourceType: 'tab',
+};
+
+describe('SessionDetailCard organism (IMPL-542)', () => {
+  it('renders session info and status badge', () => {
+    render(<SessionDetailCard client={buildClient({})} session={session} latestSegments={[]} />);
+    expect(screen.getByText('YouTube Live')).toBeInTheDocument();
+    expect(screen.getByText('[tab]')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveAttribute('data-variant', 'active');
+  });
+
+  it('shows latest transcript preview when segments exist', () => {
+    render(
+      <SessionDetailCard
+        client={buildClient({})}
+        session={session}
+        latestSegments={[
+          {
+            sessionId: 's-1',
+            segmentId: 'seg-1',
+            originalText: 'Hello',
+            translatedText: 'こんにちは',
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('こんにちは')).toBeInTheDocument();
+  });
+
+  it('dispatches stopSourceSession and calls onStopped on success', async () => {
+    const stopFn = vi.fn(() =>
+      Promise.resolve<BackgroundResponse<StopSourceSessionResult>>({
+        ok: true,
+        value: { sessionId: 's-1', state: 'stopped', stoppedAt: 'now' },
+      }),
+    );
+    const onStopped = vi.fn();
+    render(
+      <SessionDetailCard
+        client={buildClient({ stop: stopFn })}
+        session={session}
+        latestSegments={[]}
+        onStopped={onStopped}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'YouTube Live を停止' }));
+    await waitFor(() => expect(stopFn).toHaveBeenCalledWith({ sessionId: 's-1' }));
+    await waitFor(() => expect(onStopped).toHaveBeenCalled());
+  });
+
+  it('shows error message when stop fails', async () => {
+    const stopFn = vi.fn(() =>
+      Promise.resolve<BackgroundResponse<StopSourceSessionResult>>({
+        ok: false,
+        error: { type: 'internal', code: 'INTERNAL_ERROR', message: '停止失敗' },
+      }),
+    );
+    render(
+      <SessionDetailCard
+        client={buildClient({ stop: stopFn })}
+        session={session}
+        latestSegments={[]}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'YouTube Live を停止' }));
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('停止失敗'));
+  });
+
+  it('dispatches exportSessionResult with collected input and shows bytes', async () => {
+    const exportFn = vi.fn(() =>
+      Promise.resolve<BackgroundResponse<ExportSessionResultResult>>({
+        ok: true,
+        value: { exportId: 'exp-1', format: 'json', bytes: 4096 },
+      }),
+    );
+    const onExported = vi.fn();
+    render(
+      <SessionDetailCard
+        client={buildClient({ exportFn })}
+        session={session}
+        latestSegments={[]}
+        onExported={onExported}
+      />,
+    );
+    await userEvent.selectOptions(
+      screen.getByRole('combobox', { name: 'エクスポート形式' }),
+      'JSON (.json)',
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'エクスポートを実行' }));
+    await waitFor(() =>
+      expect(exportFn).toHaveBeenCalledWith({
+        sessionId: 's-1',
+        format: 'json',
+        includeOriginal: true,
+        includeTranslation: true,
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText('4096 バイトを出力しました。')).toBeInTheDocument(),
+    );
+    expect(onExported).toHaveBeenCalled();
+  });
+});

--- a/packages/extension/src/presentation/organisms/session-detail-card.tsx
+++ b/packages/extension/src/presentation/organisms/session-detail-card.tsx
@@ -1,0 +1,100 @@
+import { useMemo } from 'react';
+import { Button } from '../atoms/button';
+import { StatusBadge } from '../atoms/status-badge';
+import { useBackgroundCommand } from '../hooks/use-background-command';
+import {
+  type BackgroundClient,
+  type ExportSessionResultResult,
+} from '../infrastructure/background-client';
+import { ExportControls, type ExportControlsStatus } from '../molecules/export-controls';
+import { TranscriptPreview, type TranscriptPreviewLine } from '../molecules/transcript-preview';
+
+export type SessionDetailViewModel = Readonly<{
+  sessionId: string;
+  displayName: string;
+  state: string;
+  sourceType: string;
+}>;
+
+export type Props = Readonly<{
+  client: BackgroundClient;
+  session: SessionDetailViewModel;
+  latestSegments: readonly TranscriptPreviewLine[];
+  onStopped?: () => void;
+  onExported?: (result: ExportSessionResultResult) => void;
+}>;
+
+const toStatus = (
+  state: ReturnType<typeof useBackgroundCommand<never, ExportSessionResultResult>>['state'],
+): ExportControlsStatus => {
+  switch (state.status) {
+    case 'idle':
+      return { kind: 'idle' };
+    case 'pending':
+      return { kind: 'pending' };
+    case 'success':
+      return { kind: 'success', bytes: state.value.bytes };
+    case 'error':
+      return { kind: 'error', message: state.error.message };
+  }
+};
+
+/**
+ * IMPL-542 SessionDetailCard organism。
+ *
+ * 1 セッションの詳細表示 (SidePanel 用):
+ * - ヘッダ: displayName + sourceType + StatusBadge
+ * - 本体: 最新字幕プレビュー (TranscriptPreview)
+ * - フッタ: Stop ボタン + ExportControls
+ *
+ * Stop / Export は BackgroundClient 経由で dispatch。結果を props.onStopped /
+ * onExported で caller に伝える。エラー時はそのまま ExportControls の status で
+ * UI 反映する (Stop 側の error 表示は SessionDetailCard 内で message として出す)。
+ */
+export function SessionDetailCard(props: Props) {
+  const stopCommand = useBackgroundCommand(props.client.stopSourceSession);
+  const exportCommand = useBackgroundCommand(props.client.exportSessionResult);
+
+  const exportStatus = useMemo(() => toStatus(exportCommand.state), [exportCommand.state]);
+
+  const handleStop = (): void => {
+    void stopCommand.execute({ sessionId: props.session.sessionId }).then((response) => {
+      if (response.ok && props.onStopped !== undefined) props.onStopped();
+    });
+  };
+
+  return (
+    <article className="card" aria-label={`${props.session.displayName} セッション詳細`}>
+      <header className="header">
+        <div className="info">
+          <span className="name">{props.session.displayName}</span>
+          <span className="source">[{props.session.sourceType}]</span>
+          <StatusBadge state={props.session.state} />
+        </div>
+        <Button
+          variant="danger"
+          ariaLabel={`${props.session.displayName} を停止`}
+          onClick={handleStop}
+          disabled={stopCommand.state.status === 'pending'}
+        >
+          {stopCommand.state.status === 'pending' ? '停止中…' : '停止'}
+        </Button>
+      </header>
+      <TranscriptPreview sessionId={props.session.sessionId} segments={props.latestSegments} />
+      {stopCommand.state.status === 'error' ? (
+        <p className="message" role="alert">
+          停止に失敗しました: {stopCommand.state.error.message}
+        </p>
+      ) : null}
+      <ExportControls
+        sessionId={props.session.sessionId}
+        status={exportStatus}
+        onExport={(input) => {
+          void exportCommand.execute(input).then((response) => {
+            if (response.ok && props.onExported !== undefined) props.onExported(response.value);
+          });
+        }}
+      />
+    </article>
+  );
+}

--- a/packages/extension/src/presentation/templates/side-panel-template.test.tsx
+++ b/packages/extension/src/presentation/templates/side-panel-template.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SidePanelTemplate } from './side-panel-template';
+
+describe('SidePanelTemplate (IMPL-552)', () => {
+  it('renders header title', () => {
+    render(<SidePanelTemplate listSlot={<div>list</div>} />);
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'perapera セッション' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders version when provided', () => {
+    render(<SidePanelTemplate listSlot={<div>list</div>} version="0.1.0" />);
+    expect(screen.getByText('v0.1.0')).toBeInTheDocument();
+  });
+
+  it('renders listSlot content', () => {
+    render(<SidePanelTemplate listSlot={<div>LIST-HERE</div>} />);
+    expect(screen.getByText('LIST-HERE')).toBeInTheDocument();
+  });
+
+  it('exposes a section landmark for the list', () => {
+    render(<SidePanelTemplate listSlot={<div>list</div>} />);
+    expect(screen.getByRole('region', { name: '稼働中のセッション詳細' })).toBeInTheDocument();
+  });
+});

--- a/packages/extension/src/presentation/templates/side-panel-template.tsx
+++ b/packages/extension/src/presentation/templates/side-panel-template.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+
+export type Props = Readonly<{
+  listSlot: ReactNode;
+  version?: string;
+}>;
+
+/**
+ * IMPL-552 SidePanelTemplate。
+ *
+ * Side Panel (持続表示) の最外レイアウト。CLAUDE.md §React ルール準拠:
+ * - root className は `container`
+ * - 単一単語 className
+ * - props は `props.xxx` アクセス
+ *
+ * Popup より縦長・幅広の表示を想定し、list セクションをスクロール可能にする。
+ */
+export function SidePanelTemplate(props: Props) {
+  return (
+    <div className="container">
+      <header className="header">
+        <h1 className="title">perapera セッション</h1>
+        {props.version !== undefined ? <span className="version">v{props.version}</span> : null}
+      </header>
+      <section className="section" aria-label="稼働中のセッション詳細">
+        {props.listSlot}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 5 PR 次 #3 (roadmap §4) に従い、Chrome 拡張の Side Panel UI を最小実装。ユーザーが **稼働中セッション一覧 / 最新字幕プレビュー / 停止 / エクスポート (TXT/JSON)** を確認・操作できる持続表示画面を提供する。

### 背景

PR #48 (IMPL-510〜551 Popup UI) で sourcing 導線 (start/stop) が成立。Side Panel はよりリッチな情報 (字幕プレビュー、エクスポート) を持続表示する補助画面として実装する。Popup と BackgroundClient / hooks / atoms を共有し差分だけを追加。

### 変更内容

**molecules**:
- IMPL-533 `ExportControls` — format (txt/json) select + include original/translation checkbox + Export ボタン + success/error feedback。UI 層で DD-273 ExportFormatSpec の「片方以上 true」制約を先回り検証
- IMPL-534 `TranscriptPreview` — SessionMonitorState.latestSegments を sessionId フィルタして最新 N 件 (既定 3) を original + translated で表示

**organisms**:
- IMPL-542 `SessionDetailCard` — SessionListItem (Popup) を拡張。header (displayName + sourceType + StatusBadge) / body (TranscriptPreview) / footer (Stop + ExportControls) の 3 段構成
- IMPL-543 `ActiveSessionDetailList` — useBackgroundQuery で 2s polling、SessionDetailCard を各セッション単位で展開

**template + entry**:
- IMPL-552 `SidePanelTemplate` — header + scrollable list section のみの配置
- IMPL-553 SidePanel App.tsx 差し替え — createBackgroundClient + ActiveSessionDetailList
- sidepanel.css — popup.css と同じ palette を共有、container は height:100vh + overflow、card / preview / exporter スタイル追加

### 本番実装で Mock / in-memory を使わない原則

- BackgroundClient は Popup と同じ default `chrome.runtime.sendMessage` (production)、test は fake sender
- 全 organisms は BackgroundClient を prop で受け、test では fake client を明示注入
- Popup と presentation 層を共有 (atoms, hooks, BackgroundClient) することで infra 二重化を回避

## Test plan

- [x] `pnpm fmt:check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — 両 workspace green
- [x] `pnpm --filter @perapera/extension test` — 752 / 752 pass (既存 728 + 新規 24)
  - ExportControls: 7
  - TranscriptPreview: 5
  - SessionDetailCard: 5
  - ActiveSessionDetailList: 3
  - SidePanelTemplate: 4
- [x] `pnpm --filter @perapera/relay-api test` — 184 / 184 pass (無影響)
- [x] `pnpm --filter @perapera/extension build` — sidepanel chunk (5.64 kB) + CSS (3.56 kB) を `.output/chrome-mv3/` に生成

## 後続 PR (roadmap §4)

- (次) #4 Content script overlay (OverlayCommand の受け手、字幕描画)
- (次) #5 Offscreen document + Monitor page
- (次) #6 Design system tokens / atoms refresh

## Out of Scope

- Side Panel の設定パネル (overlay settings 変更 UI) — Phase 5 後半
- Side Panel の履歴タブ (過去の Export 一覧) — Phase 6
- 双方向 streaming (Background → SidePanel push) — Phase 6