### PR TITLE
feat(extension): IMPL-554〜558 Content script overlay (parseCommand + dispatcher + entry + positionPreset/maxLines)

### DIFF
--- a/packages/extension/src/entrypoints/content/index.ts
+++ b/packages/extension/src/entrypoints/content/index.ts
@@ -1,8 +1,51 @@
+import { createContentScriptOverlayPresenter } from '../../infrastructure/overlay/content-script-overlay-presenter';
+import {
+  createDefaultOverlayViewFactory,
+  defaultOverlayDocumentApi,
+} from '../../infrastructure/overlay/default-overlay-view';
+import { parseOverlayCommand } from './overlay-commands';
+import { createOverlayDispatcher } from './overlay-dispatcher';
+
+/**
+ * IMPL-558 Content script entry。
+ *
+ * Background Service Worker から chrome.runtime.sendMessage 経由で届く
+ * `OverlayCommand` を受信 → Zod validation → `ContentScriptOverlayPresenter`
+ * (IMPL-330) + `defaultOverlayViewFactory` (production default) で
+ * Shadow DOM オーバーレイを描画する。
+ *
+ * **本番実装で mock / in-memory を使わない原則**:
+ * - `defaultOverlayDocumentApi` を明示注入 (production default)
+ * - presenter / dispatcher は real implementation (test 用 stub は使わない)
+ * - chrome.runtime.onMessage listener で不明メッセージは silent ignore
+ *   (Popup/SidePanel 向けの BackgroundResponse envelope は型が異なるため
+ *   Zod validation で自然に落ちる)
+ */
 export default defineContentScript({
   matches: ['<all_urls>'],
   runAt: 'document_idle',
   main() {
-    // Content Script: translation overlay を Shadow DOM でマウントする予定
     console.log('[perapera] content script loaded');
+
+    const viewFactory = createDefaultOverlayViewFactory({
+      documentApi: defaultOverlayDocumentApi,
+    });
+    const presenter = createContentScriptOverlayPresenter({ overlayViewFactory: viewFactory });
+    const dispatch = createOverlayDispatcher({ presenter });
+
+    chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+      const parsed = parseOverlayCommand(message);
+      if (parsed.isErr()) {
+        // OverlayCommand 以外の message (Popup/SidePanel ↔ Background の
+        // BackgroundRequest 等) が流れてくるため silent ignore。return false で
+        // listener が async 応答しないことを宣言する。
+        return false;
+      }
+      void dispatch(parsed.value).finally(() => {
+        sendResponse(undefined);
+      });
+      // async 応答を宣言する (sendResponse を呼び戻すまで port を開いたままにする)。
+      return true;
+    });
   },
 });

--- a/packages/extension/src/entrypoints/content/overlay-commands.test.ts
+++ b/packages/extension/src/entrypoints/content/overlay-commands.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import { parseOverlayCommand } from './overlay-commands';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+
+describe('parseOverlayCommand (IMPL-554)', () => {
+  describe('overlay.mount', () => {
+    it('parses a valid mount command', () => {
+      const result = parseOverlayCommand({
+        type: 'overlay.mount',
+        sessionIdentifier: SESSION_ID,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.type).toBe('overlay.mount');
+        if (result.value.type === 'overlay.mount') {
+          expect(result.value.sessionIdentifier).toBe(SESSION_ID);
+        }
+      }
+    });
+
+    it('rejects mount with missing sessionIdentifier', () => {
+      const result = parseOverlayCommand({ type: 'overlay.mount' });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects mount with malformed sessionIdentifier', () => {
+      const result = parseOverlayCommand({
+        type: 'overlay.mount',
+        sessionIdentifier: 'not-a-ulid',
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('overlay.render', () => {
+    it('parses a valid render command with original and translated lines', () => {
+      const result = parseOverlayCommand({
+        type: 'overlay.render',
+        model: {
+          sessionIdentifier: SESSION_ID,
+          lines: [
+            {
+              segmentIdentifier: SEGMENT_ID,
+              originalText: 'Hello',
+              translatedText: 'こんにちは',
+              targetLanguage: 'ja',
+              isFinal: true,
+            },
+          ],
+        },
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk() && result.value.type === 'overlay.render') {
+        expect(result.value.model.lines).toHaveLength(1);
+        const line = result.value.model.lines[0];
+        expect(line?.originalText).toBe('Hello');
+        expect(line?.translatedText).toBe('こんにちは');
+        expect(line?.isFinal).toBe(true);
+      }
+    });
+
+    it('accepts nullable originalText / translatedText / targetLanguage', () => {
+      const result = parseOverlayCommand({
+        type: 'overlay.render',
+        model: {
+          sessionIdentifier: SESSION_ID,
+          lines: [
+            {
+              segmentIdentifier: SEGMENT_ID,
+              originalText: null,
+              translatedText: 'こんにちは',
+              targetLanguage: null,
+              isFinal: false,
+            },
+          ],
+        },
+      });
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('accepts empty lines array', () => {
+      const result = parseOverlayCommand({
+        type: 'overlay.render',
+        model: { sessionIdentifier: SESSION_ID, lines: [] },
+      });
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('rejects render with malformed segmentIdentifier', () => {
+      const result = parseOverlayCommand({
+        type: 'overlay.render',
+        model: {
+          sessionIdentifier: SESSION_ID,
+          lines: [
+            {
+              segmentIdentifier: 'invalid',
+              originalText: null,
+              translatedText: null,
+              targetLanguage: null,
+              isFinal: true,
+            },
+          ],
+        },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('overlay.update-settings', () => {
+    it('parses a valid update-settings command', () => {
+      const result = parseOverlayCommand({
+        type: 'overlay.update-settings',
+        sessionIdentifier: SESSION_ID,
+        settings: {
+          positionPreset: 'bottom',
+          opacity: 0.8,
+          maxLines: 3,
+          fontScale: 1,
+          showOriginalText: true,
+          showTranslatedText: true,
+        },
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk() && result.value.type === 'overlay.update-settings') {
+        expect(result.value.settings.opacity).toBe(0.8);
+      }
+    });
+
+    it('rejects update-settings with out-of-range opacity', () => {
+      const result = parseOverlayCommand({
+        type: 'overlay.update-settings',
+        sessionIdentifier: SESSION_ID,
+        settings: {
+          positionPreset: 'bottom',
+          opacity: 1.5,
+          maxLines: 3,
+          fontScale: 1,
+          showOriginalText: true,
+          showTranslatedText: true,
+        },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects update-settings when both show flags are false (domain invariant)', () => {
+      const result = parseOverlayCommand({
+        type: 'overlay.update-settings',
+        sessionIdentifier: SESSION_ID,
+        settings: {
+          positionPreset: 'bottom',
+          opacity: 1,
+          maxLines: 1,
+          fontScale: 1,
+          showOriginalText: false,
+          showTranslatedText: false,
+        },
+      });
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('overlay.unmount', () => {
+    it('parses a valid unmount command', () => {
+      const result = parseOverlayCommand({
+        type: 'overlay.unmount',
+        sessionIdentifier: SESSION_ID,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk() && result.value.type === 'overlay.unmount') {
+        expect(result.value.sessionIdentifier).toBe(SESSION_ID);
+      }
+    });
+  });
+
+  describe('unknown / malformed', () => {
+    it('rejects arbitrary non-OverlayCommand messages (e.g., BackgroundRequest)', () => {
+      const result = parseOverlayCommand({
+        type: 'command.start-source-session',
+        input: {},
+      });
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('rejects non-object payloads', () => {
+      expect(parseOverlayCommand(null).isErr()).toBe(true);
+      expect(parseOverlayCommand(42).isErr()).toBe(true);
+      expect(parseOverlayCommand('text').isErr()).toBe(true);
+    });
+  });
+});

--- a/packages/extension/src/entrypoints/content/overlay-commands.ts
+++ b/packages/extension/src/entrypoints/content/overlay-commands.ts
@@ -1,0 +1,177 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { createOverlaySettings, type OverlaySettings } from '../../domain/profile/overlay-settings';
+import {
+  type OverlayLine,
+  type OverlayRenderModel,
+} from '../../application/ports/overlay-presenter';
+import {
+  parseSegmentIdentifier,
+  type SegmentIdentifier,
+} from '../../domain/transcript/segment-identifier';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { validationError, type DomainError } from '../../domain/shared/errors';
+
+/**
+ * IMPL-554 OverlayCommand の runtime validation。
+ *
+ * Background Service Worker (`ChromeMessagingOverlayPresenter`) から
+ * chrome.runtime.sendMessage 経由で届くメッセージを受け取る際、content script
+ * 側では JSON 形式の untrusted payload として扱い、Zod で validation する。
+ *
+ * SW 側の TypeScript `OverlayCommand` 型 (`chrome-messaging-overlay-presenter.ts`)
+ * と shape を同期する。branded ドメイン型 (`SessionIdentifier` /
+ * `SegmentIdentifier` / `OverlaySettings`) は既存 parser 関数を通して構築する。
+ *
+ * 検証失敗時は `validationError` を返し、呼び出し側 (content entry) は
+ * OverlayCommand 以外の message として silent ignore する。
+ */
+
+const overlayLineRawSchema = z.object({
+  segmentIdentifier: z.string().min(1),
+  originalText: z.string().nullable(),
+  translatedText: z.string().nullable(),
+  targetLanguage: z.string().nullable(),
+  isFinal: z.boolean(),
+});
+
+const overlayRenderModelRawSchema = z.object({
+  sessionIdentifier: z.string().min(1),
+  lines: z.array(overlayLineRawSchema),
+});
+
+const overlaySettingsRawSchema = z.object({
+  positionPreset: z.enum(['top', 'bottom', 'floating']),
+  opacity: z.number().min(0).max(1),
+  maxLines: z.number().int().min(1),
+  fontScale: z.number().positive(),
+  showOriginalText: z.boolean(),
+  showTranslatedText: z.boolean(),
+});
+
+const mountCommandSchema = z.object({
+  type: z.literal('overlay.mount'),
+  sessionIdentifier: z.string().min(1),
+});
+
+const renderCommandSchema = z.object({
+  type: z.literal('overlay.render'),
+  model: overlayRenderModelRawSchema,
+});
+
+const updateSettingsCommandSchema = z.object({
+  type: z.literal('overlay.update-settings'),
+  sessionIdentifier: z.string().min(1),
+  settings: overlaySettingsRawSchema,
+});
+
+const unmountCommandSchema = z.object({
+  type: z.literal('overlay.unmount'),
+  sessionIdentifier: z.string().min(1),
+});
+
+const overlayCommandRawSchema = z.discriminatedUnion('type', [
+  mountCommandSchema,
+  renderCommandSchema,
+  updateSettingsCommandSchema,
+  unmountCommandSchema,
+]);
+
+/**
+ * 検証済 OverlayCommand 型。SW 側の `OverlayCommand` と shape 互換だが、
+ * 識別子は branded ドメイン型に変換済 (`SessionIdentifier` /
+ * `SegmentIdentifier`)。settings / OverlayLine フィールドは raw shape のまま
+ * 渡す (presentation 側の OverlayPresenter が受ける型と同じ)。
+ */
+export type OverlayCommand =
+  | Readonly<{ type: 'overlay.mount'; sessionIdentifier: SessionIdentifier }>
+  | Readonly<{ type: 'overlay.render'; model: OverlayRenderModel }>
+  | Readonly<{
+      type: 'overlay.update-settings';
+      sessionIdentifier: SessionIdentifier;
+      settings: OverlaySettings;
+    }>
+  | Readonly<{ type: 'overlay.unmount'; sessionIdentifier: SessionIdentifier }>;
+
+const toOverlayLine = (
+  raw: z.infer<typeof overlayLineRawSchema>,
+): Result<OverlayLine, DomainError> =>
+  parseSegmentIdentifier(raw.segmentIdentifier).map(
+    (segmentIdentifier: SegmentIdentifier): OverlayLine => ({
+      segmentIdentifier,
+      originalText: raw.originalText,
+      translatedText: raw.translatedText,
+      targetLanguage: raw.targetLanguage,
+      isFinal: raw.isFinal,
+    }),
+  );
+
+const toOverlayRenderModel = (
+  raw: z.infer<typeof overlayRenderModelRawSchema>,
+): Result<OverlayRenderModel, DomainError> =>
+  parseSessionIdentifier(raw.sessionIdentifier).andThen((sessionIdentifier) => {
+    const lines: OverlayLine[] = [];
+    for (const rawLine of raw.lines) {
+      const parsed = toOverlayLine(rawLine);
+      if (parsed.isErr()) return err(parsed.error);
+      lines.push(parsed.value);
+    }
+    return ok<OverlayRenderModel, DomainError>({ sessionIdentifier, lines });
+  });
+
+/**
+ * OverlaySettings raw payload を branded aggregate に変換する。`createOverlaySettings`
+ * factory を再利用して不変条件 (showOriginalText || showTranslatedText) まで検証する。
+ */
+const toOverlaySettings = (
+  raw: z.infer<typeof overlaySettingsRawSchema>,
+): Result<OverlaySettings, DomainError> => createOverlaySettings(raw);
+
+export const parseOverlayCommand = (raw: unknown): Result<OverlayCommand, DomainError> => {
+  const parsed = overlayCommandRawSchema.safeParse(raw);
+  if (!parsed.success) {
+    return err(
+      validationError({
+        field: 'OverlayCommand',
+        message: parsed.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  const data = parsed.data;
+  switch (data.type) {
+    case 'overlay.mount':
+      return parseSessionIdentifier(data.sessionIdentifier).map(
+        (sessionIdentifier): OverlayCommand => ({
+          type: 'overlay.mount',
+          sessionIdentifier,
+        }),
+      );
+    case 'overlay.render':
+      return toOverlayRenderModel(data.model).map(
+        (model): OverlayCommand => ({
+          type: 'overlay.render',
+          model,
+        }),
+      );
+    case 'overlay.update-settings':
+      return parseSessionIdentifier(data.sessionIdentifier).andThen((sessionIdentifier) =>
+        toOverlaySettings(data.settings).map(
+          (settings): OverlayCommand => ({
+            type: 'overlay.update-settings',
+            sessionIdentifier,
+            settings,
+          }),
+        ),
+      );
+    case 'overlay.unmount':
+      return parseSessionIdentifier(data.sessionIdentifier).map(
+        (sessionIdentifier): OverlayCommand => ({
+          type: 'overlay.unmount',
+          sessionIdentifier,
+        }),
+      );
+  }
+};

--- a/packages/extension/src/entrypoints/content/overlay-dispatcher.test.ts
+++ b/packages/extension/src/entrypoints/content/overlay-dispatcher.test.ts
@@ -1,0 +1,121 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import { type OverlayPresenter } from '../../application/ports/overlay-presenter';
+import { createOverlaySettings } from '../../domain/profile/overlay-settings';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { parseSegmentIdentifier } from '../../domain/transcript/segment-identifier';
+import { invariantViolationError } from '../../domain/shared/errors';
+import { createOverlayDispatcher } from './overlay-dispatcher';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+
+const identifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+const segmentIdentifier = parseSegmentIdentifier(SEGMENT_ID)._unsafeUnwrap();
+
+const settings = createOverlaySettings({
+  positionPreset: 'bottom',
+  opacity: 0.8,
+  maxLines: 2,
+  fontScale: 1,
+  showOriginalText: true,
+  showTranslatedText: true,
+})._unsafeUnwrap();
+
+const buildPresenter = (): OverlayPresenter => ({
+  mount: vi.fn(() => okAsync(undefined)),
+  render: vi.fn(() => okAsync(undefined)),
+  updateSettings: vi.fn(() => okAsync(undefined)),
+  unmount: vi.fn(() => okAsync(undefined)),
+});
+
+describe('createOverlayDispatcher (IMPL-555)', () => {
+  it('dispatches overlay.mount to presenter.mount', async () => {
+    const presenter = buildPresenter();
+    const dispatch = createOverlayDispatcher({ presenter });
+    await dispatch({ type: 'overlay.mount', sessionIdentifier: identifier });
+    expect(presenter.mount).toHaveBeenCalledWith(identifier);
+  });
+
+  it('dispatches overlay.render to presenter.render', async () => {
+    const presenter = buildPresenter();
+    const dispatch = createOverlayDispatcher({ presenter });
+    await dispatch({
+      type: 'overlay.render',
+      model: {
+        sessionIdentifier: identifier,
+        lines: [
+          {
+            segmentIdentifier,
+            originalText: 'Hi',
+            translatedText: 'こんにちは',
+            targetLanguage: 'ja',
+            isFinal: true,
+          },
+        ],
+      },
+    });
+    expect(presenter.render).toHaveBeenCalledOnce();
+  });
+
+  it('dispatches overlay.update-settings to presenter.updateSettings', async () => {
+    const presenter = buildPresenter();
+    const dispatch = createOverlayDispatcher({ presenter });
+    await dispatch({
+      type: 'overlay.update-settings',
+      sessionIdentifier: identifier,
+      settings,
+    });
+    expect(presenter.updateSettings).toHaveBeenCalledWith(identifier, settings);
+  });
+
+  it('dispatches overlay.unmount to presenter.unmount', async () => {
+    const presenter = buildPresenter();
+    const dispatch = createOverlayDispatcher({ presenter });
+    await dispatch({ type: 'overlay.unmount', sessionIdentifier: identifier });
+    expect(presenter.unmount).toHaveBeenCalledWith(identifier);
+  });
+
+  it('logs presenter errors to logWarn and does not throw', async () => {
+    const presenter: OverlayPresenter = {
+      mount: vi.fn(() =>
+        errAsync(invariantViolationError({ invariant: 'overlay-mount-failed', details: 'boom' })),
+      ),
+      render: vi.fn(() => okAsync(undefined)),
+      updateSettings: vi.fn(() => okAsync(undefined)),
+      unmount: vi.fn(() => okAsync(undefined)),
+    };
+    const logWarn = vi.fn<(message: string) => void>();
+    const dispatch = createOverlayDispatcher({ presenter, logWarn });
+    await expect(
+      dispatch({ type: 'overlay.mount', sessionIdentifier: identifier }),
+    ).resolves.toBeUndefined();
+    expect(logWarn).toHaveBeenCalledOnce();
+    expect(logWarn).toHaveBeenCalledWith(expect.stringMatching(/mount failed/));
+  });
+
+  it('uses console.warn as default sink when logWarn is not provided', async () => {
+    const presenter: OverlayPresenter = {
+      mount: vi.fn(() => okAsync(undefined)),
+      render: vi.fn(() =>
+        errAsync(invariantViolationError({ invariant: 'overlay-render-failed', details: 'x' })),
+      ),
+      updateSettings: vi.fn(() => okAsync(undefined)),
+      unmount: vi.fn(() => okAsync(undefined)),
+    };
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const dispatch = createOverlayDispatcher({ presenter });
+      await dispatch({
+        type: 'overlay.render',
+        model: { sessionIdentifier: identifier, lines: [] },
+      });
+      expect(consoleWarnSpy).toHaveBeenCalledOnce();
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/extension/src/entrypoints/content/overlay-dispatcher.ts
+++ b/packages/extension/src/entrypoints/content/overlay-dispatcher.ts
@@ -1,0 +1,62 @@
+import { type OverlayPresenter } from '../../application/ports/overlay-presenter';
+import { describeDomainError, type DomainError } from '../../domain/shared/errors';
+import { type OverlayCommand } from './overlay-commands';
+
+/**
+ * IMPL-555 OverlayCommand → OverlayPresenter dispatcher (content script)。
+ *
+ * Content script 側で受信・検証済みの OverlayCommand を対応する
+ * `OverlayPresenter` メソッドに振り分ける。Presenter の Result は
+ * 個別にログへ落とし込み void Promise を返す (hot-path の描画失敗を
+ * listener の呼び出し元に伝播させない設計)。
+ */
+export type OverlayDispatcher = (command: OverlayCommand) => Promise<void>;
+
+export type OverlayDispatcherDependencies = Readonly<{
+  presenter: OverlayPresenter;
+  /** Err ログ用 sink。既定は console.warn。test で vi.fn を注入可能 */
+  logWarn?: (message: string) => void;
+}>;
+
+const defaultLogWarn = (message: string): void => {
+  console.warn(message);
+};
+
+const logPresenterError = (
+  logWarn: (message: string) => void,
+  scope: string,
+  error: DomainError,
+): void => {
+  logWarn(`[perapera] overlay-dispatcher ${scope} failed: ${describeDomainError(error)}`);
+};
+
+export const createOverlayDispatcher = (deps: OverlayDispatcherDependencies): OverlayDispatcher => {
+  const logWarn = deps.logWarn ?? defaultLogWarn;
+  return async (command) => {
+    switch (command.type) {
+      case 'overlay.mount': {
+        const result = await deps.presenter.mount(command.sessionIdentifier);
+        if (result.isErr()) logPresenterError(logWarn, 'mount', result.error);
+        return;
+      }
+      case 'overlay.render': {
+        const result = await deps.presenter.render(command.model);
+        if (result.isErr()) logPresenterError(logWarn, 'render', result.error);
+        return;
+      }
+      case 'overlay.update-settings': {
+        const result = await deps.presenter.updateSettings(
+          command.sessionIdentifier,
+          command.settings,
+        );
+        if (result.isErr()) logPresenterError(logWarn, 'update-settings', result.error);
+        return;
+      }
+      case 'overlay.unmount': {
+        const result = await deps.presenter.unmount(command.sessionIdentifier);
+        if (result.isErr()) logPresenterError(logWarn, 'unmount', result.error);
+        return;
+      }
+    }
+  };
+};

--- a/packages/extension/src/infrastructure/overlay/default-overlay-view.test.ts
+++ b/packages/extension/src/infrastructure/overlay/default-overlay-view.test.ts
@@ -131,4 +131,99 @@ describe('createDefaultOverlayViewFactory (IMPL-330 production helper)', () => {
       view.unmount();
     }).not.toThrow();
   });
+
+  describe('positionPreset (IMPL-556)', () => {
+    it("positionPreset='top' anchors host to the top edge", () => {
+      const { api, host } = buildDocumentApi();
+      const factory = createDefaultOverlayViewFactory({ documentApi: api });
+      const view = factory(sessionIdentifier);
+      view.mount();
+      const top = createOverlaySettings({
+        positionPreset: 'top',
+        opacity: 1,
+        maxLines: 2,
+        fontScale: 1,
+        showOriginalText: true,
+        showTranslatedText: true,
+      })._unsafeUnwrap();
+      view.update(buildModel(), top);
+      expect(host.style.top).toBe('0px');
+      expect(host.style.bottom).toBe('auto');
+      expect(host.style.justifyContent).toBe('flex-start');
+    });
+
+    it("positionPreset='bottom' keeps host anchored to the bottom", () => {
+      const { api, host } = buildDocumentApi();
+      const factory = createDefaultOverlayViewFactory({ documentApi: api });
+      const view = factory(sessionIdentifier);
+      view.mount();
+      view.update(buildModel(), settings);
+      expect(host.style.bottom).toBe('0px');
+      expect(host.style.justifyContent).toBe('flex-end');
+    });
+
+    it("positionPreset='floating' centers host vertically via transform", () => {
+      const { api, host } = buildDocumentApi();
+      const factory = createDefaultOverlayViewFactory({ documentApi: api });
+      const view = factory(sessionIdentifier);
+      view.mount();
+      const floating = createOverlaySettings({
+        positionPreset: 'floating',
+        opacity: 1,
+        maxLines: 2,
+        fontScale: 1,
+        showOriginalText: true,
+        showTranslatedText: true,
+      })._unsafeUnwrap();
+      view.update(buildModel(), floating);
+      expect(host.style.top).toBe('50%');
+      expect(host.style.transform).toContain('translateY(-50%)');
+    });
+  });
+
+  describe('maxLines (IMPL-557)', () => {
+    const makeLines = (count: number) =>
+      Array.from({ length: count }, (_, index) => ({
+        segmentIdentifier: parseSegmentIdentifier(
+          `01HZX8Y1R8M7D3Q2P4T5V6W7A${String(index)}${'A'.repeat(25)}`.slice(0, 26),
+        )._unsafeUnwrap(),
+        originalText: `line-${index}`,
+        translatedText: null,
+        targetLanguage: null,
+        isFinal: true,
+      }));
+
+    it('slices model.lines to the most recent maxLines when larger than limit', () => {
+      const { api, shadowRoot } = buildDocumentApi();
+      const factory = createDefaultOverlayViewFactory({ documentApi: api });
+      const view = factory(sessionIdentifier);
+      view.mount();
+      const limited = createOverlaySettings({
+        positionPreset: 'bottom',
+        opacity: 1,
+        maxLines: 2,
+        fontScale: 1,
+        showOriginalText: true,
+        showTranslatedText: true,
+      })._unsafeUnwrap();
+      view.update({ sessionIdentifier, lines: makeLines(5) }, limited);
+      const text = shadowRoot.textContent ?? '';
+      expect(text).not.toContain('line-0');
+      expect(text).not.toContain('line-2');
+      expect(text).toContain('line-3');
+      expect(text).toContain('line-4');
+    });
+
+    it('renders all lines when settings=null (fallback, no slicing)', () => {
+      const { api, shadowRoot } = buildDocumentApi();
+      const factory = createDefaultOverlayViewFactory({ documentApi: api });
+      const view = factory(sessionIdentifier);
+      view.mount();
+      view.update({ sessionIdentifier, lines: makeLines(3) }, null);
+      const text = shadowRoot.textContent ?? '';
+      expect(text).toContain('line-0');
+      expect(text).toContain('line-1');
+      expect(text).toContain('line-2');
+    });
+  });
 });

--- a/packages/extension/src/infrastructure/overlay/default-overlay-view.ts
+++ b/packages/extension/src/infrastructure/overlay/default-overlay-view.ts
@@ -67,9 +67,17 @@ const BASE_STYLE = `
 .perapera-overlay-translated { font-weight: 500; }
 `;
 
-const renderLines = (root: HTMLElement, model: OverlayRenderModel): void => {
+const renderLines = (
+  root: HTMLElement,
+  model: OverlayRenderModel,
+  settings: OverlaySettings | null,
+): void => {
   root.replaceChildren();
-  for (const line of model.lines) {
+  const displayLines =
+    settings !== null && settings.maxLines > 0
+      ? model.lines.slice(Math.max(0, model.lines.length - settings.maxLines))
+      : model.lines;
+  for (const line of displayLines) {
     const lineEl = document.createElement('div');
     lineEl.className = 'perapera-overlay-line';
     lineEl.setAttribute('data-segment-identifier', line.segmentIdentifier);
@@ -87,6 +95,40 @@ const renderLines = (root: HTMLElement, model: OverlayRenderModel): void => {
       lineEl.append(translated);
     }
     root.append(lineEl);
+  }
+};
+
+/**
+ * `positionPreset` を host (Shadow DOM を抱える fixed 要素) の inline style に
+ * 反映する。`settings === null` の場合は初期値 (bottom 配置) に復帰する。
+ */
+const applyPositionPreset = (host: HTMLElement, settings: OverlaySettings | null): void => {
+  if (settings === null) {
+    host.style.top = 'auto';
+    host.style.bottom = '0';
+    host.style.transform = '';
+    host.style.justifyContent = 'flex-end';
+    return;
+  }
+  switch (settings.positionPreset) {
+    case 'top':
+      host.style.top = '0';
+      host.style.bottom = 'auto';
+      host.style.transform = '';
+      host.style.justifyContent = 'flex-start';
+      break;
+    case 'bottom':
+      host.style.top = 'auto';
+      host.style.bottom = '0';
+      host.style.transform = '';
+      host.style.justifyContent = 'flex-end';
+      break;
+    case 'floating':
+      host.style.top = '50%';
+      host.style.bottom = 'auto';
+      host.style.transform = 'translateY(-50%)';
+      host.style.justifyContent = 'center';
+      break;
   }
 };
 
@@ -132,7 +174,8 @@ export const createDefaultOverlayViewFactory = (
       update: (model, settings) => {
         if (rootElement === null) return;
         applySettings(rootElement, settings);
-        renderLines(rootElement, model);
+        if (hostElement !== null) applyPositionPreset(hostElement, settings);
+        renderLines(rootElement, model, settings);
       },
       unmount: () => {
         if (hostElement !== null) {


### PR DESCRIPTION
## Summary

Phase 5 PR 次 #4 (roadmap §4) に従い、Background Service Worker からの `OverlayCommand` を content script で受信し、Shadow DOM で字幕オーバーレイを描画するホットパスを閉じる。

### 背景

PR #47 で SW 側 `ChromeMessagingOverlayPresenter` (IMPL-331) が `chrome.runtime.sendMessage` 越しに `OverlayCommand` (mount / render / update-settings / unmount) をブロードキャストする実装が完了済。ただし受信側 content script は skeleton のままで、対象ページ上の overlay が動いていなかった。本 PR でその gap を埋め、partial / final / translation final を overlay に描画するループを完成させる。

### 変更内容

**新規 (content script 側)**:
- IMPL-554 `entrypoints/content/overlay-commands.ts` — Zod + branded 型 parser。SW 型と shape 同期、`createOverlaySettings` 経由で不変条件検証
- IMPL-555 `entrypoints/content/overlay-dispatcher.ts` — 4 command を `OverlayPresenter` method に dispatch、Result を logWarn にログ
- IMPL-558 `entrypoints/content/index.ts` 差し替え — production 配線 (defaultOverlayDocumentApi + createContentScriptOverlayPresenter + createOverlayDispatcher) + chrome.runtime.onMessage listener

**拡張 (既存 infrastructure)**:
- IMPL-556 `default-overlay-view.ts` — `positionPreset` (top / bottom / floating) を host inline style に反映
- IMPL-557 `default-overlay-view.ts` — `settings.maxLines` で model.lines を末尾 N 件にスライス

### 本番実装で Mock / in-memory を使わない原則

- `defaultOverlayDocumentApi` / `createDefaultOverlayViewFactory` / `createContentScriptOverlayPresenter` を production default として明示注入
- SW 側 `BackgroundRequest` など OverlayCommand 以外のメッセージは Zod validation で自然に弾け、silent ignore で他 listener の応答に干渉しない
- test では DocumentApi / OverlayPresenter / logWarn を DI で fake に差し替え、実コード側には mock を残さない

### 設計書準拠

- CLAUDE.md §ホットパス最優先原則: dispatcher は render / unmount 側の Err を hot-path 内で throw しない (logWarn + void)
- CLAUDE.md §データ保存方針: overlay の設定は既に SW 側 chrome.storage.local 由来の `OverlaySettings`、本 PR で描画時に全 field (opacity / fontScale / positionPreset / maxLines) を反映
- DD-108 OverlayPresenter: `ContentScriptOverlayPresenter` (IMPL-330) を再利用し、Shadow DOM 描画責務は view factory に閉じる

## Test plan

- [x] `pnpm fmt:check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — 両 workspace green
- [x] `pnpm --filter @perapera/extension test` — 776 / 776 pass (既存 752 + 新規 24)
  - overlay-commands: 13
  - overlay-dispatcher: 6
  - default-overlay-view 追加 (positionPreset 3 + maxLines 2): 5
- [x] `pnpm --filter @perapera/relay-api test` — 184 / 184 pass (無影響)
- [x] `pnpm --filter @perapera/extension build` — `.output/chrome-mv3/content-scripts/content.js` が 85.42 kB で生成成功

## 後続 PR (roadmap §4)

- (次) #5 Offscreen document + Monitor page (タブ以外のソース向け overlay)
- (次) #6 Design system tokens / atoms / fonts

## Out of Scope

- Shadow DOM React 化 (現状 vanilla DOM。Phase 5 PR 次 #6 で検討)
- overlay 双方向通信 (overlay → background)
- ユーザー設定による injection 条件絞り込み (`matches` は `<all_urls>` のまま)