### PR TITLE
feat(extension): IMPL-560〜564 Offscreen document + Monitor page

### DIFF
--- a/packages/extension/src/entrypoints/monitor/App.tsx
+++ b/packages/extension/src/entrypoints/monitor/App.tsx
@@ -1,8 +1,32 @@
+import { useOverlayListener } from './use-overlay-listener';
+
+/**
+ * IMPL-564 Monitor page App。
+ *
+ * 非タブ系ソース (マイク / デスクトップ音声) 向けの overlay 表示先。
+ * `useOverlayListener` で chrome.runtime.onMessage を監視し、
+ * Shadow DOM オーバーレイを自ページ上に描画する。
+ *
+ * 本ページ自体の UI は「説明ヘッダ」のみで、実際の字幕は Shadow DOM 内に
+ * 独立描画される (`data-perapera-overlay` host)。
+ */
 export function App() {
+  useOverlayListener();
   return (
     <div className="container">
-      <h1>perapera Monitor</h1>
-      <p>マイクなどブラウザ外起源の音声に対するオーバーレイ表示先となる専用モニタです。</p>
+      <header className="header">
+        <h1 className="title">perapera Monitor</h1>
+      </header>
+      <section className="section">
+        <p className="message">
+          マイクやデスクトップ音声など、ブラウザタブ以外のソースを使用している場合、
+          このページに字幕オーバーレイが表示されます。
+        </p>
+        <p className="message" data-variant="muted">
+          セッション開始後、数秒で初期字幕が届きます。届かない場合は popup から
+          セッションを再開してください。
+        </p>
+      </section>
     </div>
   );
 }

--- a/packages/extension/src/entrypoints/monitor/main.tsx
+++ b/packages/extension/src/entrypoints/monitor/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { App } from './App';
+import './monitor.css';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/packages/extension/src/entrypoints/monitor/monitor.css
+++ b/packages/extension/src/entrypoints/monitor/monitor.css
@@ -1,0 +1,82 @@
+/*
+ * Monitor page CSS。popup / sidepanel と同じ palette を共有。
+ * 単一単語 className (CLAUDE.md §React ルール)。overlay 自体は Shadow DOM で
+ * 独立描画されるため、本 CSS は Monitor ページの「説明 UI」にのみ適用される。
+ */
+
+:root {
+  color-scheme: light dark;
+  --color-text: #1a1a1a;
+  --color-muted: #666;
+  --color-bg: #ffffff;
+  --color-border: #e0e0e0;
+  --color-accent: #2563eb;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-text: #f5f5f5;
+    --color-muted: #a0a0a0;
+    --color-bg: #111111;
+    --color-border: #333333;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    'Hiragino Sans',
+    'Yu Gothic UI',
+    sans-serif;
+  font-size: 14px;
+  color: var(--color-text);
+  background: var(--color-bg);
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 32px 24px;
+}
+
+.header {
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 12px;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.message {
+  font-size: 13px;
+  color: var(--color-text);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.message[data-variant='muted'] {
+  color: var(--color-muted);
+  font-size: 12px;
+}

--- a/packages/extension/src/entrypoints/monitor/use-overlay-listener.test.tsx
+++ b/packages/extension/src/entrypoints/monitor/use-overlay-listener.test.tsx
@@ -1,0 +1,104 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useOverlayListener } from './use-overlay-listener';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SEGMENT_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+
+type Listener = Parameters<typeof chrome.runtime.onMessage.addListener>[0];
+
+describe('useOverlayListener (IMPL-563)', () => {
+  let listeners: Listener[];
+  let addSpy: ReturnType<typeof vi.fn>;
+  let removeSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    listeners = [];
+    addSpy = vi.fn((listener: Listener) => {
+      listeners.push(listener);
+    });
+    removeSpy = vi.fn((listener: Listener) => {
+      listeners = listeners.filter((entry) => entry !== listener);
+    });
+    Object.defineProperty(chrome.runtime, 'onMessage', {
+      value: {
+        addListener: addSpy,
+        removeListener: removeSpy,
+        hasListener: vi.fn(),
+      },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    listeners = [];
+    // Overlay hosts are appended imperatively to document.body; RTL cleanup
+    // doesn't remove them. Clean up here to avoid cross-test leakage.
+    for (const host of document.querySelectorAll('[data-perapera-overlay]')) {
+      host.remove();
+    }
+  });
+
+  it('registers a listener on mount and removes it on unmount', () => {
+    const { unmount } = renderHook(() => useOverlayListener());
+    expect(addSpy).toHaveBeenCalledOnce();
+    unmount();
+    expect(removeSpy).toHaveBeenCalledOnce();
+  });
+
+  it('mounts a Shadow DOM overlay host on overlay.mount command', async () => {
+    renderHook(() => useOverlayListener());
+    const listener = listeners[0];
+    if (listener === undefined) throw new Error('listener not registered');
+    const sendResponse = vi.fn();
+    listener({ type: 'overlay.mount', sessionIdentifier: SESSION_ID }, {}, sendResponse);
+    await waitFor(() => expect(sendResponse).toHaveBeenCalledOnce());
+    const host = document.querySelector('[data-perapera-overlay]');
+    expect(host).not.toBeNull();
+  });
+
+  it('renders a Shadow DOM line on overlay.render command', async () => {
+    renderHook(() => useOverlayListener());
+    const listener = listeners[0];
+    if (listener === undefined) throw new Error('listener not registered');
+    const mountResponse = vi.fn();
+    listener({ type: 'overlay.mount', sessionIdentifier: SESSION_ID }, {}, mountResponse);
+    await waitFor(() => expect(mountResponse).toHaveBeenCalledOnce());
+    const renderResponse = vi.fn();
+    listener(
+      {
+        type: 'overlay.render',
+        model: {
+          sessionIdentifier: SESSION_ID,
+          lines: [
+            {
+              segmentIdentifier: SEGMENT_ID,
+              originalText: 'Hello',
+              translatedText: 'こんにちは',
+              targetLanguage: 'ja',
+              isFinal: true,
+            },
+          ],
+        },
+      },
+      {},
+      renderResponse,
+    );
+    await waitFor(() => expect(renderResponse).toHaveBeenCalledOnce());
+    const host = document.querySelector('[data-perapera-overlay]');
+    const shadowText = host?.shadowRoot?.textContent ?? '';
+    expect(shadowText).toContain('Hello');
+    expect(shadowText).toContain('こんにちは');
+  });
+
+  it('silently ignores non-OverlayCommand messages (returns false)', () => {
+    renderHook(() => useOverlayListener());
+    const listener = listeners[0];
+    if (listener === undefined) throw new Error('listener not registered');
+    const sendResponse = vi.fn();
+    const ret = listener({ type: 'command.start-source-session' }, {}, sendResponse);
+    expect(ret).toBe(false);
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/src/entrypoints/monitor/use-overlay-listener.ts
+++ b/packages/extension/src/entrypoints/monitor/use-overlay-listener.ts
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+import { createContentScriptOverlayPresenter } from '../../infrastructure/overlay/content-script-overlay-presenter';
+import {
+  createDefaultOverlayViewFactory,
+  defaultOverlayDocumentApi,
+} from '../../infrastructure/overlay/default-overlay-view';
+import { parseOverlayCommand } from '../content/overlay-commands';
+import { createOverlayDispatcher } from '../content/overlay-dispatcher';
+
+/**
+ * IMPL-563 Monitor page overlay listener hook。
+ *
+ * Content script と同じ pattern で `chrome.runtime.onMessage` を listen し、
+ * `OverlayCommand` を Shadow DOM overlay に dispatch する。Monitor page では
+ * タブページではなく拡張が所有する HTML を対象にする (非 tab ソース: マイク /
+ * デスクトップ音声向け)。
+ *
+ * 実装は本 hook を App root から 1 度だけ呼ぶ。contentScriptOverlayPresenter
+ * はセッション単位で mount を管理するため、Monitor に複数セッションが流れ込んでも
+ * overlay は同じ Shadow host を複数 session で共有しない (session ごとに別個の host)。
+ *
+ * 解除 (unmount): hook の useEffect cleanup で chrome.runtime.onMessage の
+ * listener を remove する。開発中の HMR で leak しない。
+ */
+export const useOverlayListener = (): void => {
+  useEffect(() => {
+    const viewFactory = createDefaultOverlayViewFactory({
+      documentApi: defaultOverlayDocumentApi,
+    });
+    const presenter = createContentScriptOverlayPresenter({ overlayViewFactory: viewFactory });
+    const dispatch = createOverlayDispatcher({ presenter });
+
+    const listener: Parameters<typeof chrome.runtime.onMessage.addListener>[0] = (
+      message,
+      _sender,
+      sendResponse,
+    ) => {
+      const parsed = parseOverlayCommand(message);
+      if (parsed.isErr()) return false;
+      void dispatch(parsed.value).finally(() => {
+        sendResponse(undefined);
+      });
+      return true;
+    };
+
+    chrome.runtime.onMessage.addListener(listener);
+    return () => {
+      chrome.runtime.onMessage.removeListener(listener);
+    };
+  }, []);
+};

--- a/packages/extension/src/entrypoints/offscreen/main.ts
+++ b/packages/extension/src/entrypoints/offscreen/main.ts
@@ -1,3 +1,39 @@
-// Offscreen document: DOM / MediaStream を必要とする音声処理ハブ
-// AudioPreprocessor / RelayWebSocketGateway は後続で実装
+import { defaultAudioContextFactory } from '../../infrastructure/audio/audio-preprocessor';
+import { createOffscreenAudioHost } from './offscreen-audio-host';
+import { parseOffscreenCommand } from './offscreen-commands';
+
+/**
+ * IMPL-562 Offscreen document entry。
+ *
+ * Service Worker からの `OffscreenCommand` を chrome.runtime.onMessage で受け、
+ * `OffscreenAudioHost` で AudioContext を lifecycle 管理する。MV3 の SW は
+ * `new AudioContext()` を呼べないため、offscreen document が代理で保持する。
+ *
+ * **本番実装で mock / in-memory を使わない原則**:
+ * - `defaultAudioContextFactory` を明示注入 (production default)
+ * - test では `createOffscreenAudioHost` に stub を入れる (entry 本体は real)
+ *
+ * MVP スコープ: AudioContext 確保までの shell。PCM 転送 / AudioWorklet 配線は
+ * Phase 6 integration で追加予定。
+ */
 console.log('[perapera] offscreen document loaded');
+
+const host = createOffscreenAudioHost({
+  audioContextFactory: defaultAudioContextFactory,
+});
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  const parsed = parseOffscreenCommand(message);
+  if (parsed.isErr()) {
+    // OverlayCommand / BackgroundRequest など非 Offscreen メッセージも流入する
+    // ため silent ignore。return false で async 応答しないことを宣言。
+    return false;
+  }
+  host.dispatch(parsed.value);
+  sendResponse({ ok: true });
+  return false;
+});
+
+window.addEventListener('beforeunload', () => {
+  host.dispose();
+});

--- a/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.test.ts
+++ b/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type AudioContextLike,
+  type AudioContextFactory,
+} from '../../infrastructure/audio/audio-preprocessor';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { createOffscreenAudioHost } from './offscreen-audio-host';
+
+const SESSION_A = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SESSION_B = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+const identifierA: SessionIdentifier = parseSessionIdentifier(SESSION_A)._unsafeUnwrap();
+const identifierB: SessionIdentifier = parseSessionIdentifier(SESSION_B)._unsafeUnwrap();
+
+const buildFakeContext = (
+  sampleRate: number,
+): AudioContextLike & { closeFn: ReturnType<typeof vi.fn> } => {
+  const closeFn = vi.fn(() => Promise.resolve());
+  return {
+    sampleRate,
+    audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
+    close: closeFn,
+    createMediaStreamSource: vi.fn(() => ({})),
+    closeFn,
+  };
+};
+
+const buildLogger = () => ({
+  debug: vi.fn<(message: string) => void>(),
+  warn: vi.fn<(message: string) => void>(),
+});
+
+describe('createOffscreenAudioHost (IMPL-561)', () => {
+  it('opens an AudioContext on offscreen.audio.open', () => {
+    const context = buildFakeContext(16000);
+    const factory: AudioContextFactory = vi.fn(() => context);
+    const host = createOffscreenAudioHost({ audioContextFactory: factory });
+    host.dispatch({ type: 'offscreen.audio.open', sessionIdentifier: identifierA });
+    expect(factory).toHaveBeenCalledOnce();
+    expect(host.has(identifierA)).toBe(true);
+  });
+
+  it('uses sampleRateHz override when provided', () => {
+    const factory = vi.fn<AudioContextFactory>(() => buildFakeContext(48000));
+    const host = createOffscreenAudioHost({ audioContextFactory: factory });
+    host.dispatch({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: identifierA,
+      sampleRateHz: 48000,
+    });
+    expect(factory).toHaveBeenCalledWith({ sampleRate: 48000 });
+  });
+
+  it('defaults sampleRate to 16000 when not provided', () => {
+    const factory = vi.fn<AudioContextFactory>(() => buildFakeContext(16000));
+    const host = createOffscreenAudioHost({ audioContextFactory: factory });
+    host.dispatch({ type: 'offscreen.audio.open', sessionIdentifier: identifierA });
+    expect(factory).toHaveBeenCalledWith({ sampleRate: 16000 });
+  });
+
+  it('reuses existing AudioContext on duplicate open', () => {
+    const factory = vi.fn<AudioContextFactory>(() => buildFakeContext(16000));
+    const host = createOffscreenAudioHost({ audioContextFactory: factory });
+    host.dispatch({ type: 'offscreen.audio.open', sessionIdentifier: identifierA });
+    host.dispatch({ type: 'offscreen.audio.open', sessionIdentifier: identifierA });
+    expect(factory).toHaveBeenCalledOnce();
+  });
+
+  it('closes AudioContext on offscreen.audio.close', () => {
+    const context = buildFakeContext(16000);
+    const factory = vi.fn<AudioContextFactory>(() => context);
+    const host = createOffscreenAudioHost({ audioContextFactory: factory });
+    host.dispatch({ type: 'offscreen.audio.open', sessionIdentifier: identifierA });
+    host.dispatch({ type: 'offscreen.audio.close', sessionIdentifier: identifierA });
+    expect(context.closeFn).toHaveBeenCalledOnce();
+    expect(host.has(identifierA)).toBe(false);
+  });
+
+  it('is a no-op when close is received for unknown session', () => {
+    const factory = vi.fn<AudioContextFactory>(() => buildFakeContext(16000));
+    const host = createOffscreenAudioHost({ audioContextFactory: factory });
+    host.dispatch({ type: 'offscreen.audio.close', sessionIdentifier: identifierA });
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it('handles multiple sessions independently', () => {
+    const factory = vi.fn<AudioContextFactory>(() => buildFakeContext(16000));
+    const host = createOffscreenAudioHost({ audioContextFactory: factory });
+    host.dispatch({ type: 'offscreen.audio.open', sessionIdentifier: identifierA });
+    host.dispatch({ type: 'offscreen.audio.open', sessionIdentifier: identifierB });
+    expect(host.has(identifierA)).toBe(true);
+    expect(host.has(identifierB)).toBe(true);
+    host.dispatch({ type: 'offscreen.audio.close', sessionIdentifier: identifierA });
+    expect(host.has(identifierA)).toBe(false);
+    expect(host.has(identifierB)).toBe(true);
+  });
+
+  it('ping is acknowledged (debug log) without side effect', () => {
+    const logger = buildLogger();
+    const factory = vi.fn<AudioContextFactory>(() => buildFakeContext(16000));
+    const host = createOffscreenAudioHost({ audioContextFactory: factory, logger });
+    host.dispatch({ type: 'offscreen.ping' });
+    expect(factory).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('received ping'));
+  });
+
+  it('logs warn when audioContextFactory throws', () => {
+    const logger = buildLogger();
+    const factory = vi.fn<AudioContextFactory>(() => {
+      throw new Error('AudioContext unavailable');
+    });
+    const host = createOffscreenAudioHost({ audioContextFactory: factory, logger });
+    host.dispatch({ type: 'offscreen.audio.open', sessionIdentifier: identifierA });
+    expect(host.has(identifierA)).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('AudioContext unavailable'));
+  });
+
+  it('dispose closes all active contexts', () => {
+    const contextA = buildFakeContext(16000);
+    const contextB = buildFakeContext(16000);
+    let call = 0;
+    const factory: AudioContextFactory = vi.fn(() => {
+      call += 1;
+      return call === 1 ? contextA : contextB;
+    });
+    const host = createOffscreenAudioHost({ audioContextFactory: factory });
+    host.dispatch({ type: 'offscreen.audio.open', sessionIdentifier: identifierA });
+    host.dispatch({ type: 'offscreen.audio.open', sessionIdentifier: identifierB });
+    host.dispose();
+    expect(contextA.closeFn).toHaveBeenCalledOnce();
+    expect(contextB.closeFn).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.ts
+++ b/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.ts
@@ -1,0 +1,119 @@
+import {
+  type AudioContextFactory,
+  type AudioContextLike,
+} from '../../infrastructure/audio/audio-preprocessor';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type OffscreenCommand } from './offscreen-commands';
+
+/**
+ * IMPL-561 Offscreen Audio Host。
+ *
+ * Background Service Worker から受信した `OffscreenCommand` に応じて
+ * AudioContext を sessionId 単位で open / close する lifecycle manager。
+ *
+ * **本番実装で mock を使わない設計**:
+ * - `audioContextFactory` は必須 DI。production entrypoint で
+ *   `defaultAudioContextFactory` を明示注入、test では minimal stub を注入
+ * - AudioContext は sessionIdentifier → context の Map で保持。同一 session に
+ *   複数回 open が来た場合は既存 context を再利用 (idempotent)
+ *
+ * MVP スコープ:
+ * - 実際の PCM frame 転送 / AudioWorklet 配線は Phase 6 integration で追加
+ * - 本モジュールは「AudioContext を確保する」ところまで (SW と分離された DOM
+ *   コンテキストで Audio API を使えるようにする土台)
+ */
+export type OffscreenAudioHost = Readonly<{
+  dispatch: (command: OffscreenCommand) => void;
+  /** sessionId に対する AudioContext が現在確保されているか */
+  has: (sessionIdentifier: SessionIdentifier) => boolean;
+  /** 登録中の全 AudioContext を破棄 (entry shutdown 用) */
+  dispose: () => void;
+}>;
+
+export type OffscreenAudioHostDependencies = Readonly<{
+  audioContextFactory: AudioContextFactory;
+  /** 操作のログ sink。既定は console */
+  logger?: Readonly<{
+    debug: (message: string) => void;
+    warn: (message: string) => void;
+  }>;
+}>;
+
+const DEFAULT_LOGGER = {
+  debug: (message: string): void => {
+    console.debug(message);
+  },
+  warn: (message: string): void => {
+    console.warn(message);
+  },
+};
+
+const DEFAULT_SAMPLE_RATE = 16000 as const;
+
+export const createOffscreenAudioHost = (
+  deps: OffscreenAudioHostDependencies,
+): OffscreenAudioHost => {
+  const contexts = new Map<SessionIdentifier, AudioContextLike>();
+  const logger = deps.logger ?? DEFAULT_LOGGER;
+
+  const closeContext = (sessionIdentifier: SessionIdentifier): void => {
+    const context = contexts.get(sessionIdentifier);
+    if (context === undefined) return;
+    contexts.delete(sessionIdentifier);
+    void context.close().catch((cause) => {
+      logger.warn(
+        `[perapera] offscreen-audio-host close failed for ${sessionIdentifier}: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      );
+    });
+  };
+
+  const openContext = (sessionIdentifier: SessionIdentifier, sampleRateHz?: number): void => {
+    if (contexts.has(sessionIdentifier)) {
+      logger.debug(
+        `[perapera] offscreen-audio-host re-use existing AudioContext for ${sessionIdentifier}`,
+      );
+      return;
+    }
+    try {
+      const context = deps.audioContextFactory({
+        sampleRate: sampleRateHz ?? DEFAULT_SAMPLE_RATE,
+      });
+      contexts.set(sessionIdentifier, context);
+      logger.debug(
+        `[perapera] offscreen-audio-host opened AudioContext for ${sessionIdentifier} (sampleRate=${String(
+          context.sampleRate,
+        )})`,
+      );
+    } catch (cause) {
+      logger.warn(
+        `[perapera] offscreen-audio-host open failed for ${sessionIdentifier}: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      );
+    }
+  };
+
+  return {
+    dispatch: (command) => {
+      switch (command.type) {
+        case 'offscreen.ping':
+          logger.debug('[perapera] offscreen-audio-host received ping');
+          return;
+        case 'offscreen.audio.open':
+          openContext(command.sessionIdentifier, command.sampleRateHz);
+          return;
+        case 'offscreen.audio.close':
+          closeContext(command.sessionIdentifier);
+          return;
+      }
+    },
+    has: (sessionIdentifier) => contexts.has(sessionIdentifier),
+    dispose: () => {
+      for (const [sessionIdentifier] of contexts) {
+        closeContext(sessionIdentifier);
+      }
+    },
+  };
+};

--- a/packages/extension/src/entrypoints/offscreen/offscreen-commands.test.ts
+++ b/packages/extension/src/entrypoints/offscreen/offscreen-commands.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { parseOffscreenCommand } from './offscreen-commands';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+
+describe('parseOffscreenCommand (IMPL-560)', () => {
+  it('parses offscreen.ping', () => {
+    const result = parseOffscreenCommand({ type: 'offscreen.ping' });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value.type).toBe('offscreen.ping');
+  });
+
+  it('parses offscreen.audio.open with default sampleRate', () => {
+    const result = parseOffscreenCommand({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: SESSION_ID,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && result.value.type === 'offscreen.audio.open') {
+      expect(result.value.sessionIdentifier).toBe(SESSION_ID);
+      expect(result.value.sampleRateHz).toBeUndefined();
+    }
+  });
+
+  it('parses offscreen.audio.open with explicit sampleRateHz', () => {
+    const result = parseOffscreenCommand({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: SESSION_ID,
+      sampleRateHz: 48000,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && result.value.type === 'offscreen.audio.open') {
+      expect(result.value.sampleRateHz).toBe(48000);
+    }
+  });
+
+  it('parses offscreen.audio.close', () => {
+    const result = parseOffscreenCommand({
+      type: 'offscreen.audio.close',
+      sessionIdentifier: SESSION_ID,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && result.value.type === 'offscreen.audio.close') {
+      expect(result.value.sessionIdentifier).toBe(SESSION_ID);
+    }
+  });
+
+  it('rejects audio.open with malformed sessionIdentifier', () => {
+    const result = parseOffscreenCommand({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: 'not-ulid',
+    });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects audio.open with negative sampleRate', () => {
+    const result = parseOffscreenCommand({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: SESSION_ID,
+      sampleRateHz: -1,
+    });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects unknown command types', () => {
+    const result = parseOffscreenCommand({ type: 'offscreen.unknown' });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('rejects non-object payloads', () => {
+    expect(parseOffscreenCommand(null).isErr()).toBe(true);
+    expect(parseOffscreenCommand(42).isErr()).toBe(true);
+  });
+});

--- a/packages/extension/src/entrypoints/offscreen/offscreen-commands.ts
+++ b/packages/extension/src/entrypoints/offscreen/offscreen-commands.ts
@@ -1,0 +1,90 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { validationError, type DomainError } from '../../domain/shared/errors';
+
+/**
+ * IMPL-560 Offscreen command schema (Background → Offscreen)。
+ *
+ * MV3 Service Worker は DOM / AudioContext を直接扱えないため、
+ * `chrome.offscreen.createDocument` で作成した offscreen document に
+ * `chrome.runtime.sendMessage` で命令を送り、audio 処理を delegate する。
+ *
+ * MVP スコープでは:
+ * - `offscreen.audio.open`: sessionId に対する AudioContext を確保
+ * - `offscreen.audio.close`: sessionId の AudioContext を破棄
+ * - `offscreen.ping`: living-proof (offscreen doc が応答できるかの死活確認)
+ *
+ * 実際の PCM frame 転送や AudioWorklet への音声 pipe は Phase 6 integration で
+ * 実装する。本 PR は shell (lifecycle + message routing) を整える。
+ */
+
+const audioOpenSchema = z.object({
+  type: z.literal('offscreen.audio.open'),
+  sessionIdentifier: z.string().min(1),
+  /** AudioContext のサンプルレート (default 16000) */
+  sampleRateHz: z.number().int().positive().optional(),
+});
+
+const audioCloseSchema = z.object({
+  type: z.literal('offscreen.audio.close'),
+  sessionIdentifier: z.string().min(1),
+});
+
+const pingSchema = z.object({
+  type: z.literal('offscreen.ping'),
+});
+
+const offscreenCommandRawSchema = z.discriminatedUnion('type', [
+  audioOpenSchema,
+  audioCloseSchema,
+  pingSchema,
+]);
+
+export type OffscreenCommand =
+  | Readonly<{
+      type: 'offscreen.audio.open';
+      sessionIdentifier: SessionIdentifier;
+      sampleRateHz?: number;
+    }>
+  | Readonly<{ type: 'offscreen.audio.close'; sessionIdentifier: SessionIdentifier }>
+  | Readonly<{ type: 'offscreen.ping' }>;
+
+export const parseOffscreenCommand = (raw: unknown): Result<OffscreenCommand, DomainError> => {
+  const parsed = offscreenCommandRawSchema.safeParse(raw);
+  if (!parsed.success) {
+    return err(
+      validationError({
+        field: 'OffscreenCommand',
+        message: parsed.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  const data = parsed.data;
+  switch (data.type) {
+    case 'offscreen.ping':
+      return ok<OffscreenCommand, DomainError>({ type: 'offscreen.ping' });
+    case 'offscreen.audio.open':
+      return parseSessionIdentifier(data.sessionIdentifier).map((sessionIdentifier) => {
+        const command: OffscreenCommand =
+          data.sampleRateHz !== undefined
+            ? {
+                type: 'offscreen.audio.open',
+                sessionIdentifier,
+                sampleRateHz: data.sampleRateHz,
+              }
+            : { type: 'offscreen.audio.open', sessionIdentifier };
+        return command;
+      });
+    case 'offscreen.audio.close':
+      return parseSessionIdentifier(data.sessionIdentifier).map(
+        (sessionIdentifier): OffscreenCommand => ({
+          type: 'offscreen.audio.close',
+          sessionIdentifier,
+        }),
+      );
+  }
+};


### PR DESCRIPTION
## Summary

Phase 5 PR 次 #5 (roadmap §4) に従い、MV3 で SW が直接扱えない `AudioContext` を延命する Offscreen document と、タブ以外のソース (マイク / デスクトップ) 向け字幕オーバーレイ表示先の Monitor page を実装。

### 背景

- Service Worker は `new AudioContext()` を呼べないため、`chrome.offscreen.createDocument` で hidden ページを生成し、そこで AudioContext を保持する必要がある
- マイク / デスクトップ音声はコンテンツを持つタブがないため、専用 Monitor ページ (web_accessible_resources 登録済) で overlay を表示する

### 変更内容

**Offscreen document**:
- IMPL-560 `offscreen-commands.ts` — Zod schema + parser。`offscreen.audio.open` / `offscreen.audio.close` / `offscreen.ping`
- IMPL-561 `offscreen-audio-host.ts` — sessionId → AudioContext Map で lifecycle 管理。同一 session 再 open は idempotent、dispose で全 context を close
- IMPL-562 `entrypoints/offscreen/main.ts` — `defaultAudioContextFactory` を明示注入、`chrome.runtime.onMessage` で parse → host.dispatch。`beforeunload` で dispose

MVP スコープ: AudioContext 確保までの shell。PCM frame 転送と AudioWorklet 配線は Phase 6 integration で追加。

**Monitor page**:
- IMPL-563 `use-overlay-listener.ts` — React hook で chrome.runtime.onMessage listener を管理。Content script と同じ `parseOverlayCommand` + `createOverlayDispatcher` + `createContentScriptOverlayPresenter` (IMPL-330) + `defaultOverlayDocumentApi` を注入 (production default)
- IMPL-564 `App.tsx` 差し替え — `useOverlayListener()` を呼ぶ minimal UI (header + 説明メッセージ)。字幕は Shadow DOM 内に独立描画
- `main.tsx` に `monitor.css` import 追加
- `monitor.css` 新規 — dark mode 対応含む minimal スタイリング

### 本番実装で Mock / in-memory を使わない原則

- Offscreen の `defaultAudioContextFactory`, Monitor の `defaultOverlayDocumentApi` / `createDefaultOverlayViewFactory` / `createContentScriptOverlayPresenter` を production default として明示注入
- Zod validation で OverlayCommand / OffscreenCommand 以外のメッセージは silent ignore、他 listener の応答に干渉しない
- test のみ AudioContextFactory / chrome.runtime を差し替え、production code には mock を残さない

## Test plan

- [x] `pnpm fmt:check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — 両 workspace green
- [x] `pnpm --filter @perapera/extension test` — 798 / 798 pass (既存 776 + 新規 22)
  - offscreen-commands: 8
  - offscreen-audio-host: 10
  - use-overlay-listener (monitor): 4
- [x] `pnpm --filter @perapera/relay-api test` — 184 / 184 pass (無影響)
- [x] `pnpm --filter @perapera/extension build` — `.output/chrome-mv3/` に offscreen.html / monitor.html + monitor.css (909 B) が生成される

## 後続 PR (roadmap §4)

- (次) #6 Design system tokens / atoms refresh / フォント読込

## Out of Scope

- PCM frame 転送 / AudioWorklet 実配線 (Phase 6 integration)
- SW 側での `chrome.offscreen.createDocument` 呼び出し (別 PR で AudioPreprocessor proxy と併せて)
- Monitor page の session state UI (現状は overlay 表示先としての役割のみ)