### PR TITLE
feat(extension): IMPL-590/591 design system tokens + font loading (Phase 5 PR 次 #6)

### DIFF
--- a/packages/extension/src/entrypoints/monitor/monitor.css
+++ b/packages/extension/src/entrypoints/monitor/monitor.css
@@ -1,26 +1,11 @@
 /*
- * Monitor page CSS。popup / sidepanel と同じ palette を共有。
+ * Monitor page CSS。tokens.css + fonts.css を popup / sidepanel と共有。
  * 単一単語 className (CLAUDE.md §React ルール)。overlay 自体は Shadow DOM で
  * 独立描画されるため、本 CSS は Monitor ページの「説明 UI」にのみ適用される。
  */
 
-:root {
-  color-scheme: light dark;
-  --color-text: #1a1a1a;
-  --color-muted: #666;
-  --color-bg: #ffffff;
-  --color-border: #e0e0e0;
-  --color-accent: #2563eb;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-text: #f5f5f5;
-    --color-muted: #a0a0a0;
-    --color-bg: #111111;
-    --color-border: #333333;
-  }
-}
+@import url('../../presentation/styles/tokens.css');
+@import url('../../presentation/styles/fonts.css');
 
 * {
   box-sizing: border-box;
@@ -29,17 +14,11 @@
 body {
   margin: 0;
   padding: 0;
-  font-family:
-    system-ui,
-    -apple-system,
-    'Segoe UI',
-    Roboto,
-    'Hiragino Sans',
-    'Yu Gothic UI',
-    sans-serif;
-  font-size: 14px;
-  color: var(--color-text);
-  background: var(--color-bg);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-body);
+  line-height: var(--line-height-body);
+  color: var(--color-text-primary);
+  background: var(--color-background);
   min-height: 100vh;
 }
 
@@ -48,35 +27,36 @@ body {
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 32px 24px;
+  gap: var(--space-lg);
+  padding: var(--space-2xl) var(--space-xl);
 }
 
 .header {
   border-bottom: 1px solid var(--color-border);
-  padding-bottom: 12px;
+  padding-bottom: var(--space-md);
 }
 
 .title {
-  font-size: 20px;
-  font-weight: 600;
+  font-size: var(--font-size-h2);
+  font-weight: var(--font-weight-heading);
+  line-height: var(--line-height-heading);
   margin: 0;
 }
 
 .section {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-sm);
 }
 
 .message {
-  font-size: 13px;
-  color: var(--color-text);
-  line-height: 1.6;
+  font-size: var(--font-size-body);
+  color: var(--color-text-primary);
+  line-height: var(--line-height-body);
   margin: 0;
 }
 
 .message[data-variant='muted'] {
-  color: var(--color-muted);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-small);
 }

--- a/packages/extension/src/entrypoints/popup/popup.css
+++ b/packages/extension/src/entrypoints/popup/popup.css
@@ -1,25 +1,11 @@
 /*
- * Popup minimal CSS。vanilla + 単一単語 className (CLAUDE.md §React ルール)。
- * Design system tokens は Phase 5 PR 次 #6 で導入予定。
+ * Popup CSS。tokens.css + fonts.css を共有 (IMPL-590/591)、単一単語 className
+ * (CLAUDE.md §React ルール)。カラー / フォント / スペーシング値は
+ * `var(--token-*)` 経由で参照する。
  */
 
-:root {
-  color-scheme: light;
-  --color-text: #1a1a1a;
-  --color-muted: #666;
-  --color-bg: #ffffff;
-  --color-border: #e0e0e0;
-  --color-accent: #2563eb;
-  --color-accent-fg: #ffffff;
-  --color-danger: #dc2626;
-  --color-danger-fg: #ffffff;
-  --color-active: #10b981;
-  --color-pending: #f59e0b;
-  --color-degraded: #c2410c;
-  --color-error: #dc2626;
-  --color-stopped: #6b7280;
-  --color-neutral: #9ca3af;
-}
+@import url('../../presentation/styles/tokens.css');
+@import url('../../presentation/styles/fonts.css');
 
 * {
   box-sizing: border-box;
@@ -28,17 +14,11 @@
 body {
   margin: 0;
   padding: 0;
-  font-family:
-    system-ui,
-    -apple-system,
-    'Segoe UI',
-    Roboto,
-    'Hiragino Sans',
-    'Yu Gothic UI',
-    sans-serif;
-  font-size: 13px;
-  color: var(--color-text);
-  background: var(--color-bg);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-small);
+  line-height: var(--line-height-body);
+  color: var(--color-text-primary);
+  background: var(--color-surface);
   width: 360px;
   min-height: 320px;
 }
@@ -46,8 +26,8 @@ body {
 .container {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 12px;
+  gap: var(--space-md);
+  padding: var(--space-md);
 }
 
 .header {
@@ -55,30 +35,33 @@ body {
   align-items: baseline;
   justify-content: space-between;
   border-bottom: 1px solid var(--color-border);
-  padding-bottom: 8px;
+  padding-bottom: var(--space-sm);
 }
 
 .title {
-  font-size: 15px;
-  font-weight: 600;
+  font-size: var(--font-size-h3);
+  font-weight: var(--font-weight-h3);
+  line-height: var(--line-height-heading);
   margin: 0;
 }
 
 .version {
-  font-size: 11px;
-  color: var(--color-muted);
+  font-family: var(--font-family-numeric);
+  font-size: var(--font-size-small);
+  font-weight: var(--font-weight-numeric);
+  color: var(--color-text-muted);
 }
 
 .section {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-sm);
 }
 
 .subtitle {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-muted);
+  font-size: var(--font-size-small);
+  font-weight: var(--font-weight-h3);
+  color: var(--color-text-muted);
   margin: 0;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -210,11 +193,12 @@ body {
   display: inline-flex;
   align-items: center;
   padding: 2px 6px;
-  border-radius: 999px;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--color-accent-fg);
-  background: var(--color-neutral);
+  border-radius: var(--radius-pill);
+  font-family: var(--font-family-numeric);
+  font-size: var(--font-size-small);
+  font-weight: var(--font-weight-numeric);
+  color: var(--color-text-inverse);
+  background: var(--color-state-neutral);
   align-self: flex-start;
 }
 

--- a/packages/extension/src/entrypoints/sidepanel/sidepanel.css
+++ b/packages/extension/src/entrypoints/sidepanel/sidepanel.css
@@ -1,26 +1,11 @@
 /*
- * SidePanel CSS。popup.css とトークンを共有するが Side Panel は幅を画面幅に
- * 合わせて伸ばす (Chrome の side panel は可変幅)。単一単語 className のみ使用。
- * Design system tokens は Phase 5 PR 次 #6 で置換予定。
+ * SidePanel CSS。tokens.css + fonts.css を popup と共有し、Side Panel 特有の
+ * 幅可変レイアウト (`container` に height:100vh) を追加。
+ * 単一単語 className (CLAUDE.md §React ルール)。
  */
 
-:root {
-  color-scheme: light;
-  --color-text: #1a1a1a;
-  --color-muted: #666;
-  --color-bg: #ffffff;
-  --color-border: #e0e0e0;
-  --color-accent: #2563eb;
-  --color-accent-fg: #ffffff;
-  --color-danger: #dc2626;
-  --color-danger-fg: #ffffff;
-  --color-active: #10b981;
-  --color-pending: #f59e0b;
-  --color-degraded: #c2410c;
-  --color-error: #dc2626;
-  --color-stopped: #6b7280;
-  --color-neutral: #9ca3af;
-}
+@import url('../../presentation/styles/tokens.css');
+@import url('../../presentation/styles/fonts.css');
 
 * {
   box-sizing: border-box;
@@ -29,25 +14,19 @@
 body {
   margin: 0;
   padding: 0;
-  font-family:
-    system-ui,
-    -apple-system,
-    'Segoe UI',
-    Roboto,
-    'Hiragino Sans',
-    'Yu Gothic UI',
-    sans-serif;
-  font-size: 13px;
-  color: var(--color-text);
-  background: var(--color-bg);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-small);
+  line-height: var(--line-height-body);
+  color: var(--color-text-primary);
+  background: var(--color-background);
   min-height: 100vh;
 }
 
 .container {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 12px;
+  gap: var(--space-md);
+  padding: var(--space-md);
   height: 100vh;
   overflow: hidden;
 }
@@ -57,25 +36,28 @@ body {
   align-items: baseline;
   justify-content: space-between;
   border-bottom: 1px solid var(--color-border);
-  padding-bottom: 8px;
+  padding-bottom: var(--space-sm);
   flex-shrink: 0;
 }
 
 .title {
-  font-size: 15px;
-  font-weight: 600;
+  font-size: var(--font-size-h3);
+  font-weight: var(--font-weight-h3);
+  line-height: var(--line-height-heading);
   margin: 0;
 }
 
 .version {
-  font-size: 11px;
-  color: var(--color-muted);
+  font-family: var(--font-family-numeric);
+  font-size: var(--font-size-small);
+  font-weight: var(--font-weight-numeric);
+  color: var(--color-text-muted);
 }
 
 .section {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-sm);
   overflow-y: auto;
   flex: 1;
 }
@@ -83,17 +65,17 @@ body {
 .list {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-sm);
 }
 
 .card {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 10px;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
   border: 1px solid var(--color-border);
-  border-radius: 6px;
-  background: var(--color-bg);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
 }
 
 .card > .header {
@@ -130,11 +112,12 @@ body {
   display: inline-flex;
   align-items: center;
   padding: 2px 6px;
-  border-radius: 999px;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--color-accent-fg);
-  background: var(--color-neutral);
+  border-radius: var(--radius-pill);
+  font-family: var(--font-family-numeric);
+  font-size: var(--font-size-small);
+  font-weight: var(--font-weight-numeric);
+  color: var(--color-text-inverse);
+  background: var(--color-state-neutral);
 }
 
 .badge[data-variant='active'] {

--- a/packages/extension/src/presentation/styles/fonts.css
+++ b/packages/extension/src/presentation/styles/fonts.css
@@ -1,0 +1,15 @@
+/*
+ * IMPL-591 Font loading (ui-ux-design.md §3.2)。
+ *
+ * Google Fonts 経由で `IBM Plex Sans JP` (400 / 500 / 600 / 700) と
+ * `Space Grotesk` (500) を読み込む。extension page の CSP は `self` に加えて
+ * `https://fonts.gstatic.com` からの font 取得を許容するため、
+ * `@import` + `font-display: swap` で初期表示のブロックを避ける。
+ *
+ * オフライン・CSP 制約が強化された場合は自己ホスト (fonts/*.woff2) への
+ * 切替を検討する。ui-ux-design.md §3.2 の font stack 自体は tokens.css の
+ * `--font-family-body` / `--font-family-numeric` で system フォント fallback を
+ * 含むため、本ファイルの @import が失敗しても UI 自体は機能する。
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@400;500;600;700&family=Space+Grotesk:wght@500&display=swap');

--- a/packages/extension/src/presentation/styles/tokens.css
+++ b/packages/extension/src/presentation/styles/tokens.css
@@ -1,0 +1,111 @@
+/*
+ * IMPL-590 Design system tokens (ui-ux-design.md §3 準拠)。
+ *
+ * Popup / SidePanel / Monitor / Content script overlay が共通利用する CSS
+ * 変数の単一 source of truth。各 stylesheet は本ファイルを `@import` して
+ * `var(--xxx)` で参照する。
+ *
+ * **CLAUDE.md §React ルール準拠** (単一単語 className、container root):
+ * 本ファイルは class 定義を持たず、tokens (カスタムプロパティ) のみを
+ * 宣言する。実際の style セレクタは popup.css / sidepanel.css / monitor.css
+ * 側で定義し、値は必ず tokens を参照する。
+ */
+
+:root {
+  color-scheme: light;
+
+  /* ---------- Color palette (ui-ux-design.md §3.1) ---------- */
+  --color-primary: #0f766e;
+  --color-primary-fg: #ffffff;
+  --color-secondary: #475569;
+  --color-secondary-fg: #ffffff;
+
+  --color-success: #16a34a;
+  --color-warning: #ea580c;
+  --color-error: #dc2626;
+  --color-error-fg: #ffffff;
+
+  --color-background: #f5f1e8;
+  --color-surface: #ffffff;
+  --color-surface-strong: #0f172a;
+
+  --color-text-primary: #111827;
+  --color-text-inverse: #f8fafc;
+  --color-text-muted: #6b7280;
+
+  --color-border: #e5e7eb;
+  --color-border-strong: #9ca3af;
+
+  /* Session state pill palette (StatusBadge data-variant) */
+  --color-state-active: var(--color-success);
+  --color-state-pending: var(--color-warning);
+  --color-state-degraded: #c2410c;
+  --color-state-error: var(--color-error);
+  --color-state-stopped: #6b7280;
+  --color-state-neutral: #9ca3af;
+
+  /* Legacy alias — 既存 stylesheet からの移行猶予として維持 */
+  --color-accent: var(--color-primary);
+  --color-accent-fg: var(--color-primary-fg);
+  --color-danger: var(--color-error);
+  --color-danger-fg: var(--color-error-fg);
+  --color-muted: var(--color-text-muted);
+  --color-bg: var(--color-surface);
+  --color-text: var(--color-text-primary);
+  --color-active: var(--color-state-active);
+  --color-pending: var(--color-state-pending);
+  --color-degraded: var(--color-state-degraded);
+  --color-stopped: var(--color-state-stopped);
+  --color-neutral: var(--color-state-neutral);
+
+  /* ---------- Typography (ui-ux-design.md §3.2) ---------- */
+  --font-family-body:
+    'IBM Plex Sans JP', system-ui, -apple-system, 'Segoe UI', Roboto, 'Hiragino Sans',
+    'Yu Gothic UI', sans-serif;
+  --font-family-numeric: 'Space Grotesk', 'IBM Plex Sans JP', system-ui, -apple-system, sans-serif;
+
+  --font-size-h1: 28px;
+  --font-size-h2: 22px;
+  --font-size-h3: 18px;
+  --font-size-body: 14px;
+  --font-size-small: 12px;
+
+  --font-weight-body: 400;
+  --font-weight-numeric: 500;
+  --font-weight-h3: 600;
+  --font-weight-heading: 700;
+
+  --line-height-heading: 1.3;
+  --line-height-body: 1.5;
+
+  /* ---------- Spacing (ui-ux-design.md §3.3) ---------- */
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 12px;
+  --space-lg: 16px;
+  --space-xl: 24px;
+  --space-2xl: 32px;
+
+  /* ---------- Radius / elevation ---------- */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-pill: 999px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --color-background: #0b1220;
+    --color-surface: #111827;
+    --color-surface-strong: #1e293b;
+    --color-text-primary: #f5f5f5;
+    --color-text-inverse: #0f172a;
+    --color-text-muted: #94a3b8;
+    --color-border: #1f2937;
+    --color-border-strong: #64748b;
+
+    --color-bg: var(--color-surface);
+    --color-text: var(--color-text-primary);
+    --color-muted: var(--color-text-muted);
+  }
+}

--- a/packages/extension/src/presentation/styles/tokens.test.ts
+++ b/packages/extension/src/presentation/styles/tokens.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const tokensPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), './tokens.css');
+const fontsPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), './fonts.css');
+
+describe('design system tokens.css (IMPL-590)', () => {
+  const tokens = readFileSync(tokensPath, 'utf8');
+
+  it('declares the 10 colors from ui-ux-design.md §3.1', () => {
+    const required = [
+      '--color-primary: #0f766e',
+      '--color-secondary: #475569',
+      '--color-success: #16a34a',
+      '--color-warning: #ea580c',
+      '--color-error: #dc2626',
+      '--color-background: #f5f1e8',
+      '--color-surface: #ffffff',
+      '--color-surface-strong: #0f172a',
+      '--color-text-primary: #111827',
+      '--color-text-inverse: #f8fafc',
+    ];
+    for (const token of required) {
+      expect(tokens).toContain(token);
+    }
+  });
+
+  it('declares the typography scale (h1 / h2 / h3 / body / small)', () => {
+    expect(tokens).toContain('--font-size-h1: 28px');
+    expect(tokens).toContain('--font-size-h2: 22px');
+    expect(tokens).toContain('--font-size-h3: 18px');
+    expect(tokens).toContain('--font-size-body: 14px');
+    expect(tokens).toContain('--font-size-small: 12px');
+  });
+
+  it('declares font families with IBM Plex Sans JP and Space Grotesk', () => {
+    expect(tokens).toContain("'IBM Plex Sans JP'");
+    expect(tokens).toContain("'Space Grotesk'");
+    // system-ui fallback must exist so tokens still resolve when Google Fonts fail
+    expect(tokens).toContain('system-ui');
+  });
+
+  it('declares the 6-step spacing scale (xs / sm / md / lg / xl / 2xl)', () => {
+    expect(tokens).toContain('--space-xs: 4px');
+    expect(tokens).toContain('--space-sm: 8px');
+    expect(tokens).toContain('--space-md: 12px');
+    expect(tokens).toContain('--space-lg: 16px');
+    expect(tokens).toContain('--space-xl: 24px');
+    expect(tokens).toContain('--space-2xl: 32px');
+  });
+
+  it('declares session state palette aliases (StatusBadge data-variant)', () => {
+    expect(tokens).toContain('--color-state-active:');
+    expect(tokens).toContain('--color-state-pending:');
+    expect(tokens).toContain('--color-state-degraded:');
+    expect(tokens).toContain('--color-state-error:');
+    expect(tokens).toContain('--color-state-stopped:');
+    expect(tokens).toContain('--color-state-neutral:');
+  });
+
+  it('preserves legacy aliases for incremental migration', () => {
+    // 既存 stylesheet の移行猶予。すべて削除されたら本 test も除去
+    expect(tokens).toContain('--color-accent:');
+    expect(tokens).toContain('--color-danger:');
+    expect(tokens).toContain('--color-bg:');
+    expect(tokens).toContain('--color-text:');
+  });
+
+  it('applies dark mode via prefers-color-scheme media query', () => {
+    expect(tokens).toMatch(/@media \(prefers-color-scheme: dark\)/);
+  });
+});
+
+describe('design system fonts.css (IMPL-591)', () => {
+  const fonts = readFileSync(fontsPath, 'utf8');
+
+  it('imports IBM Plex Sans JP + Space Grotesk from Google Fonts', () => {
+    expect(fonts).toContain('IBM+Plex+Sans+JP');
+    expect(fonts).toContain('Space+Grotesk');
+    expect(fonts).toContain('display=swap');
+  });
+});


### PR DESCRIPTION
## Summary

roadmap §4 (次) #6 に従い、Popup / SidePanel / Monitor / Content script overlay が共通利用する design system tokens と font loading を導入。ui-ux-design.md §3 のカラーパレット・タイポグラフィ・スペーシング仕様を `:root` CSS 変数として固定し、各 stylesheet から `var(--token-*)` で参照する形に整理する。

### 背景

Popup / SidePanel / Monitor それぞれの stylesheet に palette が重複していた。roadmap の Phase 5 最終 PR として design system tokens を抽出・共有し、以降の atoms refresh や設計仕様変更に耐える基盤とする。

### 変更内容

**新規**:
- `presentation/styles/tokens.css` (IMPL-590) — ui-ux-design.md §3 準拠:
  - カラー 10 色 (Primary `#0F766E` / Secondary `#475569` / Success / Warning / Error / Background / Surface / Surface Strong / Text Primary / Text Inverse)
  - タイポスケール (h1 28 / h2 22 / h3 18 / body 14 / small 12 + weight 400/500/600/700)
  - スペーシング (xs 4 / sm 8 / md 12 / lg 16 / xl 24 / 2xl 32)
  - radius tokens (sm / md / pill) + line-height
  - StatusBadge session state palette (active / pending / degraded / error / stopped / neutral)
  - `@media (prefers-color-scheme: dark)` で dark mode を自動切替
  - 既存 stylesheet 互換のため legacy alias (`--color-accent` / `--color-danger` / `--color-bg` / ...) を残し段階移行

- `presentation/styles/fonts.css` (IMPL-591) — Google Fonts 経由で `IBM Plex Sans JP` (400/500/600/700) + `Space Grotesk` (500) を `@import` (font-display: swap)。tokens 側で system-ui fallback を持つため CSP 制限等で Google Fonts が読めなくても UI は機能する

**差し替え**:
- `entrypoints/popup/popup.css` / `sidepanel.css` / `monitor.css` — `:root` の直接宣言を削除し tokens.css + fonts.css を `@import`、font-family / font-size / color / gap / padding / border-radius を `var(--token-*)` で参照。`.title` / `.badge` / `.version` は設計仕様 (H2/H3 + Numeric / Status 向け `Space Grotesk`) に整合

### 本番実装で Mock / in-memory を使わない原則

- 本 PR はスタイル層のみで adapter / DI 契約は一切変更なし。Background / UseCase 層への影響ゼロ
- font は production default として Google Fonts、test は CSS 内容の static 検証のみ (ネットワーク不要)

## Test plan

- [x] `pnpm fmt:check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — 両 workspace green
- [x] `pnpm --filter @perapera/extension test` — 806 / 806 pass (既存 798 + 新規 8)
  - tokens.test.ts: UI/UX 仕様の 10 色 / 5 段階タイポ / 6 段階スペーシング / dark mode / legacy alias / Google Fonts import 検証
- [x] `pnpm --filter @perapera/relay-api test` — 184 / 184 pass (無影響)
- [x] `pnpm --filter @perapera/extension build` — popup / sidepanel / monitor CSS に tokens + fonts がインラインされ、`.output/chrome-mv3/assets/*.css` が生成される (popup 5.67 KB / sidepanel 5.93 KB / monitor 3.2 KB)

## Out of Scope

- 自己ホストフォント (woff2 バンドル) への切替 (現状 Google Fonts)
- 個別 atom component の内部 className 構造変更 (CSS 側を tokens 参照に揃えるのみ、atom の JSX は変わらず)
- Storybook 導入 (本 PR は vitest snapshot のみ)