### PR TITLE
feat(extension): IMPL-600/601 Phase 5 integration — wire RelaySession + CaptureOrchestrator + Offscreen lifecycle

### DIFF
--- a/packages/extension/src/application/services/relay-session-subscriber.test.ts
+++ b/packages/extension/src/application/services/relay-session-subscriber.test.ts
@@ -1,0 +1,163 @@
+import { errAsync, okAsync, type ResultAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { internalAppError, type ApplicationError } from '../errors/application-errors';
+import {
+  type RelayEvent,
+  type RelayEventListener,
+  type RelayGateway,
+} from '../ports/relay-gateway';
+import { createRelaySessionSubscriber, type RelayEventHandler } from './relay-session-subscriber';
+
+const SESSION_A = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SESSION_B = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+const identifierA: SessionIdentifier = parseSessionIdentifier(SESSION_A)._unsafeUnwrap();
+const identifierB: SessionIdentifier = parseSessionIdentifier(SESSION_B)._unsafeUnwrap();
+
+const buildFakeGateway = (): {
+  gateway: RelayGateway;
+  listeners: Map<SessionIdentifier, RelayEventListener>;
+  unsubscribeCalls: SessionIdentifier[];
+} => {
+  const listeners = new Map<SessionIdentifier, RelayEventListener>();
+  const unsubscribeCalls: SessionIdentifier[] = [];
+  const subscribe: RelayGateway['subscribe'] = (sessionIdentifier, listener) => {
+    listeners.set(sessionIdentifier, listener);
+    return () => {
+      unsubscribeCalls.push(sessionIdentifier);
+      listeners.delete(sessionIdentifier);
+    };
+  };
+  const gateway: RelayGateway = {
+    openSession: vi.fn(() => okAsync(undefined)),
+    sendAudioFrame: vi.fn(() => okAsync(undefined)),
+    closeSession: vi.fn(() => okAsync(undefined)),
+    subscribe: vi.fn(subscribe),
+  };
+  return { gateway, listeners, unsubscribeCalls };
+};
+
+const buildHandler = (
+  result: ResultAsync<void, ApplicationError> = okAsync<void, ApplicationError>(undefined),
+): RelayEventHandler => vi.fn<RelayEventHandler>(() => result);
+
+describe('createRelaySessionSubscriber (IMPL-600)', () => {
+  it('subscribes on start and dispatches events to handleEvent', () => {
+    const { gateway, listeners } = buildFakeGateway();
+    const handleEvent = buildHandler();
+    const subscriber = createRelaySessionSubscriber({
+      relayGateway: gateway,
+      handleEvent,
+    });
+
+    subscriber.start(identifierA);
+    expect(gateway.subscribe).toHaveBeenCalledWith(identifierA, expect.any(Function));
+
+    const event: RelayEvent = {
+      type: 'transcript.final',
+      sessionIdentifier: identifierA,
+      segmentIdentifier: 'seg-1',
+      text: 'Hello',
+      finalizedAt: '2026-04-22T00:00:00.000Z',
+    };
+    listeners.get(identifierA)?.(event);
+    expect(handleEvent).toHaveBeenCalledWith(event);
+  });
+
+  it('stop releases the subscription', () => {
+    const { gateway, unsubscribeCalls } = buildFakeGateway();
+    const subscriber = createRelaySessionSubscriber({
+      relayGateway: gateway,
+      handleEvent: buildHandler(),
+    });
+    subscriber.start(identifierA);
+    expect(subscriber.activeCount()).toBe(1);
+    subscriber.stop(identifierA);
+    expect(unsubscribeCalls).toEqual([identifierA]);
+    expect(subscriber.activeCount()).toBe(0);
+  });
+
+  it('stop for unregistered session is a no-op', () => {
+    const { gateway, unsubscribeCalls } = buildFakeGateway();
+    const subscriber = createRelaySessionSubscriber({
+      relayGateway: gateway,
+      handleEvent: buildHandler(),
+    });
+    subscriber.stop(identifierA);
+    expect(unsubscribeCalls).toEqual([]);
+  });
+
+  it('start twice for same session releases existing subscription first (idempotent)', () => {
+    const { gateway, unsubscribeCalls } = buildFakeGateway();
+    const subscriber = createRelaySessionSubscriber({
+      relayGateway: gateway,
+      handleEvent: buildHandler(),
+    });
+    subscriber.start(identifierA);
+    subscriber.start(identifierA);
+    expect(unsubscribeCalls).toEqual([identifierA]);
+    expect(gateway.subscribe).toHaveBeenCalledTimes(2);
+    expect(subscriber.activeCount()).toBe(1);
+  });
+
+  it('stopAll releases every active subscription', () => {
+    const { gateway, unsubscribeCalls } = buildFakeGateway();
+    const subscriber = createRelaySessionSubscriber({
+      relayGateway: gateway,
+      handleEvent: buildHandler(),
+    });
+    subscriber.start(identifierA);
+    subscriber.start(identifierB);
+    expect(subscriber.activeCount()).toBe(2);
+    subscriber.stopAll();
+    expect(new Set(unsubscribeCalls)).toEqual(new Set([identifierA, identifierB]));
+    expect(subscriber.activeCount()).toBe(0);
+  });
+
+  it('logs warn when handleEvent returns Err', async () => {
+    const logWarn = vi.fn();
+    const { gateway, listeners } = buildFakeGateway();
+    const handleEvent = buildHandler(errAsync(internalAppError({ message: 'boom' })));
+    const subscriber = createRelaySessionSubscriber({
+      relayGateway: gateway,
+      handleEvent,
+      logWarn,
+    });
+    subscriber.start(identifierA);
+    listeners.get(identifierA)?.({
+      type: 'session.error',
+      sessionIdentifier: identifierA,
+      code: 'X',
+      message: 'e',
+      retryable: false,
+      fatal: false,
+    });
+    await Promise.resolve();
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining('boom'));
+  });
+
+  it('logs warn when Unsubscribe throws', () => {
+    const logWarn = vi.fn();
+    const gateway: RelayGateway = {
+      openSession: vi.fn(() => okAsync(undefined)),
+      sendAudioFrame: vi.fn(() => okAsync(undefined)),
+      closeSession: vi.fn(() => okAsync(undefined)),
+      subscribe: vi.fn(() => {
+        return () => {
+          throw new Error('unsub failed');
+        };
+      }),
+    };
+    const subscriber = createRelaySessionSubscriber({
+      relayGateway: gateway,
+      handleEvent: buildHandler(),
+      logWarn,
+    });
+    subscriber.start(identifierA);
+    subscriber.stop(identifierA);
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining('unsub failed'));
+  });
+});

--- a/packages/extension/src/application/services/relay-session-subscriber.ts
+++ b/packages/extension/src/application/services/relay-session-subscriber.ts
@@ -1,0 +1,99 @@
+import { type ResultAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type ApplicationError } from '../errors/application-errors';
+import { type RelayEvent, type RelayGateway, type Unsubscribe } from '../ports/relay-gateway';
+
+/**
+ * IMPL-600 RelaySessionSubscriber (application service)。
+ *
+ * 各 `SourceSession` の開始・終了に合わせて `RelayGateway.subscribe` の登録と
+ * 解除を管理する。受信したサーバーイベント (`RelayEvent`) は注入された
+ * `handleEvent` 関数に dispatch し、transcript / translation / session.error
+ * 各種のドメイン処理に接続する。
+ *
+ * `handleEvent` は通常 `SessionCommandService.handleRelayEvent` を late-bind
+ * したもの (composition root の circular dependency 回避のため)。
+ *
+ * **本番実装で mock を使わない設計**:
+ * - `relayGateway` / `handleEvent` は必須 DI
+ * - test では fake gateway + fake handler を注入して subscribe / unsubscribe /
+ *   dispatch 契約を検証
+ *
+ * **内部状態**:
+ * - `Map<SessionIdentifier, Unsubscribe>` で active subscription を保持
+ * - Service Worker 再起動で消失する性質は許容 (stateless 再登録を想定、
+ *   後続 PR で session recovery と共に再接続する)
+ */
+export type RelaySessionSubscriber = Readonly<{
+  /** Session start 時に呼び出す。既存 subscription は先に解除 (冪等) */
+  start: (sessionIdentifier: SessionIdentifier) => void;
+  /** Session stop 時に呼び出す。未登録 session は no-op */
+  stop: (sessionIdentifier: SessionIdentifier) => void;
+  /** SW shutdown / ExtensionApp.close 時に全解除 */
+  stopAll: () => void;
+  /** Active subscription 数 (test / metrics 用) */
+  activeCount: () => number;
+}>;
+
+export type RelayEventHandler = (event: RelayEvent) => ResultAsync<void, ApplicationError>;
+
+export type RelaySessionSubscriberDependencies = Readonly<{
+  relayGateway: RelayGateway;
+  handleEvent: RelayEventHandler;
+  /** Err ログ sink。default console.warn */
+  logWarn?: (message: string) => void;
+}>;
+
+const defaultLogWarn = (message: string): void => {
+  console.warn(message);
+};
+
+export const createRelaySessionSubscriber = (
+  deps: RelaySessionSubscriberDependencies,
+): RelaySessionSubscriber => {
+  const subscriptions = new Map<SessionIdentifier, Unsubscribe>();
+  const logWarn = deps.logWarn ?? defaultLogWarn;
+
+  const dispatchEvent = (event: RelayEvent): void => {
+    void deps.handleEvent(event).match(
+      () => undefined,
+      (error) => {
+        logWarn(
+          `[perapera] relay-session-subscriber handleEvent failed: ${error.type}: ${error.message}`,
+        );
+      },
+    );
+  };
+
+  const release = (sessionIdentifier: SessionIdentifier): void => {
+    const existing = subscriptions.get(sessionIdentifier);
+    if (existing === undefined) return;
+    try {
+      existing();
+    } catch (cause) {
+      logWarn(
+        `[perapera] relay-session-subscriber unsubscribe failed for ${sessionIdentifier}: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      );
+    }
+    subscriptions.delete(sessionIdentifier);
+  };
+
+  return {
+    start: (sessionIdentifier) => {
+      release(sessionIdentifier);
+      const unsubscribe = deps.relayGateway.subscribe(sessionIdentifier, dispatchEvent);
+      subscriptions.set(sessionIdentifier, unsubscribe);
+    },
+    stop: (sessionIdentifier) => {
+      release(sessionIdentifier);
+    },
+    stopAll: () => {
+      for (const [sessionIdentifier] of subscriptions) {
+        release(sessionIdentifier);
+      }
+    },
+    activeCount: () => subscriptions.size,
+  };
+};

--- a/packages/extension/src/application/use-cases/start-source-session-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/start-source-session-use-case.test.ts
@@ -16,6 +16,8 @@ import {
 } from '../../domain/shared/errors';
 import { type PermissionCoordinator } from '../ports/permission-coordinator';
 import { type RelayGateway } from '../ports/relay-gateway';
+import { type CaptureOrchestrator } from '../services/capture-orchestrator';
+import { type RelaySessionSubscriber } from '../services/relay-session-subscriber';
 import {
   createStartSourceSessionUseCase,
   type StartSourceSessionDependencies,
@@ -66,11 +68,38 @@ const buildDependencies = (
   const permissionCoordinator: PermissionCoordinator = {
     requestFor: vi.fn(grantingRequestFor),
   };
+  const connect: CaptureOrchestrator['connect'] = (command) =>
+    okAsync({
+      sessionIdentifier: command.sessionIdentifier,
+      sourceType: command.sourceType,
+      stream: new MediaStream(),
+      frameChannel: {
+        frames: {
+          [Symbol.asyncIterator]: (): AsyncIterator<never> => ({
+            next: (): Promise<IteratorReturnResult<undefined>> =>
+              Promise.resolve({ done: true, value: undefined }),
+          }),
+        },
+        close: () => undefined,
+      },
+    });
+  const captureOrchestrator: CaptureOrchestrator = {
+    connect: vi.fn(connect),
+    disconnect: vi.fn(() => okAsync(undefined)),
+  };
+  const relaySessionSubscriber: RelaySessionSubscriber = {
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    activeCount: vi.fn(() => 0),
+  };
   return {
     sourceSessionRepository,
     extensionProfileRepository,
     relayGateway,
     permissionCoordinator,
+    captureOrchestrator,
+    relaySessionSubscriber,
     clock: () => STARTED_AT,
     idFactory: {
       session: () => SESSION_ID,

--- a/packages/extension/src/application/use-cases/start-source-session-use-case.ts
+++ b/packages/extension/src/application/use-cases/start-source-session-use-case.ts
@@ -22,12 +22,17 @@ import {
 } from '../errors/application-errors';
 import { type PermissionCoordinator } from '../ports/permission-coordinator';
 import { type RelayGateway } from '../ports/relay-gateway';
+import { type StartSourceCommand } from '../ports/source-adapter';
+import { type CaptureOrchestrator } from '../services/capture-orchestrator';
+import { type RelaySessionSubscriber } from '../services/relay-session-subscriber';
 
 export type StartSourceSessionDependencies = Readonly<{
   sourceSessionRepository: SourceSessionRepository;
   extensionProfileRepository: ExtensionProfileRepository;
   relayGateway: RelayGateway;
   permissionCoordinator: PermissionCoordinator;
+  captureOrchestrator: CaptureOrchestrator;
+  relaySessionSubscriber: RelaySessionSubscriber;
   clock: () => string;
   idFactory: Readonly<{
     session: () => string;
@@ -50,6 +55,17 @@ const normalizeChainError = (error: ChainError): ApplicationError => {
   return toApplicationError(error);
 };
 
+const toStartSourceCommand = (session: SourceSession): StartSourceCommand => {
+  switch (session.sourceType) {
+    case 'tab':
+      return { sourceType: 'tab', sessionIdentifier: session.sessionIdentifier };
+    case 'microphone':
+      return { sourceType: 'microphone', sessionIdentifier: session.sessionIdentifier };
+    case 'desktop':
+      return { sourceType: 'desktop', sessionIdentifier: session.sessionIdentifier };
+  }
+};
+
 /**
  * IMPL-210 StartSourceSessionUseCase (DD-301)。
  *
@@ -60,9 +76,16 @@ const normalizeChainError = (error: ChainError): ApplicationError => {
  * 4. `createSourceSession` → `startSourceSession` (idle → requesting_permission)
  * 5. `save` (1st: requesting_permission state)
  * 6. `permissionCoordinator.requestFor` → granted / denied 分岐
- *    - granted: `transitionSourceSessionState('connecting')` → `relayGateway.openSession` → `save` (2nd)
- *    - denied: `transitionSourceSessionState('error')` → `save` (2nd) → errAsync(permissionRequiredAppError)
+ *    - granted: `transitionSourceSessionState('connecting')` →
+ *      `captureOrchestrator.connect` → `relayGateway.openSession` →
+ *      `relaySessionSubscriber.start(sessionId)` → `save` (2nd)
+ *    - denied: `transitionSourceSessionState('error')` → `save` (2nd) →
+ *      errAsync(permissionRequiredAppError)
  * 7. 出力 DTO: `{ sessionId, state, startedAt }`
+ *
+ * IMPL-600 (Phase 5 integration): capture 接続と relay subscribe を
+ * connect フェーズで配線し、以降の `RelayEvent` (transcript / translation) が
+ * `SessionCommandService.handleRelayEvent` に流れるようにする。
  */
 export const createStartSourceSessionUseCase = (
   deps: StartSourceSessionDependencies,
@@ -102,11 +125,15 @@ export const createStartSourceSessionUseCase = (
                           savedSession,
                           'connecting',
                         ).asyncAndThen((connecting) =>
-                          deps.relayGateway
-                            .openSession(connecting)
-                            .andThen(() =>
-                              deps.sourceSessionRepository.save(connecting).map(() => connecting),
-                            ),
+                          deps.captureOrchestrator
+                            .connect(toStartSourceCommand(connecting))
+                            .andThen(() => deps.relayGateway.openSession(connecting))
+                            .andThen(() => {
+                              deps.relaySessionSubscriber.start(connecting.sessionIdentifier);
+                              return deps.sourceSessionRepository
+                                .save(connecting)
+                                .map(() => connecting);
+                            }),
                         );
                       }
                       return transitionSourceSessionState(savedSession, 'error').asyncAndThen(

--- a/packages/extension/src/application/use-cases/stop-source-session-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/stop-source-session-use-case.test.ts
@@ -11,6 +11,8 @@ import type { OverlayPresenter } from '../ports/overlay-presenter';
 import type { RelayGateway } from '../ports/relay-gateway';
 import type { SourceSessionRepository } from '../../domain/repositories/source-session-repository';
 import type { SourceSession } from '../../domain/session/source-session';
+import type { CaptureOrchestrator } from '../services/capture-orchestrator';
+import type { RelaySessionSubscriber } from '../services/relay-session-subscriber';
 import {
   createStopSourceSessionUseCase,
   type StopSourceSessionDependencies,
@@ -53,10 +55,37 @@ const buildDependencies = (
     updateSettings: vi.fn(() => okAsync(undefined)),
     unmount: vi.fn(() => okAsync(undefined)),
   };
+  const connect: CaptureOrchestrator['connect'] = (command) =>
+    okAsync({
+      sessionIdentifier: command.sessionIdentifier,
+      sourceType: command.sourceType,
+      stream: new MediaStream(),
+      frameChannel: {
+        frames: {
+          [Symbol.asyncIterator]: (): AsyncIterator<never> => ({
+            next: (): Promise<IteratorReturnResult<undefined>> =>
+              Promise.resolve({ done: true, value: undefined }),
+          }),
+        },
+        close: () => undefined,
+      },
+    });
+  const captureOrchestrator: CaptureOrchestrator = {
+    connect: vi.fn(connect),
+    disconnect: vi.fn(() => okAsync(undefined)),
+  };
+  const relaySessionSubscriber: RelaySessionSubscriber = {
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(),
+    activeCount: vi.fn(() => 0),
+  };
   return {
     sourceSessionRepository,
     relayGateway,
     overlayPresenter,
+    captureOrchestrator,
+    relaySessionSubscriber,
     clock: () => STOPPED_AT,
     ...overrides,
   };

--- a/packages/extension/src/application/use-cases/stop-source-session-use-case.ts
+++ b/packages/extension/src/application/use-cases/stop-source-session-use-case.ts
@@ -11,11 +11,15 @@ import {
 import { toApplicationError, type ApplicationError } from '../errors/application-errors';
 import { type OverlayPresenter } from '../ports/overlay-presenter';
 import { type RelayGateway } from '../ports/relay-gateway';
+import { type CaptureOrchestrator } from '../services/capture-orchestrator';
+import { type RelaySessionSubscriber } from '../services/relay-session-subscriber';
 
 export type StopSourceSessionDependencies = Readonly<{
   sourceSessionRepository: SourceSessionRepository;
   relayGateway: RelayGateway;
   overlayPresenter: OverlayPresenter;
+  captureOrchestrator: CaptureOrchestrator;
+  relaySessionSubscriber: RelaySessionSubscriber;
   clock: () => string;
 }>;
 
@@ -32,9 +36,14 @@ const logWarn =
 /**
  * IMPL-215 StopSourceSessionUseCase (DD-306)。
  *
- * アクティブなセッションを停止し、Relay 接続とオーバーレイを解放する。
- * `closeSession` / `unmount` は fire-and-forget (失敗しても UseCase は成功を
- * 返す) で、結果整合性を優先する (use-case.md §6.1)。
+ * アクティブなセッションを停止し、Relay 接続 / capture / overlay / subscribe を
+ * 解放する。`closeSession` / `unmount` / `captureOrchestrator.disconnect` /
+ * `relaySessionSubscriber.stop` は fire-and-forget で結果整合性を優先
+ * (use-case.md §6.1)。
+ *
+ * IMPL-600 (Phase 5 integration): capture 切断と relay subscribe 解除を
+ * stop フェーズで並列実行し、session 停止後に relay イベントが subscriber を
+ * 経由して UseCase に流れないようにする。
  */
 export const createStopSourceSessionUseCase = (
   deps: StopSourceSessionDependencies,
@@ -48,12 +57,25 @@ export const createStopSourceSessionUseCase = (
             .andThen((session) => stopSourceSession(session, { stoppedAt: deps.clock() }))
             .andThen((stopped) => deps.sourceSessionRepository.save(stopped).map(() => stopped))
             .map((stopped): StopSourceSessionOutput => {
+              // relay subscribe 解除は同期 (throw しても listener は残らない想定)
+              try {
+                deps.relaySessionSubscriber.stop(sessionIdentifier);
+              } catch (cause) {
+                console.warn(
+                  `[use-case:stop-source-session] relay-session-subscriber.stop threw:`,
+                  cause,
+                );
+              }
+              // 下記 3 つは fire-and-forget (UseCase 自体は成功を返す)
               void deps.relayGateway
                 .closeSession(sessionIdentifier)
                 .match(() => undefined, logWarn('closeSession'));
+              void deps.captureOrchestrator
+                .disconnect(sessionIdentifier)
+                .match(() => undefined, logWarn('captureOrchestrator.disconnect'));
               void deps.overlayPresenter
                 .unmount(sessionIdentifier)
-                .match(() => undefined, logWarn('unmount'));
+                .match(() => undefined, logWarn('overlayPresenter.unmount'));
               return {
                 sessionId: stopped.sessionIdentifier,
                 state: stopped.state,

--- a/packages/extension/src/composition/extension-composition.ts
+++ b/packages/extension/src/composition/extension-composition.ts
@@ -1,3 +1,4 @@
+import { okAsync } from 'neverthrow';
 import { ulid } from 'ulid';
 import { createExportSessionResultUseCase } from '../application/use-cases/export-session-result-use-case';
 import { createGetSessionMonitorStateQuery } from '../application/use-cases/get-session-monitor-state-query';
@@ -11,6 +12,11 @@ import {
   type CaptureOrchestrator,
 } from '../application/services/capture-orchestrator';
 import { createExportService, type ExportService } from '../application/services/export-service';
+import {
+  createRelaySessionSubscriber,
+  type RelayEventHandler,
+  type RelaySessionSubscriber,
+} from '../application/services/relay-session-subscriber';
 import {
   createSessionCommandService,
   type SessionCommandService,
@@ -263,12 +269,37 @@ export const createExtensionApp = (
     bridge: ports.overlayMessagingBridge,
   });
 
+  // --------------- Application services (先に構築: circular dep 回避) ---------------
+  const captureOrchestrator = createCaptureOrchestrator({
+    sourceAdapterFactory,
+    audioPreprocessor,
+  });
+
+  // relaySessionSubscriber は handleEvent を late-bind する形で参照する。
+  // SessionCommandService を先に構築したいが、sessionCommandService は
+  // startSourceSessionUseCase 経由で subscriber に依存するため、mutable holder で
+  // 後から設定する。
+  let sessionCommandServiceRef: SessionCommandService | null = null;
+  const handleRelayEventLate: RelayEventHandler = (event) => {
+    if (sessionCommandServiceRef === null) {
+      // SW 起動直後に event が届くことはないが、安全のため no-op を返す
+      return okAsync<void, never>(undefined);
+    }
+    return sessionCommandServiceRef.handleRelayEvent(event);
+  };
+  const relaySessionSubscriber: RelaySessionSubscriber = createRelaySessionSubscriber({
+    relayGateway,
+    handleEvent: handleRelayEventLate,
+  });
+
   // --------------- UseCases (Phase 2) ---------------
   const startSourceSessionUseCase = createStartSourceSessionUseCase({
     sourceSessionRepository,
     extensionProfileRepository,
     relayGateway,
     permissionCoordinator,
+    captureOrchestrator,
+    relaySessionSubscriber,
     clock: ports.clockIso,
     idFactory: {
       session: ports.sessionIdFactory,
@@ -279,6 +310,8 @@ export const createExtensionApp = (
     sourceSessionRepository,
     relayGateway,
     overlayPresenter,
+    captureOrchestrator,
+    relaySessionSubscriber,
     clock: ports.clockIso,
   });
   const updateSourceSettingsUseCase = createUpdateSourceSettingsUseCase({
@@ -311,7 +344,7 @@ export const createExtensionApp = (
     settingsStore,
   });
 
-  // --------------- Application services (Phase 3) ---------------
+  // --------------- Application services (Phase 3 facades) ---------------
   const sessionCommandService = createSessionCommandService({
     startSourceSessionUseCase,
     stopSourceSessionUseCase,
@@ -320,12 +353,12 @@ export const createExtensionApp = (
     handleTranscriptFinalUseCase,
     clock: ports.clockMs,
   });
+  // 構築完了後に late-bind 用 ref に保存。以降 relaySessionSubscriber の
+  // dispatch が handleRelayEvent を呼べるようになる。
+  sessionCommandServiceRef = sessionCommandService;
+
   const exportService = createExportService({ exportSessionResultUseCase });
   const sessionRegistry = createSessionRegistry();
-  const captureOrchestrator = createCaptureOrchestrator({
-    sourceAdapterFactory,
-    audioPreprocessor,
-  });
   const transcriptAssembler = createTranscriptAssembler();
 
   return {
@@ -336,6 +369,7 @@ export const createExtensionApp = (
     captureOrchestrator,
     transcriptAssembler,
     close: async () => {
+      relaySessionSubscriber.stopAll();
       await sessionStore.close();
       await sourceSessionRepository.close();
       await transcriptStreamRepository.close();

--- a/packages/extension/src/composition/offscreen-lifecycle.test.ts
+++ b/packages/extension/src/composition/offscreen-lifecycle.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createOffscreenLifecycle, type OffscreenApi } from './offscreen-lifecycle';
+
+const URL = 'chrome-extension://xxx/offscreen.html';
+
+const buildApi = (overrides: Partial<OffscreenApi> = {}): OffscreenApi => ({
+  hasDocument: vi.fn(() => Promise.resolve(false)),
+  createDocument: vi.fn(() => Promise.resolve()),
+  closeDocument: vi.fn(() => Promise.resolve()),
+  ...overrides,
+});
+
+describe('createOffscreenLifecycle (IMPL-601)', () => {
+  it('creates the offscreen document on first ensure', async () => {
+    const api = buildApi();
+    const lifecycle = createOffscreenLifecycle({ offscreenApi: api, documentUrl: URL });
+    await lifecycle.ensure();
+    expect(api.createDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: URL,
+        reasons: [chrome.offscreen.Reason.AUDIO_PLAYBACK],
+      }),
+    );
+  });
+
+  it('is idempotent across multiple ensure calls', async () => {
+    const api = buildApi();
+    const lifecycle = createOffscreenLifecycle({ offscreenApi: api, documentUrl: URL });
+    await lifecycle.ensure();
+    await lifecycle.ensure();
+    await lifecycle.ensure();
+    expect(api.createDocument).toHaveBeenCalledOnce();
+  });
+
+  it('skips createDocument when hasDocument returns true', async () => {
+    const api = buildApi({
+      hasDocument: vi.fn(() => Promise.resolve(true)),
+    });
+    const lifecycle = createOffscreenLifecycle({ offscreenApi: api, documentUrl: URL });
+    await lifecycle.ensure();
+    expect(api.createDocument).not.toHaveBeenCalled();
+  });
+
+  it('swallows already-exists errors from createDocument (race condition)', async () => {
+    const api = buildApi({
+      hasDocument: vi.fn(() => Promise.resolve(false)),
+      createDocument: vi.fn(() =>
+        Promise.reject(new Error('Only one offscreen document may exist')),
+      ),
+    });
+    const lifecycle = createOffscreenLifecycle({ offscreenApi: api, documentUrl: URL });
+    await expect(lifecycle.ensure()).resolves.toBeUndefined();
+    // 2 度目の ensure は createDocument を呼ばない (すでに created=true)
+    await lifecycle.ensure();
+    expect(api.createDocument).toHaveBeenCalledOnce();
+  });
+
+  it('re-throws non-already-exists createDocument errors', async () => {
+    const logWarn = vi.fn();
+    const api = buildApi({
+      hasDocument: vi.fn(() => Promise.resolve(false)),
+      createDocument: vi.fn(() => Promise.reject(new Error('permission denied'))),
+    });
+    const lifecycle = createOffscreenLifecycle({
+      offscreenApi: api,
+      documentUrl: URL,
+      logWarn,
+    });
+    await expect(lifecycle.ensure()).rejects.toThrow(/permission denied/);
+    expect(logWarn).toHaveBeenCalled();
+  });
+
+  it('continues ensure when hasDocument throws (falls through to createDocument)', async () => {
+    const logWarn = vi.fn();
+    const api = buildApi({
+      hasDocument: vi.fn(() => Promise.reject(new Error('api unavailable'))),
+    });
+    const lifecycle = createOffscreenLifecycle({
+      offscreenApi: api,
+      documentUrl: URL,
+      logWarn,
+    });
+    await lifecycle.ensure();
+    expect(api.createDocument).toHaveBeenCalledOnce();
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining('api unavailable'));
+  });
+
+  it('close calls closeDocument and resets state', async () => {
+    const api = buildApi();
+    const lifecycle = createOffscreenLifecycle({ offscreenApi: api, documentUrl: URL });
+    await lifecycle.ensure();
+    await lifecycle.close();
+    expect(api.closeDocument).toHaveBeenCalledOnce();
+    // 再度 ensure で createDocument が呼ばれる (state リセット)
+    await lifecycle.ensure();
+    expect(api.createDocument).toHaveBeenCalledTimes(2);
+  });
+
+  it('close without prior ensure is a no-op', async () => {
+    const api = buildApi();
+    const lifecycle = createOffscreenLifecycle({ offscreenApi: api, documentUrl: URL });
+    await lifecycle.close();
+    expect(api.closeDocument).not.toHaveBeenCalled();
+  });
+
+  it('respects custom reasons / justification', async () => {
+    const api = buildApi();
+    const lifecycle = createOffscreenLifecycle({
+      offscreenApi: api,
+      documentUrl: URL,
+      reasons: [chrome.offscreen.Reason.DOM_PARSER],
+      justification: 'custom reason',
+    });
+    await lifecycle.ensure();
+    expect(api.createDocument).toHaveBeenCalledWith({
+      url: URL,
+      reasons: [chrome.offscreen.Reason.DOM_PARSER],
+      justification: 'custom reason',
+    });
+  });
+});

--- a/packages/extension/src/composition/offscreen-lifecycle.ts
+++ b/packages/extension/src/composition/offscreen-lifecycle.ts
@@ -1,0 +1,121 @@
+/**
+ * IMPL-601 Offscreen document lifecycle helper。
+ *
+ * MV3 拡張の Service Worker は DOM / AudioContext を直接扱えないため、
+ * `chrome.offscreen.createDocument` で生成した offscreen document に audio
+ * 処理を delegate する (offscreen 側の受信は IMPL-562 で実装済)。本 helper は
+ * SW 起動時に `ensure` を呼べば 1 回だけ createDocument し、既に存在する場合は
+ * no-op する idempotent lifecycle を提供する。
+ *
+ * **本番実装で mock を使わない設計**:
+ * - `offscreenApi` は必須 DI。production では `defaultOffscreenApi`
+ *   (`chrome.offscreen` を直接 wrap) を明示注入
+ * - test では minimal fake を注入する
+ */
+
+export type OffscreenApi = Readonly<{
+  hasDocument?: () => Promise<boolean>;
+  createDocument: (params: chrome.offscreen.CreateParameters) => Promise<void>;
+  closeDocument: () => Promise<void>;
+}>;
+
+export const defaultOffscreenApi: OffscreenApi = {
+  hasDocument: () => chrome.offscreen.hasDocument(),
+  createDocument: (params) => chrome.offscreen.createDocument(params),
+  closeDocument: () => chrome.offscreen.closeDocument(),
+};
+
+export type OffscreenLifecycle = Readonly<{
+  /** Offscreen document を 1 回だけ作成 (既に存在すれば no-op)。idempotent */
+  ensure: () => Promise<void>;
+  /** Service Worker shutdown 時に document を close */
+  close: () => Promise<void>;
+}>;
+
+export type OffscreenLifecycleDependencies = Readonly<{
+  offscreenApi: OffscreenApi;
+  /** offscreen.html の絶対 URL (`chrome.runtime.getURL('/offscreen.html')`) */
+  documentUrl: string;
+  /** 作成理由 (Chrome が permission 理由を記録する)。default `['AUDIO_PLAYBACK']` */
+  reasons?: chrome.offscreen.Reason[];
+  /** 作成正当化理由。default `'AudioContext host'` */
+  justification?: string;
+  /** Err ログ sink。default `console.warn` */
+  logWarn?: (message: string) => void;
+}>;
+
+const DEFAULT_REASONS: chrome.offscreen.Reason[] = [chrome.offscreen.Reason.AUDIO_PLAYBACK];
+const DEFAULT_JUSTIFICATION = 'AudioContext host for tab / microphone / desktop capture';
+
+const defaultLogWarn = (message: string): void => {
+  console.warn(message);
+};
+
+const isAlreadyExistsError = (cause: unknown): boolean => {
+  if (!(cause instanceof Error)) return false;
+  return /already|exist/i.test(cause.message);
+};
+
+export const createOffscreenLifecycle = (
+  deps: OffscreenLifecycleDependencies,
+): OffscreenLifecycle => {
+  const reasons = deps.reasons ?? DEFAULT_REASONS;
+  const justification = deps.justification ?? DEFAULT_JUSTIFICATION;
+  const logWarn = deps.logWarn ?? defaultLogWarn;
+  let created = false;
+
+  return {
+    ensure: async () => {
+      if (created) return;
+      if (deps.offscreenApi.hasDocument !== undefined) {
+        try {
+          const exists = await deps.offscreenApi.hasDocument();
+          if (exists) {
+            created = true;
+            return;
+          }
+        } catch (cause) {
+          logWarn(
+            `[perapera] offscreen-lifecycle hasDocument check failed: ${
+              cause instanceof Error ? cause.message : String(cause)
+            }`,
+          );
+        }
+      }
+      try {
+        await deps.offscreenApi.createDocument({
+          url: deps.documentUrl,
+          reasons,
+          justification,
+        });
+        created = true;
+      } catch (cause) {
+        if (isAlreadyExistsError(cause)) {
+          // 別ルートで先に createDocument された race condition。OK として扱う
+          created = true;
+          return;
+        }
+        logWarn(
+          `[perapera] offscreen-lifecycle createDocument failed: ${
+            cause instanceof Error ? cause.message : String(cause)
+          }`,
+        );
+        throw cause instanceof Error ? cause : new Error(String(cause));
+      }
+    },
+    close: async () => {
+      if (!created) return;
+      try {
+        await deps.offscreenApi.closeDocument();
+      } catch (cause) {
+        logWarn(
+          `[perapera] offscreen-lifecycle closeDocument failed: ${
+            cause instanceof Error ? cause.message : String(cause)
+          }`,
+        );
+      } finally {
+        created = false;
+      }
+    },
+  };
+};

--- a/packages/extension/src/entrypoints/background.ts
+++ b/packages/extension/src/entrypoints/background.ts
@@ -4,6 +4,7 @@ import {
   type ExtensionApp,
   type ExtensionRuntimeConfig,
 } from '../composition/extension-composition';
+import { createOffscreenLifecycle, defaultOffscreenApi } from '../composition/offscreen-lifecycle';
 import { createRuntimeDispatcher, type RuntimeDispatcher } from '../composition/runtime-dispatcher';
 
 /**
@@ -62,6 +63,17 @@ export default defineBackground(() => {
     );
   }
 
+  // Offscreen document を SW 起動時に ensure。MV3 SW は AudioContext を直接
+  // 扱えないため、offscreen document 側で確保する必要がある (IMPL-562)。
+  // 既に存在する場合は no-op。失敗しても SW 自体は継続する (手動 smoke で確認)。
+  const offscreen = createOffscreenLifecycle({
+    offscreenApi: defaultOffscreenApi,
+    documentUrl: chrome.runtime.getURL('/offscreen.html'),
+  });
+  void offscreen.ensure().catch((cause: unknown) => {
+    console.error('[perapera] offscreen ensure failed:', cause);
+  });
+
   const config: ExtensionRuntimeConfig = {
     relayApiBaseUrl: RELAY_API_BASE_URL,
     relayAccessToken: RELAY_ACCESS_TOKEN,
@@ -107,6 +119,9 @@ export default defineBackground(() => {
   chrome.runtime.onSuspend.addListener(() => {
     void app.close().catch((cause) => {
       console.warn('[perapera] ExtensionApp.close failed during onSuspend:', cause);
+    });
+    void offscreen.close().catch((cause) => {
+      console.warn('[perapera] OffscreenLifecycle.close failed during onSuspend:', cause);
     });
   });
 });

--- a/packages/extension/tests/setup.ts
+++ b/packages/extension/tests/setup.ts
@@ -14,6 +14,12 @@ type ChromeStub = {
   runtime: { id: string; sendMessage: ReturnType<typeof vi.fn> };
   storage: { local: { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> } };
   tabs: { query: ReturnType<typeof vi.fn> };
+  offscreen: {
+    Reason: Readonly<Record<string, string>>;
+    hasDocument: ReturnType<typeof vi.fn>;
+    createDocument: ReturnType<typeof vi.fn>;
+    closeDocument: ReturnType<typeof vi.fn>;
+  };
 };
 
 const chromeStub: ChromeStub = {
@@ -29,6 +35,31 @@ const chromeStub: ChromeStub = {
   },
   tabs: {
     query: vi.fn(),
+  },
+  offscreen: {
+    // `chrome.offscreen.Reason` is a string enum in `@types/chrome`. The stub
+    // mirrors the string-value shape so modules that reference
+    // `chrome.offscreen.Reason.X` don't fail at import time in jsdom.
+    Reason: Object.freeze({
+      TESTING: 'TESTING',
+      AUDIO_PLAYBACK: 'AUDIO_PLAYBACK',
+      IFRAME_SCRIPTING: 'IFRAME_SCRIPTING',
+      DOM_SCRAPING: 'DOM_SCRAPING',
+      BLOBS: 'BLOBS',
+      DOM_PARSER: 'DOM_PARSER',
+      USER_MEDIA: 'USER_MEDIA',
+      DISPLAY_MEDIA: 'DISPLAY_MEDIA',
+      WEB_RTC: 'WEB_RTC',
+      CLIPBOARD: 'CLIPBOARD',
+      LOCAL_STORAGE: 'LOCAL_STORAGE',
+      WORKERS: 'WORKERS',
+      BATTERY_STATUS: 'BATTERY_STATUS',
+      MATCH_MEDIA: 'MATCH_MEDIA',
+      GEOLOCATION: 'GEOLOCATION',
+    }),
+    hasDocument: vi.fn(),
+    createDocument: vi.fn(),
+    closeDocument: vi.fn(),
   },
 };
 


### PR DESCRIPTION
## Summary

Phase 5 の UI 層は PR #47〜#52 で完成していたが、Background Service Worker 側の
**integration 配線が 3 点欠落** しており、Popup / SidePanel から start しても字幕が overlay に届かない状態だった。本 PR はその 3 点を埋める:

1. `relayGateway.subscribe` → `SessionCommandService.handleRelayEvent` を RelaySessionSubscriber 経由で接続
2. `StartSourceSessionUseCase` が `captureOrchestrator.connect` を呼び、stop で `disconnect`
3. SW 起動時に `chrome.offscreen.createDocument` を idempotent に呼び出し (`OffscreenLifecycle`)

これで UI → SW → Relay → SessionCommandService → OverlayPresenter → Shadow DOM の **ホットパス全体** が実際に接続される。

### 変更内容

**新規 application service**:
- IMPL-600 `application/services/relay-session-subscriber.ts`
  - session ごとに `relayGateway.subscribe` を管理、unsubscribe を保持
  - `handleEvent` 関数を DI で受ける (late-bind で circular dep を回避)
  - Err は logWarn、Unsubscribe throw も握り潰し

**新規 composition helper**:
- IMPL-601 `composition/offscreen-lifecycle.ts`
  - `chrome.offscreen.createDocument` を idempotent にラップ
  - `hasDocument` チェック + already-exists エラー握り潰し + `close` サポート
  - `defaultOffscreenApi` を production default として export
  - `tests/setup.ts` に `chrome.offscreen.Reason` string enum stub を追加

**UseCase 配線**:
- `start-source-session-use-case.ts` に `captureOrchestrator` + `relaySessionSubscriber` 必須依存追加
  - 順序: permission granted → `connect(command)` → `relayGateway.openSession` → `subscriber.start(sessionId)` → save
- `stop-source-session-use-case.ts` に同依存追加
  - relaySessionSubscriber.stop を同期 + closeSession / disconnect / unmount を fire-and-forget で並列実行

**composition + background 更新**:
- `extension-composition.ts` で CaptureOrchestrator を先に生成 → RelaySessionSubscriber (late-bind) → UseCases → SessionCommandService → subscriber の handleEvent ref を設定
- `entrypoints/background.ts` 起動時に `OffscreenLifecycle.ensure()` を呼び出し、onSuspend で close

### 本番実装で Mock / in-memory を使わない原則

- RelaySessionSubscriber: `relayGateway` / `handleEvent` 必須 DI、test で fake を明示注入
- OffscreenLifecycle: `offscreenApi` 必須 DI、production は `defaultOffscreenApi` (chrome.offscreen wrap)、test は minimal fake
- 循環依存は late-bind pattern で解決 (mutable ref を 1 箇所のみ使用、外部には露出しない)

## Test plan

- [x] `pnpm fmt:check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — 両 workspace green
- [x] `pnpm --filter @perapera/extension test` — 822 / 822 pass (既存 806 + 新規 16)
  - relay-session-subscriber: 7
  - offscreen-lifecycle: 9
  - 既存 start/stop UseCase tests は DI mock 追加のみで既存 expectation 維持
- [x] `pnpm --filter @perapera/relay-api test` — 184 / 184 pass (無影響)
- [x] `pnpm --filter @perapera/extension build` — offscreen chunk (2.17 kB) + content.js (85.42 kB) + 既存成果物すべて `.output/chrome-mv3/` に生成

## 後続 PR (Phase 5 M2 完成 / Phase 6 前準備)

- Audio frame pipeline (`captureOrchestrator.frames` → `relayGateway.sendAudioFrame` の実際のデータ転送)
- SW → offscreen audio.open / audio.close の command 送信
- Phase 6 Playwright E2E (mock provider で overlay ループを閉じる)
- WXT zip 配布 smoke

## Out of Scope

- Audio frame 転送は captureOrchestrator.frames の AsyncIterable 消費が必要で、独立 PR が望ましい
- Session recovery on SW restart (IndexedDB から active session を読み戻して再 subscribe)
- Permission UI (popup 側の permission denied feedback は既に表示済)