### PR TITLE
feat(extension): IMPL-603 orphan session cleanup on SW restart (stopped transition)

### DIFF
--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.4.0'
+version: '0.4.1'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -228,9 +228,9 @@ PR #45 で domain repository adapter が揃ったため、Background composition
 
 **Phase 5 残タスク (§4 PR 次 #7〜#10)**:
 
-- [ ] IMPL-602 Audio frame pipeline: `captureOrchestrator.frames` → `relayGateway.sendAudioFrame` (本 PR)
-- [ ] SW → Offscreen audio.open / audio.close コマンド送信
-- [ ] Session recovery on SW restart
+- [x] IMPL-602 Audio frame pipeline: `captureOrchestrator.frames` → `relayGateway.sendAudioFrame` (PR #54)
+- [x] IMPL-603 Orphan session cleanup on SW restart: `stopSourceSession` で全 active を stopped 化 (本 PR)
+- [ ] SW → Offscreen audio.open / audio.close コマンド送信 (AudioWorklet + offscreen preprocessor と同時)
 - [ ] WXT zip 配布 smoke (Chrome Web Store 提出前提)
 
 依存: Phase 4 の Relay API が develop 上で動作中 (完了)、Phase 3 infrastructure adapter および Phase 3.5 repository adapter が揃っている (完了)。
@@ -273,7 +273,7 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 - [x] `session.stop` / `session.pause` / `session.resume` の server 側振る舞い — PR #43 (IMPL-421/422) で確定。pause/resume は debug log 留め、stop は stream handle close
 - [x] Provider サーキットブレーカー発火時のエラー設計 — PR #41 (IMPL-446) で `invariantViolationError` を `session.error` envelope に変換
 - [x] Phase 5 開始時の chrome.runtime messaging schema — PR #47 の `runtime-messages.ts` (Zod discriminated union) で Command / Query / Offscreen 各 schema を確定
-- [ ] Background 多重起動時のセッション継続 — PR #53 で `RelaySessionSubscriber` / `OffscreenLifecycle` を整備したが、SW 再起動時の active session 復元は未実装。§4 PR 次 #9 (Session recovery) で確定
+- [x] Background 多重起動時のセッション継続 — **復元は行わず orphan session を `stopped` 状態に遷移** (IMPL-603)。MV3 の permission / capture 制約により full restore は user gesture が必要で MVP 外。ユーザーは Popup から新規 session 開始
 - [ ] AudioWorklet を offscreen document にホストする際の chrome.tabCapture との連携方式 — MVP は SW 側で `AudioPreprocessor` stub (empty frame channel) を保持。実 AudioWorklet + offscreen ホスト化は Phase 5 後続 PR で決定
 - [ ] Audio frame 送信失敗時の永続キュー / retry 設計 — 本 PR (IMPL-602) は 1 回 warn + skip。AudioWorklet 実装後の計測結果で再評価
 - [ ] DB v2 schema migration の必要性 — MVP で同時 3 session 前提の full-scan が足りない場合のみ実施
@@ -286,3 +286,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.2.0      | 2026-04-22 | Phase 4 完了を反映 (IMPL-400〜451)。直近 PR 優先順位を Phase 5 presentation 層へ更新。                                                                                                                                                                                                                                                                                                                                      |
 | 0.3.0      | 2026-04-22 | Phase 3.5 Domain Repository Adapters (PR #45) 完了を反映。Phase 5 進行中へ遷移、§4 の PR 次優先順位を Background composition 起点に再構成。D1/D2/D4 決定を反映。§10 宿題の 3 件を Phase 4 成果でクローズ、Phase 5 固有の論点 3 件を追加。                                                                                                                                                                                   |
 | 0.4.0      | 2026-04-22 | Phase 5 拡張 presentation 層の PR #47〜#53 (Background composition / Popup UI / Side Panel UI / Content overlay / Offscreen+Monitor / Design tokens / Phase 5 integration gap 埋め) 完了を反映。Phase 5 進捗 ~85% へ。§4 の PR 次優先順位を残タスク (audio frame pipeline / SW→Offscreen command / session recovery / WXT zip / Phase 6 E2E) に再構成。§6 M2 チェックリスト 7/8 完了、§10 messaging schema 論点をクローズ。 |
+| 0.4.1      | 2026-04-22 | IMPL-602 Audio frame pipeline (PR #54) と IMPL-603 Orphan session cleanup (本 PR) の完了を反映。§10 "Background 多重起動時のセッション継続" 論点を "stopped 遷移" 方針でクローズ (full restore は MV3 permission 制約で MVP 外)。                                                                                                                                                                                           |

--- a/packages/extension/src/application/services/orphan-session-cleanup-service.test.ts
+++ b/packages/extension/src/application/services/orphan-session-cleanup-service.test.ts
@@ -1,0 +1,192 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import { type SourceSessionRepository } from '../../domain/repositories/source-session-repository';
+import { createLanguagePair } from '../../domain/session/language-pair';
+import { createSourceSession, type SourceSession } from '../../domain/session/source-session';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { createOrphanSessionCleanupService } from './orphan-session-cleanup-service';
+
+const STARTED_AT = '2026-04-22T00:00:00.000Z';
+const CLEANUP_AT = '2026-04-22T00:10:00.000Z';
+
+const buildSession = (
+  sessionId: string,
+  sourceId: string,
+  state: SourceSession['state'],
+): SourceSession => {
+  const base = createSourceSession({
+    sessionIdentifier: sessionId,
+    sourceIdentifier: sourceId,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt: STARTED_AT,
+  })._unsafeUnwrap();
+  return { ...base, state };
+};
+
+const SESSION_IDS = [
+  '01HZX8Y1R8M7D3Q2P4T5V6W7A1',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7A2',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7A3',
+] as const;
+const SOURCE_IDS = [
+  '01HZX8Y1R8M7D3Q2P4T5V6W7B1',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7B2',
+  '01HZX8Y1R8M7D3Q2P4T5V6W7B3',
+] as const;
+
+const buildRepository = (
+  sessions: readonly SourceSession[],
+  overrides: Partial<SourceSessionRepository> = {},
+): SourceSessionRepository => ({
+  findById: vi.fn(() =>
+    errAsync<SourceSession, DomainError>(
+      invariantViolationError({ invariant: 'unused', details: 'unused' }),
+    ),
+  ),
+  findActiveSessions: vi.fn(() => okAsync(sessions)),
+  save: vi.fn(() => okAsync(undefined)),
+  ...overrides,
+});
+
+describe('createOrphanSessionCleanupService (IMPL-603)', () => {
+  it('transitions all active non-terminal sessions to stopped state', async () => {
+    const sessions = [
+      buildSession(SESSION_IDS[0], SOURCE_IDS[0], 'capturing'),
+      buildSession(SESSION_IDS[1], SOURCE_IDS[1], 'transcribing'),
+      buildSession(SESSION_IDS[2], SOURCE_IDS[2], 'translating'),
+    ];
+    const repository = buildRepository(sessions);
+    const service = createOrphanSessionCleanupService({
+      sourceSessionRepository: repository,
+      clock: () => CLEANUP_AT,
+    });
+
+    const result = await service.cleanup();
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.recoveredCount).toBe(3);
+    }
+    expect(repository.save).toHaveBeenCalledTimes(3);
+    const saveMock = vi.mocked(repository.save);
+    for (const call of saveMock.mock.calls) {
+      expect(call[0].state).toBe('stopped');
+      expect(call[0].stoppedAt).toBe(CLEANUP_AT);
+    }
+  });
+
+  it('returns recoveredCount 0 when there are no active sessions', async () => {
+    const repository = buildRepository([]);
+    const service = createOrphanSessionCleanupService({
+      sourceSessionRepository: repository,
+      clock: () => CLEANUP_AT,
+    });
+
+    const result = await service.cleanup();
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.recoveredCount).toBe(0);
+    }
+    expect(repository.save).not.toHaveBeenCalled();
+  });
+
+  it('skips sessions already in error state (keeps the failure indication)', async () => {
+    const sessions = [
+      buildSession(SESSION_IDS[0], SOURCE_IDS[0], 'capturing'),
+      buildSession(SESSION_IDS[1], SOURCE_IDS[1], 'error'),
+    ];
+    const repository = buildRepository(sessions);
+    const service = createOrphanSessionCleanupService({
+      sourceSessionRepository: repository,
+      clock: () => CLEANUP_AT,
+    });
+
+    const result = await service.cleanup();
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.recoveredCount).toBe(1);
+    }
+    expect(repository.save).toHaveBeenCalledTimes(1);
+    const saveMock = vi.mocked(repository.save);
+    expect(saveMock.mock.calls[0]?.[0].sessionIdentifier).toBe(SESSION_IDS[0]);
+  });
+
+  it('cleans up idle sessions too (stopped is reachable from any non-terminal state)', async () => {
+    const sessions = [
+      buildSession(SESSION_IDS[0], SOURCE_IDS[0], 'capturing'),
+      buildSession(SESSION_IDS[1], SOURCE_IDS[1], 'idle'),
+    ];
+    const repository = buildRepository(sessions);
+    const service = createOrphanSessionCleanupService({
+      sourceSessionRepository: repository,
+      clock: () => CLEANUP_AT,
+    });
+
+    const result = await service.cleanup();
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.recoveredCount).toBe(2);
+    }
+    expect(repository.save).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues with other sessions when one save fails (fire-and-forget per session)', async () => {
+    const logWarn = vi.fn();
+    const sessions = [
+      buildSession(SESSION_IDS[0], SOURCE_IDS[0], 'capturing'),
+      buildSession(SESSION_IDS[1], SOURCE_IDS[1], 'transcribing'),
+    ];
+    let callCount = 0;
+    const repository = buildRepository(sessions, {
+      save: vi.fn(() => {
+        callCount += 1;
+        if (callCount === 1) {
+          return errAsync<void, DomainError>(
+            invariantViolationError({ invariant: 'storage-write-failed', details: 'quota' }),
+          );
+        }
+        return okAsync<void, DomainError>(undefined);
+      }),
+    });
+    const service = createOrphanSessionCleanupService({
+      sourceSessionRepository: repository,
+      clock: () => CLEANUP_AT,
+      logWarn,
+    });
+
+    const result = await service.cleanup();
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.recoveredCount).toBe(1);
+    }
+    expect(repository.save).toHaveBeenCalledTimes(2);
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining('storage-write-failed'));
+  });
+
+  it('propagates findActiveSessions failure as the cleanup error', async () => {
+    const repository = buildRepository([], {
+      findActiveSessions: vi.fn(() =>
+        errAsync<readonly SourceSession[], DomainError>(
+          invariantViolationError({ invariant: 'storage-read-integrity', details: 'db corrupt' }),
+        ),
+      ),
+    });
+    const service = createOrphanSessionCleanupService({
+      sourceSessionRepository: repository,
+      clock: () => CLEANUP_AT,
+    });
+
+    const result = await service.cleanup();
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.kind).toBe('invariant-violation');
+    }
+    expect(repository.save).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/src/application/services/orphan-session-cleanup-service.ts
+++ b/packages/extension/src/application/services/orphan-session-cleanup-service.ts
@@ -1,0 +1,97 @@
+import { ResultAsync, okAsync } from 'neverthrow';
+import { type SourceSessionRepository } from '../../domain/repositories/source-session-repository';
+import { stopSourceSession, type SourceSession } from '../../domain/session/source-session';
+import { describeDomainError, type DomainError } from '../../domain/shared/errors';
+
+/**
+ * IMPL-603 OrphanSessionCleanupService (application service)。
+ *
+ * MV3 Service Worker は 30 秒 idle 後 shutdown されるため、SW 再起動時に
+ * IndexedDB に残存していた非終端 (non-terminal) 状態の `SourceSession` は
+ * 実在の capture / relay 接続を失った "orphan" 状態となる。本 service は
+ * SW 起動時に 1 度だけ呼ばれ、これらを `stopped` 状態に遷移させることで:
+ *
+ * - Popup / SidePanel が "過去に終了した session" として扱える
+ * - `findActiveSessions()` の結果が実体と整合する (capture / relay 未接続)
+ * - `SessionConcurrencyPolicy` (上限 3) が正しく機能する
+ *
+ * **MVP の方針**: permission / capture / stream token の restore までは行わず、
+ * orphan は一律 stopped 化する。ユーザーは Popup から明示的に新規 session を
+ * 開始する (設計論点 §10)。`stopped` は terminal state で、state machine 上
+ * 全 state から遷移可能 (detailed-design.md §7.2 の L32 一般規則)。
+ *
+ * **除外ケース**:
+ * - `error` state: 既に terminal 扱い、改めて stopped 化しない (UI で "failed" を
+ *   保持したほうがユーザーには有益)
+ * - `stopped` state: そもそも `findActiveSessions()` に含まれない
+ *
+ * **本番実装で mock を使わない設計**:
+ * - `sourceSessionRepository` は必須 DI (default なし)
+ * - test では fake repository を注入して save 呼び出しを assert
+ */
+export type OrphanSessionCleanupService = Readonly<{
+  /**
+   * 全 orphan active session を stopped 遷移させて save する。
+   * `findActiveSessions` 失敗は全体失敗として伝播、個別 session の save 失敗は
+   * warn log + 次 session へ継続 (1 件の失敗が全体を止めない)。
+   */
+  cleanup: () => ResultAsync<CleanupResult, DomainError>;
+}>;
+
+export type CleanupResult = Readonly<{
+  /** 実際に stopped state へ遷移・save 成功した session 数 */
+  recoveredCount: number;
+}>;
+
+export type OrphanSessionCleanupDependencies = Readonly<{
+  sourceSessionRepository: SourceSessionRepository;
+  /** Now を ISO8601 文字列で返す clock。stopSourceSession の stoppedAt に使用 */
+  clock: () => string;
+  /** Err ログ sink。default console.warn */
+  logWarn?: (message: string) => void;
+}>;
+
+const defaultLogWarn = (message: string): void => {
+  console.warn(message);
+};
+
+const shouldSkip = (session: SourceSession): boolean => session.state === 'error';
+
+export const createOrphanSessionCleanupService = (
+  deps: OrphanSessionCleanupDependencies,
+): OrphanSessionCleanupService => {
+  const logWarn = deps.logWarn ?? defaultLogWarn;
+
+  const processSingleSession = (session: SourceSession): ResultAsync<boolean, DomainError> => {
+    if (shouldSkip(session)) return okAsync<boolean, DomainError>(false);
+    const transition = stopSourceSession(session, { stoppedAt: deps.clock() });
+    if (transition.isErr()) {
+      logWarn(
+        `[perapera] orphan-session-cleanup transition failed for ${session.sessionIdentifier}: ${describeDomainError(
+          transition.error,
+        )}`,
+      );
+      return okAsync<boolean, DomainError>(false);
+    }
+    return deps.sourceSessionRepository
+      .save(transition.value)
+      .map(() => true)
+      .orElse((error) => {
+        logWarn(
+          `[perapera] orphan-session-cleanup save failed for ${session.sessionIdentifier}: ${describeDomainError(
+            error,
+          )}`,
+        );
+        return okAsync<boolean, DomainError>(false);
+      });
+  };
+
+  return {
+    cleanup: () =>
+      deps.sourceSessionRepository.findActiveSessions().andThen((sessions) =>
+        ResultAsync.combine(sessions.map(processSingleSession)).map((results) => ({
+          recoveredCount: results.filter((recovered) => recovered).length,
+        })),
+      ),
+  };
+};

--- a/packages/extension/src/composition/extension-composition.test.ts
+++ b/packages/extension/src/composition/extension-composition.test.ts
@@ -127,8 +127,19 @@ describe('createExtensionApp (IMPL-500)', () => {
     expect(app.captureOrchestrator).toBeDefined();
     expect(app.audioFramePump).toBeDefined();
     expect(app.audioFramePump.activeCount()).toBe(0);
+    expect(app.orphanSessionCleanup).toBeDefined();
+    expect(app.orphanSessionCleanup.cleanup).toBeTypeOf('function');
     expect(app.transcriptAssembler).toBeDefined();
     expect(app.close).toBeTypeOf('function');
+  });
+
+  it('orphanSessionCleanup.cleanup resolves to recoveredCount 0 when IndexedDB is empty', async () => {
+    app = createExtensionApp(config, createTestPorts());
+    const result = await app.orphanSessionCleanup.cleanup();
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.recoveredCount).toBe(0);
+    }
   });
 
   it('SessionRegistry starts empty', () => {

--- a/packages/extension/src/composition/extension-composition.ts
+++ b/packages/extension/src/composition/extension-composition.ts
@@ -17,6 +17,10 @@ import {
 } from '../application/services/capture-orchestrator';
 import { createExportService, type ExportService } from '../application/services/export-service';
 import {
+  createOrphanSessionCleanupService,
+  type OrphanSessionCleanupService,
+} from '../application/services/orphan-session-cleanup-service';
+import {
   createRelaySessionSubscriber,
   type RelayEventHandler,
   type RelaySessionSubscriber,
@@ -192,6 +196,7 @@ export type ExtensionApp = Readonly<{
   sessionRegistry: SessionRegistry;
   captureOrchestrator: CaptureOrchestrator;
   audioFramePump: AudioFramePump;
+  orphanSessionCleanup: OrphanSessionCleanupService;
   transcriptAssembler: TranscriptAssembler;
   close: () => Promise<void>;
 }>;
@@ -297,6 +302,10 @@ export const createExtensionApp = (
     handleEvent: handleRelayEventLate,
   });
   const audioFramePump: AudioFramePump = createAudioFramePump();
+  const orphanSessionCleanup: OrphanSessionCleanupService = createOrphanSessionCleanupService({
+    sourceSessionRepository,
+    clock: ports.clockIso,
+  });
 
   // --------------- UseCases (Phase 2) ---------------
   const startSourceSessionUseCase = createStartSourceSessionUseCase({
@@ -376,6 +385,7 @@ export const createExtensionApp = (
     sessionRegistry,
     captureOrchestrator,
     audioFramePump,
+    orphanSessionCleanup,
     transcriptAssembler,
     close: async () => {
       relaySessionSubscriber.stopAll();

--- a/packages/extension/src/entrypoints/background.ts
+++ b/packages/extension/src/entrypoints/background.ts
@@ -83,6 +83,23 @@ export default defineBackground(() => {
   };
   const ports = createProductionRuntimePorts();
   const app: ExtensionApp = createExtensionApp(config, ports);
+
+  // SW 再起動時に IndexedDB に残存していた orphan active session を stopped 化
+  // (IMPL-603, 設計論点 §10)。ensure() の完了を待たずに並列実行してよい
+  // (異なるストレージ: chrome.offscreen vs IndexedDB)。
+  void app.orphanSessionCleanup.cleanup().match(
+    (summary) => {
+      if (summary.recoveredCount > 0) {
+        console.log(
+          `[perapera] orphan-session-cleanup: ${summary.recoveredCount.toString()} sessions transitioned to stopped`,
+        );
+      }
+    },
+    (error) => {
+      console.warn('[perapera] orphan-session-cleanup failed:', error);
+    },
+  );
+
   const dispatch: RuntimeDispatcher = createRuntimeDispatcher({
     sessionCommandService: app.sessionCommandService,
     exportService: app.exportService,


### PR DESCRIPTION
## Summary

- 新規 `OrphanSessionCleanupService` (`packages/extension/src/application/services/orphan-session-cleanup-service.ts`)。MV3 SW 再起動時に IndexedDB に残存していた non-terminal の `SourceSession` を `stopSourceSession` で `stopped` 状態に遷移させる
- `extension-composition.ts` で wiring し、`ExtensionApp` に公開
- `background.ts` 起動時 (offscreen ensure と並列) に `cleanup()` を 1 度だけ呼び出し、`recoveredCount` をログ出力
- ロードマップ v0.4.1 へ更新 (§10 "Background 多重起動時のセッション継続" 論点をクローズ)

## Context

PR #54 (IMPL-602) で audio frame pipeline が閉じたが、MV3 Service Worker の特性 (30 秒 idle で shutdown) により、`SourceSession` が `capturing` / `transcribing` / `translating` 等の active 状態のまま IndexedDB に残ったまま SW が消えるケースがある。再起動後は実 capture / relay 接続を失った "orphan" 状態となり、`SessionConcurrencyPolicy` (上限 3) を不当に占有してしまう。

本 PR で SW 起動時に 1 度だけ全 active session を `stopped` 遷移させ、UI と整合する状態に戻す。

## 設計判断 (§10 論点クローズ)

設計論点 §10 "Background 多重起動時のセッション継続" は roadmap で 「復元する vs offscreen keep-alive」 の選択を残していた。本 PR で **「復元しない、orphan は一律 stopped 化」** 方針で確定:

- **MV3 permission 制約**: `chrome.permissions.request()` は user gesture 必須。SW 起動時に自動再取得は不可
- **MediaStream 再確保**: `chrome.tabCapture` も同様に user gesture 必須
- **stream token 再発行**: relay の token 有効期限が切れている可能性
- **MVP 優先**: ユーザーは Popup から明示的に新規 session 開始する方が UX 上明快

`error` state の session は skip (既に terminal 扱い、UI で "failed" を保持したほうが有益)。`idle` state は stopped 遷移可能なのでまとめて cleanup する。

## Test Plan

- [x] `pnpm lint` (root)
- [x] `pnpm typecheck` (root, 全 workspace)
- [x] `pnpm --filter @perapera/extension test` — **839 tests passing** (+6 orphan cleanup + 1 composition smoke = +7 from PR #54 baseline 832)
- [x] `pnpm --filter @perapera/relay-api test` — 184 tests passing
- [x] `pnpm --filter @perapera/extension build` — chrome-mv3 build 成功
- [ ] 手動 smoke (unpacked 拡張): SW 強制 reload (chrome://extensions → 更新ボタン) → IndexedDB の active session が stopped 化されるログを確認

## Out of Scope (後続)

- AudioWorklet 実装 + offscreen 側 AudioPreprocessor ホスト化
- SW → Offscreen `audio.open` / `audio.close` command 送信 service
- WXT zip 配布 smoke
- Phase 6 Playwright E2E