### PR TITLE
test(extension): IMPL-605 monitor page render smoke E2E (Phase 6 拡充)

### DIFF
--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.4.2'
+version: '0.4.3'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -189,9 +189,10 @@ PR #47 時点で `wxt zip` script + CI `build-extension` job の `WXT zip` step 
 > 段階的に追加していく:
 >
 > 1. (済) `smoke.spec.ts` — Service Worker 登録確認 (PR #47 時点で配線)
-> 2. (済) `popup.spec.ts` / `sidepanel.spec.ts` — Popup / SidePanel ページの React render 確認 (本 PR, IMPL-604)
-> 3. (未) `tab-capture-translation.spec.ts` — golden path: Popup から start → Relay mock → translation overlay 描画
-> 4. (未) `permission-denied.spec.ts` — permission denied → error state 表示
+> 2. (済) `popup.spec.ts` / `sidepanel.spec.ts` — Popup / SidePanel ページの React render 確認 (PR #56, IMPL-604)
+> 3. (済) `monitor.spec.ts` — Monitor ページ (web_accessible_resources) の React render 確認 (本 PR, IMPL-605)
+> 4. (未) `tab-capture-translation.spec.ts` — golden path: Popup から start → Relay mock → translation overlay 描画
+> 5. (未) `permission-denied.spec.ts` — permission denied → error state 表示
 
 - 範囲: `packages/extension/e2e/specs/`
 - 依存: なし (各 spec 独立)
@@ -289,3 +290,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.4.0      | 2026-04-22 | Phase 5 拡張 presentation 層の PR #47〜#53 (Background composition / Popup UI / Side Panel UI / Content overlay / Offscreen+Monitor / Design tokens / Phase 5 integration gap 埋め) 完了を反映。Phase 5 進捗 ~85% へ。§4 の PR 次優先順位を残タスク (audio frame pipeline / SW→Offscreen command / session recovery / WXT zip / Phase 6 E2E) に再構成。§6 M2 チェックリスト 7/8 完了、§10 messaging schema 論点をクローズ。 |
 | 0.4.1      | 2026-04-22 | IMPL-602 Audio frame pipeline (PR #54) と IMPL-603 Orphan session cleanup (PR #55) の完了を反映。§10 "Background 多重起動時のセッション継続" 論点を "stopped 遷移" 方針でクローズ (full restore は MV3 permission 制約で MVP 外)。                                                                                                                                                                                          |
 | 0.4.2      | 2026-04-22 | IMPL-604 で Phase 6 E2E に `popup.spec.ts` / `sidepanel.spec.ts` を追加 (chrome-extension URL 直接 load → React root render 確認)。§6 M2 checklist 8 (WXT zip 配布) は実は PR #47 で達成済だったため認識を更新し M2 完了。Phase 5 残作業は SW→Offscreen audio command + AudioWorklet 実装のみ。                                                                                                                             |
+| 0.4.3      | 2026-04-22 | IMPL-605 で Phase 6 E2E に `monitor.spec.ts` を追加 (Monitor page も `web_accessible_resources` 経由で render smoke 検証)。これで chrome-extension URL 直接 load 可能な全 entrypoint (popup / sidepanel / monitor) を E2E で網羅。                                                                                                                                                                                          |

--- a/packages/extension/e2e/specs/monitor.spec.ts
+++ b/packages/extension/e2e/specs/monitor.spec.ts
@@ -1,0 +1,36 @@
+import { chromium, expect, test, type BrowserContext } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const extensionPath = path.resolve(__dirname, '../../.output/chrome-mv3');
+
+let context: BrowserContext;
+
+test.beforeAll(async () => {
+  context = await chromium.launchPersistentContext('', {
+    headless: false,
+    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`],
+  });
+});
+
+test.afterAll(async () => {
+  await context.close();
+});
+
+const resolveExtensionId = async (): Promise<string> => {
+  let [serviceWorker] = context.serviceWorkers();
+  serviceWorker ??= await context.waitForEvent('serviceworker');
+  return new URL(serviceWorker.url()).host;
+};
+
+test('monitor.html renders the React root with the overlay listener mounted', async () => {
+  const extensionId = await resolveExtensionId();
+  const page = await context.newPage();
+  // monitor.html は web_accessible_resources で外部から開ける。
+  // タブ以外のソース (microphone / desktop) のオーバーレイ表示先 (IMPL-563)。
+  await page.goto(`chrome-extension://${extensionId}/monitor.html`);
+
+  await expect(page).toHaveTitle(/perapera/i);
+  await page.locator('#root > *').first().waitFor({ timeout: 5000 });
+});


### PR DESCRIPTION
## Summary

- `e2e/specs/monitor.spec.ts` を追加。`chrome-extension://<id>/monitor.html` を直接 load して React root が render されることを smoke check
- ロードマップ v0.4.3 に進捗反映 (PR 次 #11 リスト 3 を完了マーク)

## Context

PR #56 (popup / sidepanel render smoke) で popup と sidepanel の E2E 検証を追加した。残る `chrome-extension://` 直接 load 可能な entrypoint は monitor (web_accessible_resources 経由で外部から開ける) のみ。本 PR で全 page entrypoint の smoke が揃う。

Phase 5 残作業 (SW→Offscreen audio command + AudioWorklet 実装) は規模大の独立 PR で扱う。

## Test Plan

- [x] `pnpm fmt` / `pnpm lint` / `pnpm typecheck` (root)
- [x] vitest 既存 839 tests pass (E2E は対象外)
- [ ] CI `e2e` job で monitor.spec.ts pass (push 後に確認)