### PR TITLE
feat(extension): IMPL-606 OffscreenCommandSender — Phase 5+ Step 1 (SW→Offscreen audio command)

### DIFF
--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.5.0'
+version: '0.5.1'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -31,7 +31,7 @@ author: 'Codex'
 | 3.5   | Domain Repository Adapters (IMPL-140〜143)                | ✅ 完了 (#45)                                        |
 | 4     | Relay API (IMPL-400〜451)                                 | ✅ 完了                                              |
 | 5     | 拡張 presentation 層 (IMPL-500〜605)                      | ✅ M2 完了 (実 audio data 転送は Phase 5+ へ分離)    |
-| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | ⚪ 未着手 (§4 PR 次 #12)                             |
+| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~30% (SW→Offscreen audio command sender 完了)     |
 | 6     | E2E / 性能 / 品質検証                                     | 🟡 開始 (page render smoke 4/5 完了, golden path 未) |
 | 7     | リリース / 運用整備                                       | ⚪ 未着手                                            |
 
@@ -212,19 +212,22 @@ PR #47 時点で `wxt zip` script + CI `build-extension` job の `WXT zip` step 
 
 > Phase 5+ の本丸。MV3 Service Worker は `MediaStream` / `AudioContext` を直接扱えないため、
 > capture と前処理を offscreen 側に移し、実 PCM16 フレームを `audioFramePump` 経由で
-> Relay まで流す。Plan mode で設計した上で着手する。
+> Relay まで流す。段階的に進めている:
 
-- **新規実装**:
-  - `packages/extension/public/audio-worklet.js` — AudioWorklet processor (mono 化 + 16kHz 再サンプル + 100ms バッファ → postMessage)
-  - `application/services/offscreen-command-sender.ts` — SW → offscreen `audio.open` / `audio.close` 送信
-  - `infrastructure/audio/offscreen-audio-preprocessor.ts` — offscreen 側で `getUserMedia({chromeMediaSource: 'tab'})` + AudioWorklet 起動 + AsyncIterable<AudioFrameEnvelope> を SW へ転送
-- **既存改修**:
-  - `infrastructure/capture/tab-capture-source-adapter.ts` — `chrome.tabCapture.getMediaStreamId({targetTabId})` を返す形に変更 (実 MediaStream は offscreen 側で確保)
-  - `application/services/capture-orchestrator.ts` — SourceAdapter から streamId を受け取り offscreen に audio.open 送信
-  - `entrypoints/offscreen/main.ts` — audio.open ハンドラで MediaStream + Worklet を起動、frame を SW に postMessage
-  - `extension-composition.ts` — offscreen-command-sender wiring
+#### Phase 5+ Step 1: SW → Offscreen audio command sender (✅ 完了, IMPL-606, 本 PR)
+
+- `application/services/offscreen-command-sender.ts` — SW → offscreen `audio.open` / `audio.close` / `ping` 送信 service
+- `infrastructure/messaging/chrome-runtime-message-bridge.ts` — `chrome.runtime.sendMessage` の port wrap (production adapter)
+- start/stop UseCase 配線 + composition wiring
+- offscreen 側受信ロジック (IMPL-562) は既に存在するため、**SW → offscreen の往復が成立**
+
+#### Phase 5+ Step 2: Offscreen MediaStream 受け取り + AudioWorklet 実装 (未着手, 規模大)
+
+- **新規**: `packages/extension/public/audio-worklet.js` (mono 化 + 16kHz 再サンプル + 100ms バッファ → postMessage)
+- **新規**: `infrastructure/audio/offscreen-audio-preprocessor.ts` — offscreen 側で `getUserMedia({chromeMediaSource: 'tab'})` + AudioWorklet 起動 + 配信
+- **改修**: `infrastructure/capture/tab-capture-source-adapter.ts` — `chrome.tabCapture.getMediaStreamId({targetTabId})` を返す形に変更
+- **改修**: `entrypoints/offscreen/main.ts` — audio.open ハンドラで MediaStream + Worklet を起動、frame を SW に postMessage
 - **検証**: vitest + 手動 unpacked smoke
-- **依存**: なし (PR #54 frame pump が既に SW 側で受信側を持っている)
 - **複雑性**: Plan mode で MV3 制約・MediaStream 受け渡し方式・worklet ビルド設定を慎重に設計する必要
 
 ## 5. Phase 4 完了基準 (M1) — 2026-04-22 達成
@@ -331,3 +334,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.4.2      | 2026-04-22 | IMPL-604 で Phase 6 E2E に `popup.spec.ts` / `sidepanel.spec.ts` を追加 (chrome-extension URL 直接 load → React root render 確認)。§6 M2 checklist 8 (WXT zip 配布) は実は PR #47 で達成済だったため認識を更新し M2 完了。Phase 5 残作業は SW→Offscreen audio command + AudioWorklet 実装のみ。                                                                                                                             |
 | 0.4.3      | 2026-04-22 | IMPL-605 で Phase 6 E2E に `monitor.spec.ts` を追加 (Monitor page も `web_accessible_resources` 経由で render smoke 検証)。これで chrome-extension URL 直接 load 可能な全 entrypoint (popup / sidepanel / monitor) を E2E で網羅。                                                                                                                                                                                          |
 | 0.5.0      | 2026-04-22 | Phase 5 を **M2 完了** として正式にクローズし、実 audio data routing を **Phase 5+ として分離**。§1 に IMPL 番号運用方針 (Task.md 予約番号との衝突を本 roadmap で吸収する旨) を追記。§4 に PR 次 #12 (AudioWorklet + Offscreen MediaStream) を追加し、Plan mode で慎重設計する旨を明記。§2 状態表に Phase 5+ 行を追加。                                                                                                     |
+| 0.5.1      | 2026-04-22 | IMPL-606 で Phase 5+ Step 1 (SW → Offscreen audio command sender) を実装。`OffscreenCommandSender` (application service) + `ChromeRuntimeMessageBridge` (infrastructure adapter) + start/stop UseCase 配線 + composition wiring を完了。§2 Phase 5+ ステータスを ⚪ → 🟡 ~30% に更新。Step 2 (AudioWorklet + offscreen MediaStream) は次 PR で続行。                                                                        |

--- a/packages/extension/src/application/services/offscreen-command-sender.test.ts
+++ b/packages/extension/src/application/services/offscreen-command-sender.test.ts
@@ -1,0 +1,88 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import {
+  createOffscreenCommandSender,
+  type RuntimeMessageBridge,
+} from './offscreen-command-sender';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const identifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const buildBridge = (overrides: Partial<RuntimeMessageBridge> = {}): RuntimeMessageBridge => ({
+  sendMessage: vi.fn(() => okAsync<void, DomainError>(undefined)),
+  ...overrides,
+});
+
+describe('createOffscreenCommandSender (IMPL-606)', () => {
+  it('sends audio.open with sessionIdentifier (default sampleRateHz omitted)', async () => {
+    const bridge = buildBridge();
+    const sender = createOffscreenCommandSender({ bridge });
+
+    const result = await sender.openAudioContext(identifier);
+
+    expect(result.isOk()).toBe(true);
+    expect(bridge.sendMessage).toHaveBeenCalledWith({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: SESSION_ID,
+    });
+  });
+
+  it('passes through optional sampleRateHz when provided', async () => {
+    const bridge = buildBridge();
+    const sender = createOffscreenCommandSender({ bridge });
+
+    await sender.openAudioContext(identifier, { sampleRateHz: 48000 });
+
+    expect(bridge.sendMessage).toHaveBeenCalledWith({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: SESSION_ID,
+      sampleRateHz: 48000,
+    });
+  });
+
+  it('sends audio.close with sessionIdentifier', async () => {
+    const bridge = buildBridge();
+    const sender = createOffscreenCommandSender({ bridge });
+
+    const result = await sender.closeAudioContext(identifier);
+
+    expect(result.isOk()).toBe(true);
+    expect(bridge.sendMessage).toHaveBeenCalledWith({
+      type: 'offscreen.audio.close',
+      sessionIdentifier: SESSION_ID,
+    });
+  });
+
+  it('propagates bridge failure as DomainError', async () => {
+    const bridge = buildBridge({
+      sendMessage: vi.fn(() =>
+        errAsync<void, DomainError>(
+          invariantViolationError({ invariant: 'runtime-bridge', details: 'no offscreen' }),
+        ),
+      ),
+    });
+    const sender = createOffscreenCommandSender({ bridge });
+
+    const result = await sender.openAudioContext(identifier);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.kind).toBe('invariant-violation');
+    }
+  });
+
+  it('ping returns ok when bridge succeeds', async () => {
+    const bridge = buildBridge();
+    const sender = createOffscreenCommandSender({ bridge });
+
+    const result = await sender.ping();
+
+    expect(result.isOk()).toBe(true);
+    expect(bridge.sendMessage).toHaveBeenCalledWith({ type: 'offscreen.ping' });
+  });
+});

--- a/packages/extension/src/application/services/offscreen-command-sender.ts
+++ b/packages/extension/src/application/services/offscreen-command-sender.ts
@@ -1,0 +1,60 @@
+import { type ResultAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type DomainError } from '../../domain/shared/errors';
+import { type OffscreenCommand } from '../../entrypoints/offscreen/offscreen-commands';
+
+/**
+ * IMPL-606 OffscreenCommandSender (application service)。
+ *
+ * SW (Background) から Offscreen document へ `OffscreenCommand` を送信する
+ * application 層の thin wrapper。送信経路 (`chrome.runtime.sendMessage`) は
+ * `RuntimeMessageBridge` port で抽象化され、test では fake bridge を注入できる。
+ *
+ * Offscreen 側 (IMPL-560 / IMPL-562) の `OffscreenAudioHost` が受信ハンドラを
+ * 既に実装済 — 本 sender は SW 側の "送信側骨組み" のみを提供する。実 audio
+ * 転送 (AudioWorklet で 100ms PCM16 frame 化 + offscreen → SW postMessage) は
+ * 後続 PR (Phase 5+ 第 2 段) で扱う。
+ *
+ * **本番実装で mock を使わない設計**:
+ * - `bridge` は必須 DI、production では `defaultRuntimeMessageBridge`
+ *   (`chrome.runtime.sendMessage` を直接 wrap) を明示注入
+ * - test では minimal fake bridge を注入する
+ */
+export type RuntimeMessageBridge = Readonly<{
+  /** OffscreenCommand を chrome.runtime.sendMessage 経由で送信。失敗は DomainError */
+  sendMessage: (command: OffscreenCommand) => ResultAsync<void, DomainError>;
+}>;
+
+export type OffscreenCommandSender = Readonly<{
+  /** Session に対する AudioContext を offscreen 側で確保 */
+  openAudioContext: (
+    sessionIdentifier: SessionIdentifier,
+    options?: Readonly<{ sampleRateHz?: number }>,
+  ) => ResultAsync<void, DomainError>;
+  /** Session に対する AudioContext を破棄 */
+  closeAudioContext: (sessionIdentifier: SessionIdentifier) => ResultAsync<void, DomainError>;
+  /** Offscreen document の死活確認 */
+  ping: () => ResultAsync<void, DomainError>;
+}>;
+
+export type OffscreenCommandSenderDependencies = Readonly<{
+  bridge: RuntimeMessageBridge;
+}>;
+
+export const createOffscreenCommandSender = (
+  deps: OffscreenCommandSenderDependencies,
+): OffscreenCommandSender => {
+  return {
+    openAudioContext: (sessionIdentifier, options) => {
+      const sampleRateHz = options?.sampleRateHz;
+      const command: OffscreenCommand =
+        sampleRateHz !== undefined
+          ? { type: 'offscreen.audio.open', sessionIdentifier, sampleRateHz }
+          : { type: 'offscreen.audio.open', sessionIdentifier };
+      return deps.bridge.sendMessage(command);
+    },
+    closeAudioContext: (sessionIdentifier) =>
+      deps.bridge.sendMessage({ type: 'offscreen.audio.close', sessionIdentifier }),
+    ping: () => deps.bridge.sendMessage({ type: 'offscreen.ping' }),
+  };
+};

--- a/packages/extension/src/application/use-cases/start-source-session-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/start-source-session-use-case.test.ts
@@ -20,6 +20,7 @@ import { type PermissionCoordinator } from '../ports/permission-coordinator';
 import { type RelayGateway } from '../ports/relay-gateway';
 import { type AudioFramePump } from '../services/audio-frame-pump';
 import { type CaptureOrchestrator } from '../services/capture-orchestrator';
+import { type OffscreenCommandSender } from '../services/offscreen-command-sender';
 import { type RelaySessionSubscriber } from '../services/relay-session-subscriber';
 import {
   createStartSourceSessionUseCase,
@@ -102,6 +103,11 @@ const buildDependencies = (
     stopAll: vi.fn(),
     activeCount: vi.fn(() => 0),
   };
+  const offscreenCommandSender: OffscreenCommandSender = {
+    openAudioContext: vi.fn(() => okAsync(undefined)),
+    closeAudioContext: vi.fn(() => okAsync(undefined)),
+    ping: vi.fn(() => okAsync(undefined)),
+  };
   return {
     sourceSessionRepository,
     extensionProfileRepository,
@@ -110,6 +116,7 @@ const buildDependencies = (
     captureOrchestrator,
     relaySessionSubscriber,
     audioFramePump,
+    offscreenCommandSender,
     clock: () => STARTED_AT,
     idFactory: {
       session: () => SESSION_ID,
@@ -157,6 +164,7 @@ describe('createStartSourceSessionUseCase (IMPL-210, DD-301)', () => {
     }
     expect(deps.sourceSessionRepository.save).toHaveBeenCalledTimes(2);
     expect(deps.relayGateway.openSession).toHaveBeenCalledTimes(1);
+    expect(deps.offscreenCommandSender.openAudioContext).toHaveBeenCalledWith(SESSION_ID);
     expect(deps.audioFramePump.start).toHaveBeenCalledTimes(1);
     const startCalls = vi.mocked(deps.audioFramePump.start).mock.calls;
     const firstCall = startCalls[0];

--- a/packages/extension/src/application/use-cases/start-source-session-use-case.ts
+++ b/packages/extension/src/application/use-cases/start-source-session-use-case.ts
@@ -25,6 +25,7 @@ import { type RelayGateway } from '../ports/relay-gateway';
 import { type StartSourceCommand } from '../ports/source-adapter';
 import { type AudioFramePump } from '../services/audio-frame-pump';
 import { type CaptureOrchestrator } from '../services/capture-orchestrator';
+import { type OffscreenCommandSender } from '../services/offscreen-command-sender';
 import { type RelaySessionSubscriber } from '../services/relay-session-subscriber';
 
 export type StartSourceSessionDependencies = Readonly<{
@@ -35,6 +36,7 @@ export type StartSourceSessionDependencies = Readonly<{
   captureOrchestrator: CaptureOrchestrator;
   relaySessionSubscriber: RelaySessionSubscriber;
   audioFramePump: AudioFramePump;
+  offscreenCommandSender: OffscreenCommandSender;
   clock: () => string;
   idFactory: Readonly<{
     session: () => string;
@@ -135,6 +137,11 @@ export const createStartSourceSessionUseCase = (
                             .connect(toStartSourceCommand(connecting))
                             .andThen((activeCapture) =>
                               deps.relayGateway.openSession(connecting).map(() => activeCapture),
+                            )
+                            .andThen((activeCapture) =>
+                              deps.offscreenCommandSender
+                                .openAudioContext(connecting.sessionIdentifier)
+                                .map(() => activeCapture),
                             )
                             .andThen((activeCapture) => {
                               deps.audioFramePump.start(

--- a/packages/extension/src/application/use-cases/stop-source-session-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/stop-source-session-use-case.test.ts
@@ -13,6 +13,7 @@ import type { SourceSessionRepository } from '../../domain/repositories/source-s
 import type { SourceSession } from '../../domain/session/source-session';
 import type { AudioFramePump } from '../services/audio-frame-pump';
 import type { CaptureOrchestrator } from '../services/capture-orchestrator';
+import type { OffscreenCommandSender } from '../services/offscreen-command-sender';
 import type { RelaySessionSubscriber } from '../services/relay-session-subscriber';
 import {
   createStopSourceSessionUseCase,
@@ -87,6 +88,11 @@ const buildDependencies = (
     stopAll: vi.fn(),
     activeCount: vi.fn(() => 0),
   };
+  const offscreenCommandSender: OffscreenCommandSender = {
+    openAudioContext: vi.fn(() => okAsync(undefined)),
+    closeAudioContext: vi.fn(() => okAsync(undefined)),
+    ping: vi.fn(() => okAsync(undefined)),
+  };
   return {
     sourceSessionRepository,
     relayGateway,
@@ -94,6 +100,7 @@ const buildDependencies = (
     captureOrchestrator,
     relaySessionSubscriber,
     audioFramePump,
+    offscreenCommandSender,
     clock: () => STOPPED_AT,
     ...overrides,
   };
@@ -121,6 +128,7 @@ describe('createStopSourceSessionUseCase (IMPL-215, DD-306)', () => {
     expect(deps.overlayPresenter.unmount).toHaveBeenCalledTimes(1);
     expect(deps.audioFramePump.stop).toHaveBeenCalledWith(SESSION_ID);
     expect(deps.relaySessionSubscriber.stop).toHaveBeenCalledWith(SESSION_ID);
+    expect(deps.offscreenCommandSender.closeAudioContext).toHaveBeenCalledWith(SESSION_ID);
   });
 
   it('returns validation error when input is invalid', async () => {

--- a/packages/extension/src/application/use-cases/stop-source-session-use-case.ts
+++ b/packages/extension/src/application/use-cases/stop-source-session-use-case.ts
@@ -13,6 +13,7 @@ import { type OverlayPresenter } from '../ports/overlay-presenter';
 import { type RelayGateway } from '../ports/relay-gateway';
 import { type AudioFramePump } from '../services/audio-frame-pump';
 import { type CaptureOrchestrator } from '../services/capture-orchestrator';
+import { type OffscreenCommandSender } from '../services/offscreen-command-sender';
 import { type RelaySessionSubscriber } from '../services/relay-session-subscriber';
 
 export type StopSourceSessionDependencies = Readonly<{
@@ -22,6 +23,7 @@ export type StopSourceSessionDependencies = Readonly<{
   captureOrchestrator: CaptureOrchestrator;
   relaySessionSubscriber: RelaySessionSubscriber;
   audioFramePump: AudioFramePump;
+  offscreenCommandSender: OffscreenCommandSender;
   clock: () => string;
 }>;
 
@@ -88,6 +90,9 @@ export const createStopSourceSessionUseCase = (
               void deps.overlayPresenter
                 .unmount(sessionIdentifier)
                 .match(() => undefined, logWarn('overlayPresenter.unmount'));
+              void deps.offscreenCommandSender
+                .closeAudioContext(sessionIdentifier)
+                .match(() => undefined, logWarn('offscreenCommandSender.closeAudioContext'));
               return {
                 sessionId: stopped.sessionIdentifier,
                 state: stopped.state,

--- a/packages/extension/src/composition/extension-composition.test.ts
+++ b/packages/extension/src/composition/extension-composition.test.ts
@@ -80,6 +80,7 @@ const createTestPorts = (overrides: Partial<ExtensionRuntimePorts> = {}): Extens
       ),
     ),
     overlayMessagingBridge: { send: vi.fn(() => Promise.resolve()) },
+    chromeRuntimeApi: { sendMessage: vi.fn(() => Promise.resolve(undefined)) },
     tabCaptureApi: { capture: vi.fn(() => Promise.resolve(null)) },
     userMediaApi: { getUserMedia: vi.fn(() => Promise.reject(new Error('not implemented'))) },
     desktopCaptureApi: {
@@ -127,6 +128,8 @@ describe('createExtensionApp (IMPL-500)', () => {
     expect(app.captureOrchestrator).toBeDefined();
     expect(app.audioFramePump).toBeDefined();
     expect(app.audioFramePump.activeCount()).toBe(0);
+    expect(app.offscreenCommandSender).toBeDefined();
+    expect(app.offscreenCommandSender.openAudioContext).toBeTypeOf('function');
     expect(app.orphanSessionCleanup).toBeDefined();
     expect(app.orphanSessionCleanup.cleanup).toBeTypeOf('function');
     expect(app.transcriptAssembler).toBeDefined();

--- a/packages/extension/src/composition/extension-composition.ts
+++ b/packages/extension/src/composition/extension-composition.ts
@@ -17,6 +17,11 @@ import {
 } from '../application/services/capture-orchestrator';
 import { createExportService, type ExportService } from '../application/services/export-service';
 import {
+  createOffscreenCommandSender,
+  type OffscreenCommandSender,
+  type RuntimeMessageBridge,
+} from '../application/services/offscreen-command-sender';
+import {
   createOrphanSessionCleanupService,
   type OrphanSessionCleanupService,
 } from '../application/services/orphan-session-cleanup-service';
@@ -60,6 +65,11 @@ import {
   defaultUserMediaApi,
   type UserMediaApi,
 } from '../infrastructure/capture/user-media-source-adapter';
+import {
+  createChromeRuntimeMessageBridge,
+  defaultChromeRuntimeApi,
+  type ChromeRuntimeApi,
+} from '../infrastructure/messaging/chrome-runtime-message-bridge';
 import {
   createChromeMessagingOverlayPresenter,
   defaultOverlayMessagingBridge,
@@ -146,6 +156,7 @@ export type ExtensionRuntimePorts = Readonly<{
   webSocketFactory: WebSocketFactory;
   fetchImpl: typeof fetch;
   overlayMessagingBridge: OverlayMessagingBridge;
+  chromeRuntimeApi: ChromeRuntimeApi;
   tabCaptureApi: TabCaptureApi;
   userMediaApi: UserMediaApi;
   desktopCaptureApi: DesktopCaptureApi;
@@ -171,6 +182,7 @@ export const createProductionRuntimePorts = (): ExtensionRuntimePorts => ({
   webSocketFactory: createBrowserWebSocketFactory(),
   fetchImpl: fetch,
   overlayMessagingBridge: defaultOverlayMessagingBridge,
+  chromeRuntimeApi: defaultChromeRuntimeApi,
   tabCaptureApi: defaultTabCaptureApi,
   userMediaApi: defaultUserMediaApi,
   desktopCaptureApi: defaultDesktopCaptureApi,
@@ -196,6 +208,7 @@ export type ExtensionApp = Readonly<{
   sessionRegistry: SessionRegistry;
   captureOrchestrator: CaptureOrchestrator;
   audioFramePump: AudioFramePump;
+  offscreenCommandSender: OffscreenCommandSender;
   orphanSessionCleanup: OrphanSessionCleanupService;
   transcriptAssembler: TranscriptAssembler;
   close: () => Promise<void>;
@@ -302,6 +315,12 @@ export const createExtensionApp = (
     handleEvent: handleRelayEventLate,
   });
   const audioFramePump: AudioFramePump = createAudioFramePump();
+  const runtimeMessageBridge: RuntimeMessageBridge = createChromeRuntimeMessageBridge(
+    ports.chromeRuntimeApi,
+  );
+  const offscreenCommandSender: OffscreenCommandSender = createOffscreenCommandSender({
+    bridge: runtimeMessageBridge,
+  });
   const orphanSessionCleanup: OrphanSessionCleanupService = createOrphanSessionCleanupService({
     sourceSessionRepository,
     clock: ports.clockIso,
@@ -316,6 +335,7 @@ export const createExtensionApp = (
     captureOrchestrator,
     relaySessionSubscriber,
     audioFramePump,
+    offscreenCommandSender,
     clock: ports.clockIso,
     idFactory: {
       session: ports.sessionIdFactory,
@@ -329,6 +349,7 @@ export const createExtensionApp = (
     captureOrchestrator,
     relaySessionSubscriber,
     audioFramePump,
+    offscreenCommandSender,
     clock: ports.clockIso,
   });
   const updateSourceSettingsUseCase = createUpdateSourceSettingsUseCase({
@@ -385,6 +406,7 @@ export const createExtensionApp = (
     sessionRegistry,
     captureOrchestrator,
     audioFramePump,
+    offscreenCommandSender,
     orphanSessionCleanup,
     transcriptAssembler,
     close: async () => {

--- a/packages/extension/src/infrastructure/messaging/chrome-runtime-message-bridge.test.ts
+++ b/packages/extension/src/infrastructure/messaging/chrome-runtime-message-bridge.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { type OffscreenCommand } from '../../entrypoints/offscreen/offscreen-commands';
+import {
+  createChromeRuntimeMessageBridge,
+  type ChromeRuntimeApi,
+} from './chrome-runtime-message-bridge';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const identifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
+
+const buildApi = (overrides: Partial<ChromeRuntimeApi> = {}): ChromeRuntimeApi => ({
+  sendMessage: vi.fn(() => Promise.resolve(undefined)),
+  ...overrides,
+});
+
+describe('createChromeRuntimeMessageBridge (IMPL-606)', () => {
+  it('forwards OffscreenCommand to chrome.runtime.sendMessage', async () => {
+    const api = buildApi();
+    const bridge = createChromeRuntimeMessageBridge(api);
+    const command: OffscreenCommand = {
+      type: 'offscreen.audio.open',
+      sessionIdentifier: identifier,
+    };
+
+    const result = await bridge.sendMessage(command);
+
+    expect(result.isOk()).toBe(true);
+    expect(api.sendMessage).toHaveBeenCalledWith(command);
+  });
+
+  it('maps Promise rejection to invariantViolationError', async () => {
+    const api = buildApi({
+      sendMessage: vi.fn(() => Promise.reject(new Error('no listener'))),
+    });
+    const bridge = createChromeRuntimeMessageBridge(api);
+    const command: OffscreenCommand = {
+      type: 'offscreen.audio.close',
+      sessionIdentifier: identifier,
+    };
+
+    const result = await bridge.sendMessage(command);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.kind).toBe('invariant-violation');
+      if (result.error.kind === 'invariant-violation') {
+        expect(result.error.details).toContain('no listener');
+      }
+    }
+  });
+});

--- a/packages/extension/src/infrastructure/messaging/chrome-runtime-message-bridge.ts
+++ b/packages/extension/src/infrastructure/messaging/chrome-runtime-message-bridge.ts
@@ -1,0 +1,44 @@
+import { ResultAsync } from 'neverthrow';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { type OffscreenCommand } from '../../entrypoints/offscreen/offscreen-commands';
+import { type RuntimeMessageBridge } from '../../application/services/offscreen-command-sender';
+
+/**
+ * IMPL-606 Chrome runtime message bridge (production adapter)。
+ *
+ * `chrome.runtime.sendMessage(undefined, message)` を呼び出し、Promise を
+ * `ResultAsync<void, DomainError>` に変換する。`undefined` を extensionId に
+ * 渡すと送信元と同じ拡張内の全 listener (offscreen / popup / sidepanel など)
+ * へ broadcast される。Offscreen handler が discriminator (`type` field) で
+ * 自分宛だけ拾う設計。
+ *
+ * 失敗 (chrome.runtime.lastError 含む) は `invariantViolationError` に変換。
+ *
+ * **本番実装で mock を使わない設計**:
+ * - production では `defaultChromeRuntimeMessageBridge` をそのまま使う
+ * - test では `RuntimeMessageBridge` 型に対する fake bridge を別途注入する
+ */
+export type ChromeRuntimeApi = Readonly<{
+  sendMessage: (message: OffscreenCommand) => Promise<unknown>;
+}>;
+
+export const defaultChromeRuntimeApi: ChromeRuntimeApi = {
+  sendMessage: (message) => chrome.runtime.sendMessage(message),
+};
+
+export const createChromeRuntimeMessageBridge = (
+  api: ChromeRuntimeApi = defaultChromeRuntimeApi,
+): RuntimeMessageBridge => {
+  return {
+    sendMessage: (command: OffscreenCommand) => {
+      return ResultAsync.fromPromise(
+        api.sendMessage(command),
+        (cause): DomainError =>
+          invariantViolationError({
+            invariant: 'chrome-runtime-message-bridge',
+            details: cause instanceof Error ? cause.message : String(cause),
+          }),
+      ).map(() => undefined);
+    },
+  };
+};


### PR DESCRIPTION
## Summary

- 新規 `OffscreenCommandSender` (application service) — SW から offscreen に `audio.open` / `audio.close` / `ping` を送信
- 新規 `ChromeRuntimeMessageBridge` (infrastructure adapter) — `chrome.runtime.sendMessage` の port wrap
- `StartSourceSessionUseCase` / `StopSourceSessionUseCase` に `offscreenCommandSender` を必須依存追加し、capture 接続後 / 停止時に audio.open / audio.close を送信
- `extension-composition.ts` に wiring + `ChromeRuntimeApi` を `ExtensionRuntimePorts` に追加
- ロードマップ v0.5.1 へ更新 (Phase 5+ ~30% 進捗)

## Context

PR #51 (IMPL-562) で offscreen 側の `OffscreenAudioHost` が `audio.open` / `audio.close` を受信できる状態だったが、SW 側からの送信路が未実装だった。本 PR で送信側を整備し、SW → offscreen の往復 (lifecycle) が成立する。

実 audio data 転送 (AudioWorklet で 100ms PCM16 frame 化 → offscreen → SW postMessage) は **Phase 5+ Step 2** で扱う (規模大、Plan mode で慎重設計)。現状は SW がコマンドを送って offscreen 側で AudioContext を確保するだけだが、その後段の実装と完全に整合する shell が完成。

## Test Plan

- [x] `pnpm lint` (root)
- [x] `pnpm typecheck` (root, 全 workspace)
- [x] `pnpm --filter @perapera/extension test` — **846 tests passing** (+5 sender + 2 bridge = 7 新規)
- [x] `pnpm --filter @perapera/extension build` — chrome-mv3 build 成功
- [ ] CI 全 green を確認 (push 後)