### PR TITLE
feat(extension): IMPL-607 perapera-audio-processor (Phase 5+ Step 1.5)

### DIFF
--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.5.1'
+version: '0.5.2'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -31,7 +31,7 @@ author: 'Codex'
 | 3.5   | Domain Repository Adapters (IMPL-140〜143)                | ✅ 完了 (#45)                                        |
 | 4     | Relay API (IMPL-400〜451)                                 | ✅ 完了                                              |
 | 5     | 拡張 presentation 層 (IMPL-500〜605)                      | ✅ M2 完了 (実 audio data 転送は Phase 5+ へ分離)    |
-| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~30% (SW→Offscreen audio command sender 完了)     |
+| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~50% (sender + AudioWorklet processor 配置完了)   |
 | 6     | E2E / 性能 / 品質検証                                     | 🟡 開始 (page render smoke 4/5 完了, golden path 未) |
 | 7     | リリース / 運用整備                                       | ⚪ 未着手                                            |
 
@@ -214,14 +214,21 @@ PR #47 時点で `wxt zip` script + CI `build-extension` job の `WXT zip` step 
 > capture と前処理を offscreen 側に移し、実 PCM16 フレームを `audioFramePump` 経由で
 > Relay まで流す。段階的に進めている:
 
-#### Phase 5+ Step 1: SW → Offscreen audio command sender (✅ 完了, IMPL-606, 本 PR)
+#### Phase 5+ Step 1: SW → Offscreen audio command sender (✅ 完了, IMPL-606, PR #59)
 
 - `application/services/offscreen-command-sender.ts` — SW → offscreen `audio.open` / `audio.close` / `ping` 送信 service
 - `infrastructure/messaging/chrome-runtime-message-bridge.ts` — `chrome.runtime.sendMessage` の port wrap (production adapter)
 - start/stop UseCase 配線 + composition wiring
 - offscreen 側受信ロジック (IMPL-562) は既に存在するため、**SW → offscreen の往復が成立**
 
-#### Phase 5+ Step 2: Offscreen MediaStream 受け取り + AudioWorklet 実装 (未着手, 規模大)
+#### Phase 5+ Step 1.5: AudioWorklet processor JS 配置 (✅ 完了, IMPL-607, 本 PR)
+
+- `packages/extension/src/public/perapera-audio-processor.js` を追加
+- `chrome-mv3/perapera-audio-processor.js` として WXT zip にも含まれる
+- 機能: multi-channel mono 化 + 16kHz 再サンプル + 100ms バッファ + Float32→Int16 PCM + base64 → port.postMessage
+- まだ呼び出し元なし (next step で offscreen 側 AudioPreprocessor が `audioWorklet.addModule(chrome.runtime.getURL('/perapera-audio-processor.js'))` で読み込む)
+
+#### Phase 5+ Step 2: Offscreen MediaStream 受け取り + AudioPreprocessor 移管 (未着手, 規模大)
 
 - **新規**: `packages/extension/public/audio-worklet.js` (mono 化 + 16kHz 再サンプル + 100ms バッファ → postMessage)
 - **新規**: `infrastructure/audio/offscreen-audio-preprocessor.ts` — offscreen 側で `getUserMedia({chromeMediaSource: 'tab'})` + AudioWorklet 起動 + 配信
@@ -324,14 +331,15 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 
 ## 11. 変更履歴
 
-| バージョン | 日付       | 変更内容                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.1.0      | 2026-04-21 | 初版作成。Phase 0〜3 完了、Phase 4 進行中時点の整理。                                                                                                                                                                                                                                                                                                                                                                       |
-| 0.2.0      | 2026-04-22 | Phase 4 完了を反映 (IMPL-400〜451)。直近 PR 優先順位を Phase 5 presentation 層へ更新。                                                                                                                                                                                                                                                                                                                                      |
-| 0.3.0      | 2026-04-22 | Phase 3.5 Domain Repository Adapters (PR #45) 完了を反映。Phase 5 進行中へ遷移、§4 の PR 次優先順位を Background composition 起点に再構成。D1/D2/D4 決定を反映。§10 宿題の 3 件を Phase 4 成果でクローズ、Phase 5 固有の論点 3 件を追加。                                                                                                                                                                                   |
-| 0.4.0      | 2026-04-22 | Phase 5 拡張 presentation 層の PR #47〜#53 (Background composition / Popup UI / Side Panel UI / Content overlay / Offscreen+Monitor / Design tokens / Phase 5 integration gap 埋め) 完了を反映。Phase 5 進捗 ~85% へ。§4 の PR 次優先順位を残タスク (audio frame pipeline / SW→Offscreen command / session recovery / WXT zip / Phase 6 E2E) に再構成。§6 M2 チェックリスト 7/8 完了、§10 messaging schema 論点をクローズ。 |
-| 0.4.1      | 2026-04-22 | IMPL-602 Audio frame pipeline (PR #54) と IMPL-603 Orphan session cleanup (PR #55) の完了を反映。§10 "Background 多重起動時のセッション継続" 論点を "stopped 遷移" 方針でクローズ (full restore は MV3 permission 制約で MVP 外)。                                                                                                                                                                                          |
-| 0.4.2      | 2026-04-22 | IMPL-604 で Phase 6 E2E に `popup.spec.ts` / `sidepanel.spec.ts` を追加 (chrome-extension URL 直接 load → React root render 確認)。§6 M2 checklist 8 (WXT zip 配布) は実は PR #47 で達成済だったため認識を更新し M2 完了。Phase 5 残作業は SW→Offscreen audio command + AudioWorklet 実装のみ。                                                                                                                             |
-| 0.4.3      | 2026-04-22 | IMPL-605 で Phase 6 E2E に `monitor.spec.ts` を追加 (Monitor page も `web_accessible_resources` 経由で render smoke 検証)。これで chrome-extension URL 直接 load 可能な全 entrypoint (popup / sidepanel / monitor) を E2E で網羅。                                                                                                                                                                                          |
-| 0.5.0      | 2026-04-22 | Phase 5 を **M2 完了** として正式にクローズし、実 audio data routing を **Phase 5+ として分離**。§1 に IMPL 番号運用方針 (Task.md 予約番号との衝突を本 roadmap で吸収する旨) を追記。§4 に PR 次 #12 (AudioWorklet + Offscreen MediaStream) を追加し、Plan mode で慎重設計する旨を明記。§2 状態表に Phase 5+ 行を追加。                                                                                                     |
-| 0.5.1      | 2026-04-22 | IMPL-606 で Phase 5+ Step 1 (SW → Offscreen audio command sender) を実装。`OffscreenCommandSender` (application service) + `ChromeRuntimeMessageBridge` (infrastructure adapter) + start/stop UseCase 配線 + composition wiring を完了。§2 Phase 5+ ステータスを ⚪ → 🟡 ~30% に更新。Step 2 (AudioWorklet + offscreen MediaStream) は次 PR で続行。                                                                        |
+| バージョン | 日付       | 変更内容                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.1.0      | 2026-04-21 | 初版作成。Phase 0〜3 完了、Phase 4 進行中時点の整理。                                                                                                                                                                                                                                                                                                                                                                            |
+| 0.2.0      | 2026-04-22 | Phase 4 完了を反映 (IMPL-400〜451)。直近 PR 優先順位を Phase 5 presentation 層へ更新。                                                                                                                                                                                                                                                                                                                                           |
+| 0.3.0      | 2026-04-22 | Phase 3.5 Domain Repository Adapters (PR #45) 完了を反映。Phase 5 進行中へ遷移、§4 の PR 次優先順位を Background composition 起点に再構成。D1/D2/D4 決定を反映。§10 宿題の 3 件を Phase 4 成果でクローズ、Phase 5 固有の論点 3 件を追加。                                                                                                                                                                                        |
+| 0.4.0      | 2026-04-22 | Phase 5 拡張 presentation 層の PR #47〜#53 (Background composition / Popup UI / Side Panel UI / Content overlay / Offscreen+Monitor / Design tokens / Phase 5 integration gap 埋め) 完了を反映。Phase 5 進捗 ~85% へ。§4 の PR 次優先順位を残タスク (audio frame pipeline / SW→Offscreen command / session recovery / WXT zip / Phase 6 E2E) に再構成。§6 M2 チェックリスト 7/8 完了、§10 messaging schema 論点をクローズ。      |
+| 0.4.1      | 2026-04-22 | IMPL-602 Audio frame pipeline (PR #54) と IMPL-603 Orphan session cleanup (PR #55) の完了を反映。§10 "Background 多重起動時のセッション継続" 論点を "stopped 遷移" 方針でクローズ (full restore は MV3 permission 制約で MVP 外)。                                                                                                                                                                                               |
+| 0.4.2      | 2026-04-22 | IMPL-604 で Phase 6 E2E に `popup.spec.ts` / `sidepanel.spec.ts` を追加 (chrome-extension URL 直接 load → React root render 確認)。§6 M2 checklist 8 (WXT zip 配布) は実は PR #47 で達成済だったため認識を更新し M2 完了。Phase 5 残作業は SW→Offscreen audio command + AudioWorklet 実装のみ。                                                                                                                                  |
+| 0.4.3      | 2026-04-22 | IMPL-605 で Phase 6 E2E に `monitor.spec.ts` を追加 (Monitor page も `web_accessible_resources` 経由で render smoke 検証)。これで chrome-extension URL 直接 load 可能な全 entrypoint (popup / sidepanel / monitor) を E2E で網羅。                                                                                                                                                                                               |
+| 0.5.0      | 2026-04-22 | Phase 5 を **M2 完了** として正式にクローズし、実 audio data routing を **Phase 5+ として分離**。§1 に IMPL 番号運用方針 (Task.md 予約番号との衝突を本 roadmap で吸収する旨) を追記。§4 に PR 次 #12 (AudioWorklet + Offscreen MediaStream) を追加し、Plan mode で慎重設計する旨を明記。§2 状態表に Phase 5+ 行を追加。                                                                                                          |
+| 0.5.1      | 2026-04-22 | IMPL-606 で Phase 5+ Step 1 (SW → Offscreen audio command sender) を実装。`OffscreenCommandSender` (application service) + `ChromeRuntimeMessageBridge` (infrastructure adapter) + start/stop UseCase 配線 + composition wiring を完了。§2 Phase 5+ ステータスを ⚪ → 🟡 ~30% に更新。Step 2 (AudioWorklet + offscreen MediaStream) は次 PR で続行。                                                                             |
+| 0.5.2      | 2026-04-22 | IMPL-607 で Phase 5+ Step 1.5 (AudioWorklet processor JS の単体配置) を完了。`packages/extension/src/public/perapera-audio-processor.js` を追加し、WXT build / zip の output ルートに含まれることを確認。worklet 自身は呼び出し元なし (offscreen 側 AudioPreprocessor 移管が次 step)。§2 Phase 5+ ステータスを ~30% → ~50% に更新。eslint config で `src/public/**` を ignore に追加 (W3C worklet global は ts で扱えないため)。 |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,6 +31,10 @@ export default tseslint.config(
       // （将来的に e2e/tsconfig.json を切って lint 対象へ戻す）
       'packages/extension/e2e/**',
       'packages/relay-api/perf/**',
+      // AudioWorklet processor は独立 worklet コンテキスト (W3C global:
+      // sampleRate / registerProcessor / AudioWorkletProcessor) で動くため
+      // tsconfig 配下に含めず、lint も skip する
+      'packages/extension/src/public/**',
     ],
   },
 

--- a/packages/extension/src/public/perapera-audio-processor.js
+++ b/packages/extension/src/public/perapera-audio-processor.js
@@ -1,0 +1,119 @@
+/**
+ * IMPL-607 perapera-audio-processor (AudioWorkletProcessor).
+ *
+ * MV3 offscreen document の AudioContext (`audioWorklet.addModule(...)`) で
+ * register され、capture 元 (chrome.tabCapture / getUserMedia / desktopCapture)
+ * の MediaStreamTrack を `MediaStreamAudioSourceNode` 経由で受け取り、
+ * 100ms ごとに次の前処理を行って `port.postMessage` で結果を offscreen 側へ
+ * 送信する:
+ *
+ * 1. multi-channel input → mono 化 (各 channel の平均)
+ * 2. AudioContext sampleRate (例 48kHz) → 16kHz 再サンプル (drop-by-N 簡易方式)
+ * 3. 100ms バッファ (16000 * 0.1 = 1600 samples)
+ * 4. Float32 → Int16 PCM (-1〜1 を -32768〜32767 にクランプ)
+ * 5. Int16 binary → base64 文字列に encode
+ * 6. `{ type: 'audio.frame', sequenceNumber, capturedAt, durationMs, sampleRate, channels, pcm16Base64 }` を post
+ *
+ * 受信側 (offscreen-audio-host) は AudioWorkletNode の `port.onmessage` で
+ * フレームを受け取り、SW へ `chrome.runtime.sendMessage` で転送する想定。
+ * SW 側は `audioFramePump` (IMPL-602) が既に sendAudioFrame へ drain する。
+ *
+ * 設計原則 (CLAUDE.md ホットパス §):
+ * - 永続キューを挟まない (リアルタイム性最優先)
+ * - 失敗時は console.warn + 継続 (例外を throw するとプロセッサ自体が停止する)
+ *
+ * 制約:
+ * - AudioWorkletProcessor は ES Module 構文を使えるが、TypeScript は使えない
+ * - 外部 import 不可 (Worklet の独立コンテキスト)
+ * - registerProcessor の name 引数 'perapera-audio-processor' を offscreen 側と整合させる
+ */
+
+const PROCESSOR_NAME = 'perapera-audio-processor';
+const TARGET_SAMPLE_RATE_HZ = 16000;
+const FRAME_DURATION_MS = 100;
+const TARGET_FRAME_SAMPLES = (TARGET_SAMPLE_RATE_HZ * FRAME_DURATION_MS) / 1000;
+
+const floatToPcm16 = (float32) => {
+  const int16 = new Int16Array(float32.length);
+  for (let i = 0; i < float32.length; i += 1) {
+    const clamped = Math.max(-1, Math.min(1, float32[i]));
+    int16[i] = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+  }
+  return int16;
+};
+
+const int16ToBase64 = (int16) => {
+  const bytes = new Uint8Array(int16.buffer, int16.byteOffset, int16.byteLength);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  // AudioWorklet コンテキストには btoa が存在する (W3C 仕様)
+  return btoa(binary);
+};
+
+class PeraperaAudioProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._buffer = new Float32Array(TARGET_FRAME_SAMPLES);
+    this._bufferOffset = 0;
+    this._sequenceNumber = 0;
+    // sampleRate はグローバル (W3C AudioWorklet 仕様)
+    this._inputSampleRate = sampleRate;
+    this._downsampleStep = Math.max(1, Math.round(this._inputSampleRate / TARGET_SAMPLE_RATE_HZ));
+  }
+
+  /**
+   * @param {Float32Array[][]} inputs - inputs[port][channel] = Float32Array
+   * @returns {boolean} - false で processor を停止、true で継続
+   */
+  process(inputs) {
+    const input = inputs[0];
+    if (input === undefined || input.length === 0) return true;
+
+    const channelCount = input.length;
+    const frameCount = input[0]?.length ?? 0;
+    if (frameCount === 0) return true;
+
+    for (let i = 0; i < frameCount; i += this._downsampleStep) {
+      let sum = 0;
+      for (let c = 0; c < channelCount; c += 1) {
+        sum += input[c][i] ?? 0;
+      }
+      const monoSample = sum / channelCount;
+      this._buffer[this._bufferOffset] = monoSample;
+      this._bufferOffset += 1;
+
+      if (this._bufferOffset >= TARGET_FRAME_SAMPLES) {
+        this._flush();
+      }
+    }
+
+    return true;
+  }
+
+  _flush() {
+    try {
+      const pcm16 = floatToPcm16(this._buffer);
+      const pcm16Base64 = int16ToBase64(pcm16);
+      this._sequenceNumber += 1;
+      this.port.postMessage({
+        type: 'audio.frame',
+        sequenceNumber: this._sequenceNumber,
+        capturedAt: new Date().toISOString(),
+        durationMs: FRAME_DURATION_MS,
+        sampleRate: TARGET_SAMPLE_RATE_HZ,
+        channels: 1,
+        pcm16Base64,
+      });
+    } catch (cause) {
+      // Worklet コンテキストには console があるが、throw すると processor 停止
+      console.warn('[perapera-audio-processor] flush failed:', cause);
+    } finally {
+      this._buffer = new Float32Array(TARGET_FRAME_SAMPLES);
+      this._bufferOffset = 0;
+    }
+  }
+}
+
+registerProcessor(PROCESSOR_NAME, PeraperaAudioProcessor);


### PR DESCRIPTION
## Summary

- 新規 `packages/extension/src/public/perapera-audio-processor.js` — AudioWorkletProcessor 単体実装
- WXT が `<srcDir>/public/` の static asset として `chrome-mv3/perapera-audio-processor.js` に出力 (zip 含む)
- ESLint config の global ignores に `packages/extension/src/public/**` を追加 (W3C AudioWorklet global は ts で扱えないため)
- ロードマップ v0.5.2 で Phase 5+ ~30% → ~50%

## Context

Phase 5+ Step 2 (AudioWorklet + offscreen MediaStream) の前段として、まず worklet processor JS 単体を独立 PR で作成。次 PR (Step 2) で offscreen 側 AudioPreprocessor が `audioWorklet.addModule(chrome.runtime.getURL('/perapera-audio-processor.js'))` で読み込み、`getUserMedia({chromeMediaSource: 'tab'})` で取得した MediaStream を pipe する。

## Worklet 機能

1. multi-channel input → mono 化 (各 channel の平均)
2. AudioContext sampleRate (例 48kHz) → 16kHz 再サンプル (drop-by-N 簡易方式)
3. 100ms バッファ (16000 * 0.1 = 1600 samples)
4. Float32 → Int16 PCM (-1〜1 を -32768〜32767 にクランプ)
5. Int16 binary → base64 文字列に encode
6. `{ type: 'audio.frame', sequenceNumber, capturedAt, durationMs, sampleRate, channels, pcm16Base64 }` を `port.postMessage`

## Test Plan

- [x] `pnpm fmt` / `pnpm lint` / `pnpm typecheck` (root)
- [x] `pnpm --filter @perapera/extension build` — `chrome-mv3/perapera-audio-processor.js` が出力に含まれる
- [x] `pnpm --filter @perapera/extension zip` — zip 内に `perapera-audio-processor.js` を確認 (137.01 kB)
- [ ] CI 全 green
- 単体テストは worklet コンテキスト依存 (registerProcessor / sampleRate global) のため見送り。実 audio data 検証は Step 2 完了後の手動 unpacked smoke で行う

## 残 Phase 5+ Step 2

- offscreen 側 `AudioPreprocessor` 移管 (現状は SW 側 stub `createEmptyFrameChannel`)
- `chrome.tabCapture.getMediaStreamId` → offscreen `getUserMedia({chromeMediaSource: 'tab'})` の MediaStream 受け渡し
- offscreen → SW の audio frame 転送経路 (`chrome.runtime.sendMessage` で broadcast、SW 側 listener が `audioFramePump` に注入)
- 規模大のため Plan mode で慎重設計