### PR TITLE
feat(extension): IMPL-608 PCM utility extract + unit tests (Phase 5+ Step 1.6)

### DIFF
--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.5.2'
+version: '0.5.3'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -221,12 +221,19 @@ PR #47 時点で `wxt zip` script + CI `build-extension` job の `WXT zip` step 
 - start/stop UseCase 配線 + composition wiring
 - offscreen 側受信ロジック (IMPL-562) は既に存在するため、**SW → offscreen の往復が成立**
 
-#### Phase 5+ Step 1.5: AudioWorklet processor JS 配置 (✅ 完了, IMPL-607, 本 PR)
+#### Phase 5+ Step 1.5: AudioWorklet processor JS 配置 (✅ 完了, IMPL-607, PR #60)
 
 - `packages/extension/src/public/perapera-audio-processor.js` を追加
 - `chrome-mv3/perapera-audio-processor.js` として WXT zip にも含まれる
 - 機能: multi-channel mono 化 + 16kHz 再サンプル + 100ms バッファ + Float32→Int16 PCM + base64 → port.postMessage
 - まだ呼び出し元なし (next step で offscreen 側 AudioPreprocessor が `audioWorklet.addModule(chrome.runtime.getURL('/perapera-audio-processor.js'))` で読み込む)
+
+#### Phase 5+ Step 1.6: PCM utility extract + unit test (✅ 完了, IMPL-608, 本 PR)
+
+- `packages/extension/src/infrastructure/audio/pcm-utils.ts` に worklet と等価な
+  pure function (`floatToPcm16` / `int16ToBase64` / `downsampleStep` / `monoMix`) を extract
+- 17 tests で Int16 full scale / clamp / base64 round-trip / downsample step / mono mix を検証
+- 将来 offscreen 側 AudioPreprocessor や別の tool から再利用可能
 
 #### Phase 5+ Step 2: Offscreen MediaStream 受け取り + AudioPreprocessor 移管 (未着手, 規模大)
 
@@ -343,3 +350,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.5.0      | 2026-04-22 | Phase 5 を **M2 完了** として正式にクローズし、実 audio data routing を **Phase 5+ として分離**。§1 に IMPL 番号運用方針 (Task.md 予約番号との衝突を本 roadmap で吸収する旨) を追記。§4 に PR 次 #12 (AudioWorklet + Offscreen MediaStream) を追加し、Plan mode で慎重設計する旨を明記。§2 状態表に Phase 5+ 行を追加。                                                                                                          |
 | 0.5.1      | 2026-04-22 | IMPL-606 で Phase 5+ Step 1 (SW → Offscreen audio command sender) を実装。`OffscreenCommandSender` (application service) + `ChromeRuntimeMessageBridge` (infrastructure adapter) + start/stop UseCase 配線 + composition wiring を完了。§2 Phase 5+ ステータスを ⚪ → 🟡 ~30% に更新。Step 2 (AudioWorklet + offscreen MediaStream) は次 PR で続行。                                                                             |
 | 0.5.2      | 2026-04-22 | IMPL-607 で Phase 5+ Step 1.5 (AudioWorklet processor JS の単体配置) を完了。`packages/extension/src/public/perapera-audio-processor.js` を追加し、WXT build / zip の output ルートに含まれることを確認。worklet 自身は呼び出し元なし (offscreen 側 AudioPreprocessor 移管が次 step)。§2 Phase 5+ ステータスを ~30% → ~50% に更新。eslint config で `src/public/**` を ignore に追加 (W3C worklet global は ts で扱えないため)。 |
+| 0.5.3      | 2026-04-22 | IMPL-608 で Phase 5+ Step 1.6 (PCM utility extract + unit test) を完了。worklet 内 PCM 変換ロジックを `packages/extension/src/infrastructure/audio/pcm-utils.ts` に pure function として extract し、vitest で 17 tests を追加 (Int16 full scale / clamp / base64 round-trip / downsample step / mono mix)。worklet 側コメントで ts 側との同期ルールを明記。                                                                     |

--- a/packages/extension/src/infrastructure/audio/pcm-utils.test.ts
+++ b/packages/extension/src/infrastructure/audio/pcm-utils.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import {
+  downsampleStep,
+  floatToPcm16,
+  FRAME_DURATION_MS,
+  int16ToBase64,
+  monoMix,
+  TARGET_FRAME_SAMPLES,
+  TARGET_SAMPLE_RATE_HZ,
+} from './pcm-utils';
+
+describe('floatToPcm16 (IMPL-608)', () => {
+  it('converts zero samples to zero Int16', () => {
+    const input = new Float32Array([0, 0, 0]);
+    const result = floatToPcm16(input);
+    expect(Array.from(result)).toEqual([0, 0, 0]);
+  });
+
+  it('maps 1.0 to 0x7fff (positive full scale)', () => {
+    const result = floatToPcm16(new Float32Array([1.0]));
+    expect(result[0]).toBe(0x7fff);
+  });
+
+  it('maps -1.0 to -0x8000 (negative full scale)', () => {
+    const result = floatToPcm16(new Float32Array([-1.0]));
+    expect(result[0]).toBe(-0x8000);
+  });
+
+  it('clamps out-of-range samples to Int16 boundaries', () => {
+    const result = floatToPcm16(new Float32Array([2.0, -2.0, 1.5, -1.5]));
+    expect(result[0]).toBe(0x7fff);
+    expect(result[1]).toBe(-0x8000);
+    expect(result[2]).toBe(0x7fff);
+    expect(result[3]).toBe(-0x8000);
+  });
+
+  it('preserves intermediate magnitudes (0.5 ≈ 16384)', () => {
+    const result = floatToPcm16(new Float32Array([0.5, -0.5]));
+    expect(result[0]).toBe(Math.round(0.5 * 0x7fff));
+    expect(result[1]).toBe(Math.round(-0.5 * 0x8000));
+  });
+});
+
+describe('int16ToBase64 (IMPL-608)', () => {
+  it('encodes known Int16 values into base64 little-endian bytes', () => {
+    // 0x0001 (little-endian) = bytes [0x01, 0x00]
+    const input = new Int16Array([1]);
+    const encoded = int16ToBase64(input);
+    // base64 of [0x01, 0x00] = "AQA="
+    expect(encoded).toBe('AQA=');
+  });
+
+  it('round-trips through atob back to Int16', () => {
+    const samples = new Int16Array([0, 1, -1, 0x7fff, -0x8000]);
+    const encoded = int16ToBase64(samples);
+    const decoded =
+      typeof atob === 'function'
+        ? atob(encoded)
+        : Buffer.from(encoded, 'base64').toString('binary');
+    expect(decoded.length).toBe(samples.byteLength);
+    const restoredBytes = new Uint8Array(decoded.length);
+    for (let i = 0; i < decoded.length; i += 1) {
+      restoredBytes[i] = decoded.charCodeAt(i);
+    }
+    const restored = new Int16Array(restoredBytes.buffer);
+    expect(Array.from(restored)).toEqual(Array.from(samples));
+  });
+
+  it('produces empty string for empty input', () => {
+    expect(int16ToBase64(new Int16Array(0))).toBe('');
+  });
+});
+
+describe('downsampleStep (IMPL-608)', () => {
+  it('returns 3 for 48kHz → 16kHz', () => {
+    expect(downsampleStep(48000, 16000)).toBe(3);
+  });
+
+  it('returns 1 for input at or below target rate', () => {
+    expect(downsampleStep(16000, 16000)).toBe(1);
+    expect(downsampleStep(8000, 16000)).toBe(1);
+  });
+
+  it('rounds non-integer ratios', () => {
+    // 44100 / 16000 = 2.75625 → round = 3
+    expect(downsampleStep(44100, 16000)).toBe(3);
+  });
+
+  it('returns 1 for invalid inputs (defensive)', () => {
+    expect(downsampleStep(0, 16000)).toBe(1);
+    expect(downsampleStep(16000, 0)).toBe(1);
+    expect(downsampleStep(Number.NaN, 16000)).toBe(1);
+    expect(downsampleStep(-1, 16000)).toBe(1);
+  });
+});
+
+describe('monoMix (IMPL-608)', () => {
+  it('returns 0 when there are no channels', () => {
+    expect(monoMix([], 0)).toBe(0);
+  });
+
+  it('passes through single-channel sample as-is', () => {
+    const channel = new Float32Array([0.25]);
+    expect(monoMix([channel], 0)).toBe(0.25);
+  });
+
+  it('averages two-channel samples', () => {
+    const left = new Float32Array([0.4, 0.2]);
+    const right = new Float32Array([0.2, 0.8]);
+    expect(monoMix([left, right], 0)).toBeCloseTo(0.3, 5);
+    expect(monoMix([left, right], 1)).toBeCloseTo(0.5, 5);
+  });
+
+  it('treats undefined samples as 0 (out-of-bounds defensive)', () => {
+    const short = new Float32Array([0.5]);
+    expect(monoMix([short], 1)).toBe(0);
+  });
+});
+
+describe('frame constants (IMPL-608)', () => {
+  it('exposes 16kHz / 100ms = 1600 samples per frame', () => {
+    expect(TARGET_SAMPLE_RATE_HZ).toBe(16000);
+    expect(FRAME_DURATION_MS).toBe(100);
+    expect(TARGET_FRAME_SAMPLES).toBe(1600);
+  });
+});

--- a/packages/extension/src/infrastructure/audio/pcm-utils.ts
+++ b/packages/extension/src/infrastructure/audio/pcm-utils.ts
@@ -1,0 +1,75 @@
+/**
+ * IMPL-608 PCM 変換ユーティリティ関数。
+ *
+ * `perapera-audio-processor.js` (AudioWorkletProcessor) 内で使われるロジックを
+ * pure function として extract。vitest で単体テスト可能にし、将来 offscreen
+ * 側 AudioPreprocessor で再利用する余地を残す。
+ *
+ * worklet 側は独立 context (ES Module import 制限) のため、現時点では
+ * 同一ロジックを inline で持つ。本ユーティリティは TypeScript 層での
+ * duplicate reference 実装 + test fixture として機能する。
+ *
+ * 仕様:
+ * - `pcm_s16le` / mono / 16kHz (api-specification.md §3.4)
+ * - 100ms frame = 16000 * 0.1 = 1600 samples / frame
+ */
+
+/**
+ * Float32 audio samples (-1〜1) を Int16 PCM (-32768〜32767) に変換する。
+ * クランプで overflow を防ぎ、非対称な正負レンジ (Int16 は -32768〜32767) を
+ * 扱うために負側は `× 0x8000`、正側は `× 0x7fff` でスケーリングする。
+ */
+export const floatToPcm16 = (float32: Float32Array): Int16Array => {
+  const int16 = new Int16Array(float32.length);
+  for (let i = 0; i < float32.length; i += 1) {
+    const sample = float32[i] ?? 0;
+    const clamped = Math.max(-1, Math.min(1, sample));
+    int16[i] = clamped < 0 ? Math.round(clamped * 0x8000) : Math.round(clamped * 0x7fff);
+  }
+  return int16;
+};
+
+/**
+ * Int16 PCM を Base64 文字列に encode する。
+ * AudioWorklet / browser / node (vitest) すべてで動作する最小実装として
+ * Uint8Array → 8bit char → btoa を使う。
+ */
+export const int16ToBase64 = (int16: Int16Array): string => {
+  const bytes = new Uint8Array(int16.buffer, int16.byteOffset, int16.byteLength);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  if (typeof btoa === 'function') return btoa(binary);
+  // Node 20+ (vitest) には btoa グローバルがあるが、念のため fallback
+  return Buffer.from(binary, 'binary').toString('base64');
+};
+
+/**
+ * AudioContext sampleRate (例 48000) から target 16000 への
+ * drop-by-N 再サンプルステップを算出する。最低 1、それ以外は
+ * 四捨五入した正の整数。
+ */
+export const downsampleStep = (inputSampleRate: number, targetSampleRate: number): number => {
+  if (!Number.isFinite(inputSampleRate) || inputSampleRate <= 0) return 1;
+  if (!Number.isFinite(targetSampleRate) || targetSampleRate <= 0) return 1;
+  return Math.max(1, Math.round(inputSampleRate / targetSampleRate));
+};
+
+/**
+ * 多 channel サンプル配列から mono サンプルを合成 (各 channel の平均)。
+ * `channels[c][offset]` が undefined の場合は 0 として扱う。
+ */
+export const monoMix = (channels: readonly Float32Array[], offset: number): number => {
+  if (channels.length === 0) return 0;
+  let sum = 0;
+  for (const channel of channels) {
+    sum += channel[offset] ?? 0;
+  }
+  return sum / channels.length;
+};
+
+/** 100ms フレームの target サンプル数 (16kHz 固定) */
+export const TARGET_SAMPLE_RATE_HZ = 16000;
+export const FRAME_DURATION_MS = 100;
+export const TARGET_FRAME_SAMPLES = (TARGET_SAMPLE_RATE_HZ * FRAME_DURATION_MS) / 1000;

--- a/packages/extension/src/public/perapera-audio-processor.js
+++ b/packages/extension/src/public/perapera-audio-processor.js
@@ -26,6 +26,12 @@
  * - AudioWorkletProcessor は ES Module 構文を使えるが、TypeScript は使えない
  * - 外部 import 不可 (Worklet の独立コンテキスト)
  * - registerProcessor の name 引数 'perapera-audio-processor' を offscreen 側と整合させる
+ *
+ * ロジック等価物の TypeScript 実装は
+ * `packages/extension/src/infrastructure/audio/pcm-utils.ts` (IMPL-608) に
+ * extract されており vitest で単体テスト済。worklet context は ES Module
+ * import 制限のため本ファイル内で inline 複製する。ロジックを変更する際は
+ * 両方を同期させること。
  */
 
 const PROCESSOR_NAME = 'perapera-audio-processor';


### PR DESCRIPTION
## Summary

- `packages/extension/src/infrastructure/audio/pcm-utils.ts` に worklet 内 PCM 変換ロジックを pure function として extract
- `pcm-utils.test.ts` で 17 ケースの単体テスト (Int16 full scale / clamp / base64 round-trip / downsample step / mono mix)
- worklet 側にコメントで ts 側との同期ルールを明記
- ロードマップ v0.5.3

## Context

Phase 5+ Step 1.5 (IMPL-607) で配置した `perapera-audio-processor.js` は AudioWorklet 独立コンテキストのため TypeScript / vitest で直接テストできない。本 PR で pure 関数を ts 側に extract し、契約としてのテストを追加。将来 offscreen 側 `AudioPreprocessor` からも `pcm-utils` を直接 import して再利用可能にした。

## Test Plan

- [x] `pnpm fmt` / `pnpm lint` / `pnpm typecheck` (root)
- [x] `pnpm --filter @perapera/extension test` — 863 tests passing (+17 新規)
- [x] `pnpm --filter @perapera/extension build` — smoke 済
- [ ] CI 全 green