### PR TITLE
feat(extension): IMPL-609 TabCaptureApi.getMediaStreamId (Phase 5+ Step 2a)

### DIFF
--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.5.3'
+version: '0.5.4'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -31,7 +31,7 @@ author: 'Codex'
 | 3.5   | Domain Repository Adapters (IMPL-140〜143)                | ✅ 完了 (#45)                                        |
 | 4     | Relay API (IMPL-400〜451)                                 | ✅ 完了                                              |
 | 5     | 拡張 presentation 層 (IMPL-500〜605)                      | ✅ M2 完了 (実 audio data 転送は Phase 5+ へ分離)    |
-| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~50% (sender + AudioWorklet processor 配置完了)   |
+| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~60% (sender + worklet + tabCapture streamId API) |
 | 6     | E2E / 性能 / 品質検証                                     | 🟡 開始 (page render smoke 4/5 完了, golden path 未) |
 | 7     | リリース / 運用整備                                       | ⚪ 未着手                                            |
 
@@ -228,12 +228,20 @@ PR #47 時点で `wxt zip` script + CI `build-extension` job の `WXT zip` step 
 - 機能: multi-channel mono 化 + 16kHz 再サンプル + 100ms バッファ + Float32→Int16 PCM + base64 → port.postMessage
 - まだ呼び出し元なし (next step で offscreen 側 AudioPreprocessor が `audioWorklet.addModule(chrome.runtime.getURL('/perapera-audio-processor.js'))` で読み込む)
 
-#### Phase 5+ Step 1.6: PCM utility extract + unit test (✅ 完了, IMPL-608, 本 PR)
+#### Phase 5+ Step 1.6: PCM utility extract + unit test (✅ 完了, IMPL-608, PR #61)
 
 - `packages/extension/src/infrastructure/audio/pcm-utils.ts` に worklet と等価な
   pure function (`floatToPcm16` / `int16ToBase64` / `downsampleStep` / `monoMix`) を extract
 - 17 tests で Int16 full scale / clamp / base64 round-trip / downsample step / mono mix を検証
 - 将来 offscreen 側 AudioPreprocessor や別の tool から再利用可能
+
+#### Phase 5+ Step 2a: TabCaptureApi.getMediaStreamId 追加 (✅ 完了, IMPL-609, 本 PR)
+
+- `TabCaptureApi` 型に `getMediaStreamId(options): Promise<string>` を追加
+- `defaultTabCaptureApi` に `chrome.tabCapture.getMediaStreamId` の Promise wrap 実装
+  (callback + lastError + empty id の防御検査を含む)
+- まだ SourceAdapter からは呼ばれない (Step 2b で offscreen 側配線と同時に接続)
+- test contract: getMediaStreamId が非空文字列を返すことを assert
 
 #### Phase 5+ Step 2: Offscreen MediaStream 受け取り + AudioPreprocessor 移管 (未着手, 規模大)
 
@@ -351,3 +359,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.5.1      | 2026-04-22 | IMPL-606 で Phase 5+ Step 1 (SW → Offscreen audio command sender) を実装。`OffscreenCommandSender` (application service) + `ChromeRuntimeMessageBridge` (infrastructure adapter) + start/stop UseCase 配線 + composition wiring を完了。§2 Phase 5+ ステータスを ⚪ → 🟡 ~30% に更新。Step 2 (AudioWorklet + offscreen MediaStream) は次 PR で続行。                                                                             |
 | 0.5.2      | 2026-04-22 | IMPL-607 で Phase 5+ Step 1.5 (AudioWorklet processor JS の単体配置) を完了。`packages/extension/src/public/perapera-audio-processor.js` を追加し、WXT build / zip の output ルートに含まれることを確認。worklet 自身は呼び出し元なし (offscreen 側 AudioPreprocessor 移管が次 step)。§2 Phase 5+ ステータスを ~30% → ~50% に更新。eslint config で `src/public/**` を ignore に追加 (W3C worklet global は ts で扱えないため)。 |
 | 0.5.3      | 2026-04-22 | IMPL-608 で Phase 5+ Step 1.6 (PCM utility extract + unit test) を完了。worklet 内 PCM 変換ロジックを `packages/extension/src/infrastructure/audio/pcm-utils.ts` に pure function として extract し、vitest で 17 tests を追加 (Int16 full scale / clamp / base64 round-trip / downsample step / mono mix)。worklet 側コメントで ts 側との同期ルールを明記。                                                                     |
+| 0.5.4      | 2026-04-22 | IMPL-609 で Phase 5+ Step 2a (TabCaptureApi.getMediaStreamId 追加) を完了。`chrome.tabCapture.getMediaStreamId` を Promise wrap した production adapter と test contract を追加。まだ SourceAdapter からは呼ばれない (Step 2b で offscreen 側 MediaStream 受け取り配線と同時に接続)。§2 Phase 5+ ステータスを ~50% → ~60% に更新。                                                                                               |

--- a/packages/extension/src/composition/extension-composition.test.ts
+++ b/packages/extension/src/composition/extension-composition.test.ts
@@ -81,7 +81,10 @@ const createTestPorts = (overrides: Partial<ExtensionRuntimePorts> = {}): Extens
     ),
     overlayMessagingBridge: { send: vi.fn(() => Promise.resolve()) },
     chromeRuntimeApi: { sendMessage: vi.fn(() => Promise.resolve(undefined)) },
-    tabCaptureApi: { capture: vi.fn(() => Promise.resolve(null)) },
+    tabCaptureApi: {
+      capture: vi.fn(() => Promise.resolve(null)),
+      getMediaStreamId: vi.fn(() => Promise.resolve('stream-id-fixture')),
+    },
     userMediaApi: { getUserMedia: vi.fn(() => Promise.reject(new Error('not implemented'))) },
     desktopCaptureApi: {
       getDisplayMedia: vi.fn(() => Promise.reject(new Error('not implemented'))),

--- a/packages/extension/src/infrastructure/capture/tab-capture-source-adapter.test.ts
+++ b/packages/extension/src/infrastructure/capture/tab-capture-source-adapter.test.ts
@@ -19,10 +19,14 @@ const buildCommand = (overrides: Partial<StartSourceCommand> = {}): StartSourceC
 
 const buildApi = (): TabCaptureApi & {
   capture: ReturnType<typeof vi.fn<TabCaptureApi['capture']>>;
+  getMediaStreamId: ReturnType<typeof vi.fn<TabCaptureApi['getMediaStreamId']>>;
 } => {
   const stream = new MediaStream();
   const capture = vi.fn<TabCaptureApi['capture']>(() => Promise.resolve(stream));
-  return { capture };
+  const getMediaStreamId = vi.fn<TabCaptureApi['getMediaStreamId']>(() =>
+    Promise.resolve('stream-id-fixture'),
+  );
+  return { capture, getMediaStreamId };
 };
 
 describe('createTabCaptureSourceAdapter (IMPL-300, DD-101)', () => {
@@ -51,6 +55,7 @@ describe('createTabCaptureSourceAdapter (IMPL-300, DD-101)', () => {
   it('returns invariant-violation when capture returns null (tab no longer audible)', async () => {
     const api: TabCaptureApi = {
       capture: () => Promise.resolve(null),
+      getMediaStreamId: () => Promise.resolve('stream-id-fixture'),
     };
     const adapter = createTabCaptureSourceAdapter({ tabCaptureApi: api });
     const result = await adapter.open(buildCommand());
@@ -61,6 +66,7 @@ describe('createTabCaptureSourceAdapter (IMPL-300, DD-101)', () => {
   it('returns invariant-violation when the api throws (e.g., chrome.runtime.lastError)', async () => {
     const api: TabCaptureApi = {
       capture: () => Promise.reject(new Error('Tab is not currently being captured')),
+      getMediaStreamId: () => Promise.resolve('stream-id-fixture'),
     };
     const adapter = createTabCaptureSourceAdapter({ tabCaptureApi: api });
     const result = await adapter.open(buildCommand());
@@ -77,7 +83,10 @@ describe('createTabCaptureSourceAdapter (IMPL-300, DD-101)', () => {
     const stop = vi.fn();
     const stream = new MediaStream();
     addFakeTrack(stream, { stop });
-    const api: TabCaptureApi = { capture: () => Promise.resolve(stream) };
+    const api: TabCaptureApi = {
+      capture: () => Promise.resolve(stream),
+      getMediaStreamId: () => Promise.resolve('stream-id-fixture'),
+    };
     const adapter = createTabCaptureSourceAdapter({ tabCaptureApi: api });
     await adapter.open(buildCommand());
     const result = await adapter.close(sessionIdentifier);
@@ -90,5 +99,15 @@ describe('createTabCaptureSourceAdapter (IMPL-300, DD-101)', () => {
     const adapter = createTabCaptureSourceAdapter({ tabCaptureApi: api });
     const result = await adapter.close(sessionIdentifier);
     expect(result.isOk()).toBe(true);
+  });
+
+  // IMPL-609 TabCaptureApi extension — getMediaStreamId は SourceAdapter からは
+  // まだ呼ばれない (次 PR で offscreen 側 MediaStream 受け取り配線と同時に
+  // 利用を開始する)。本 test は API 契約が確保されていることを保証する。
+  it('TabCaptureApi exposes getMediaStreamId producing non-empty stream id (contract)', async () => {
+    const api = buildApi();
+    const streamId = await api.getMediaStreamId({ targetTabId: 42 });
+    expect(streamId).toBe('stream-id-fixture');
+    expect(api.getMediaStreamId).toHaveBeenCalledWith({ targetTabId: 42 });
   });
 });

--- a/packages/extension/src/infrastructure/capture/tab-capture-source-adapter.ts
+++ b/packages/extension/src/infrastructure/capture/tab-capture-source-adapter.ts
@@ -7,12 +7,22 @@ import {
 } from '../../application/ports/source-adapter';
 
 /**
- * `chrome.tabCapture.capture` を最小 contract で抽象化した adapter。
+ * `chrome.tabCapture` を最小 contract で抽象化した adapter。
  * production では callback を Promise に wrap した default 実装、test では
  * mock を注入する。
+ *
+ * - `capture`: SW 側で MediaStream を直接取得する従来経路 (MV3 SW では
+ *   実用上動作しないが、既存の SourceAdapter API 互換のため維持)
+ * - `getMediaStreamId` (IMPL-609): `targetTabId` 指定で stream identifier
+ *   文字列を取得する経路。取得した id を offscreen document に postMessage
+ *   で渡し、offscreen 側で `navigator.mediaDevices.getUserMedia({ audio: {
+ *   mandatory: { chromeMediaSource: 'tab', chromeMediaSourceId: id } } })`
+ *   を呼ぶことで、AudioContext が使えるコンテキストで MediaStream を確保
+ *   できる。MV3 で実 audio data を Relay まで流す唯一の実用的な経路
  */
 export type TabCaptureApi = {
   capture: (options: chrome.tabCapture.CaptureOptions) => Promise<MediaStream | null>;
+  getMediaStreamId: (options: chrome.tabCapture.GetMediaStreamOptions) => Promise<string>;
 };
 
 /**
@@ -30,6 +40,25 @@ export const defaultTabCaptureApi: TabCaptureApi = {
             return;
           }
           resolve(stream);
+        });
+      } catch (cause) {
+        reject(cause instanceof Error ? cause : new Error(String(cause)));
+      }
+    }),
+  getMediaStreamId: (options) =>
+    new Promise<string>((resolve, reject) => {
+      try {
+        chrome.tabCapture.getMediaStreamId(options, (streamId) => {
+          const lastError = chrome.runtime.lastError;
+          if (lastError !== undefined) {
+            reject(new Error(lastError.message ?? 'unknown getMediaStreamId error'));
+            return;
+          }
+          if (streamId === undefined || streamId === '') {
+            reject(new Error('chrome.tabCapture.getMediaStreamId returned empty id'));
+            return;
+          }
+          resolve(streamId);
         });
       } catch (cause) {
         reject(cause instanceof Error ? cause : new Error(String(cause)));


### PR DESCRIPTION
## Summary

- `TabCaptureApi` 型に `getMediaStreamId(options): Promise<string>` を追加
- `defaultTabCaptureApi` に `chrome.tabCapture.getMediaStreamId` の Promise wrap 実装
- 既存テスト mock 拡張 + 新規 contract test

## Context

MV3 Service Worker は MediaStream を直接扱えないため、実 audio routing は offscreen 側で `navigator.mediaDevices.getUserMedia({chromeMediaSource: 'tab', chromeMediaSourceId: <streamId>})` を呼ぶ方式が必要。その streamId を SW 側で取得するための API として `chrome.tabCapture.getMediaStreamId` を Promise wrap する。

本 PR 時点では `TabCaptureSourceAdapter.open()` からはまだ呼ばれない (Step 2b で offscreen 側 MediaStream 受け取り配線と同時に接続)。

## Test Plan

- [x] `pnpm fmt` / `pnpm lint` / `pnpm typecheck` (root)
- [x] `pnpm --filter @perapera/extension test` — 864 tests passing (+1 contract test)
- [ ] CI 全 green