### PR TITLE
feat(extension): IMPL-610 audio.open tabStreamId field (Phase 5+ Step 2b-1)

### DIFF
--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.5.4'
+version: '0.5.5'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -31,7 +31,7 @@ author: 'Codex'
 | 3.5   | Domain Repository Adapters (IMPL-140〜143)                | ✅ 完了 (#45)                                        |
 | 4     | Relay API (IMPL-400〜451)                                 | ✅ 完了                                              |
 | 5     | 拡張 presentation 層 (IMPL-500〜605)                      | ✅ M2 完了 (実 audio data 転送は Phase 5+ へ分離)    |
-| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~60% (sender + worklet + tabCapture streamId API) |
+| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~65% (audio.open message に tabStreamId 追加完了) |
 | 6     | E2E / 性能 / 品質検証                                     | 🟡 開始 (page render smoke 4/5 完了, golden path 未) |
 | 7     | リリース / 運用整備                                       | ⚪ 未着手                                            |
 
@@ -235,13 +235,21 @@ PR #47 時点で `wxt zip` script + CI `build-extension` job の `WXT zip` step 
 - 17 tests で Int16 full scale / clamp / base64 round-trip / downsample step / mono mix を検証
 - 将来 offscreen 側 AudioPreprocessor や別の tool から再利用可能
 
-#### Phase 5+ Step 2a: TabCaptureApi.getMediaStreamId 追加 (✅ 完了, IMPL-609, 本 PR)
+#### Phase 5+ Step 2a: TabCaptureApi.getMediaStreamId 追加 (✅ 完了, IMPL-609, PR #62)
 
 - `TabCaptureApi` 型に `getMediaStreamId(options): Promise<string>` を追加
 - `defaultTabCaptureApi` に `chrome.tabCapture.getMediaStreamId` の Promise wrap 実装
   (callback + lastError + empty id の防御検査を含む)
 - まだ SourceAdapter からは呼ばれない (Step 2b で offscreen 側配線と同時に接続)
 - test contract: getMediaStreamId が非空文字列を返すことを assert
+
+#### Phase 5+ Step 2b-1: audio.open message に tabStreamId 追加 (✅ 完了, IMPL-610, 本 PR)
+
+- `offscreen-commands.ts` の `audioOpenSchema` / `OffscreenCommand` / `parseOffscreenCommand` に
+  optional `tabStreamId: string` field を追加
+- `OffscreenCommandSender.openAudioContext` の options に `tabStreamId` を追加
+- schema / type / sender / parser の 4 箇所で整合性保証 + 既存 test + 新規 contract test 4 件
+- offscreen 側はまだ streamId を参照しない (Step 2b-2 で `getUserMedia` 呼び出し実装)
 
 #### Phase 5+ Step 2: Offscreen MediaStream 受け取り + AudioPreprocessor 移管 (未着手, 規模大)
 
@@ -360,3 +368,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.5.2      | 2026-04-22 | IMPL-607 で Phase 5+ Step 1.5 (AudioWorklet processor JS の単体配置) を完了。`packages/extension/src/public/perapera-audio-processor.js` を追加し、WXT build / zip の output ルートに含まれることを確認。worklet 自身は呼び出し元なし (offscreen 側 AudioPreprocessor 移管が次 step)。§2 Phase 5+ ステータスを ~30% → ~50% に更新。eslint config で `src/public/**` を ignore に追加 (W3C worklet global は ts で扱えないため)。 |
 | 0.5.3      | 2026-04-22 | IMPL-608 で Phase 5+ Step 1.6 (PCM utility extract + unit test) を完了。worklet 内 PCM 変換ロジックを `packages/extension/src/infrastructure/audio/pcm-utils.ts` に pure function として extract し、vitest で 17 tests を追加 (Int16 full scale / clamp / base64 round-trip / downsample step / mono mix)。worklet 側コメントで ts 側との同期ルールを明記。                                                                     |
 | 0.5.4      | 2026-04-22 | IMPL-609 で Phase 5+ Step 2a (TabCaptureApi.getMediaStreamId 追加) を完了。`chrome.tabCapture.getMediaStreamId` を Promise wrap した production adapter と test contract を追加。まだ SourceAdapter からは呼ばれない (Step 2b で offscreen 側 MediaStream 受け取り配線と同時に接続)。§2 Phase 5+ ステータスを ~50% → ~60% に更新。                                                                                               |
+| 0.5.5      | 2026-04-22 | IMPL-610 で Phase 5+ Step 2b-1 (audio.open message に tabStreamId 追加) を完了。`offscreen-commands.ts` の schema / type / parser と `OffscreenCommandSender.openAudioContext` の options に optional `tabStreamId: string` を追加。offscreen 側は受信のみで参照なし (Step 2b-2 で `getUserMedia({chromeMediaSource: 'tab'})` 呼び出しを実装)。§2 Phase 5+ ステータスを ~60% → ~65% に更新。                                     |

--- a/packages/extension/src/application/services/offscreen-command-sender.test.ts
+++ b/packages/extension/src/application/services/offscreen-command-sender.test.ts
@@ -45,6 +45,36 @@ describe('createOffscreenCommandSender (IMPL-606)', () => {
     });
   });
 
+  it('passes through optional tabStreamId when provided (IMPL-610)', async () => {
+    const bridge = buildBridge();
+    const sender = createOffscreenCommandSender({ bridge });
+
+    await sender.openAudioContext(identifier, { tabStreamId: 'tab-stream-id-fixture' });
+
+    expect(bridge.sendMessage).toHaveBeenCalledWith({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: SESSION_ID,
+      tabStreamId: 'tab-stream-id-fixture',
+    });
+  });
+
+  it('combines sampleRateHz and tabStreamId when both provided', async () => {
+    const bridge = buildBridge();
+    const sender = createOffscreenCommandSender({ bridge });
+
+    await sender.openAudioContext(identifier, {
+      sampleRateHz: 48000,
+      tabStreamId: 'tab-stream-id-fixture',
+    });
+
+    expect(bridge.sendMessage).toHaveBeenCalledWith({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: SESSION_ID,
+      sampleRateHz: 48000,
+      tabStreamId: 'tab-stream-id-fixture',
+    });
+  });
+
   it('sends audio.close with sessionIdentifier', async () => {
     const bridge = buildBridge();
     const sender = createOffscreenCommandSender({ bridge });

--- a/packages/extension/src/application/services/offscreen-command-sender.ts
+++ b/packages/extension/src/application/services/offscreen-command-sender.ts
@@ -26,10 +26,16 @@ export type RuntimeMessageBridge = Readonly<{
 }>;
 
 export type OffscreenCommandSender = Readonly<{
-  /** Session に対する AudioContext を offscreen 側で確保 */
+  /**
+   * Session に対する AudioContext を offscreen 側で確保。
+   * `tabStreamId` (IMPL-610) を渡すと offscreen 側が
+   * `getUserMedia({chromeMediaSource: 'tab', chromeMediaSourceId: tabStreamId})`
+   * で MediaStream を確保する。tab 以外では省略 (microphone / desktop は
+   * offscreen 側で別経路を使う)。
+   */
   openAudioContext: (
     sessionIdentifier: SessionIdentifier,
-    options?: Readonly<{ sampleRateHz?: number }>,
+    options?: Readonly<{ sampleRateHz?: number; tabStreamId?: string }>,
   ) => ResultAsync<void, DomainError>;
   /** Session に対する AudioContext を破棄 */
   closeAudioContext: (sessionIdentifier: SessionIdentifier) => ResultAsync<void, DomainError>;
@@ -46,12 +52,15 @@ export const createOffscreenCommandSender = (
 ): OffscreenCommandSender => {
   return {
     openAudioContext: (sessionIdentifier, options) => {
-      const sampleRateHz = options?.sampleRateHz;
-      const command: OffscreenCommand =
-        sampleRateHz !== undefined
-          ? { type: 'offscreen.audio.open', sessionIdentifier, sampleRateHz }
-          : { type: 'offscreen.audio.open', sessionIdentifier };
-      return deps.bridge.sendMessage(command);
+      const base: {
+        type: 'offscreen.audio.open';
+        sessionIdentifier: SessionIdentifier;
+        sampleRateHz?: number;
+        tabStreamId?: string;
+      } = { type: 'offscreen.audio.open', sessionIdentifier };
+      if (options?.sampleRateHz !== undefined) base.sampleRateHz = options.sampleRateHz;
+      if (options?.tabStreamId !== undefined) base.tabStreamId = options.tabStreamId;
+      return deps.bridge.sendMessage(base satisfies OffscreenCommand);
     },
     closeAudioContext: (sessionIdentifier) =>
       deps.bridge.sendMessage({ type: 'offscreen.audio.close', sessionIdentifier }),

--- a/packages/extension/src/entrypoints/offscreen/offscreen-commands.test.ts
+++ b/packages/extension/src/entrypoints/offscreen/offscreen-commands.test.ts
@@ -34,6 +34,27 @@ describe('parseOffscreenCommand (IMPL-560)', () => {
     }
   });
 
+  it('parses offscreen.audio.open with tabStreamId (IMPL-610)', () => {
+    const result = parseOffscreenCommand({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: SESSION_ID,
+      tabStreamId: 'tab-stream-id-fixture',
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && result.value.type === 'offscreen.audio.open') {
+      expect(result.value.tabStreamId).toBe('tab-stream-id-fixture');
+    }
+  });
+
+  it('rejects offscreen.audio.open with empty tabStreamId', () => {
+    const result = parseOffscreenCommand({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: SESSION_ID,
+      tabStreamId: '',
+    });
+    expect(result.isErr()).toBe(true);
+  });
+
   it('parses offscreen.audio.close', () => {
     const result = parseOffscreenCommand({
       type: 'offscreen.audio.close',

--- a/packages/extension/src/entrypoints/offscreen/offscreen-commands.ts
+++ b/packages/extension/src/entrypoints/offscreen/offscreen-commands.ts
@@ -27,6 +27,14 @@ const audioOpenSchema = z.object({
   sessionIdentifier: z.string().min(1),
   /** AudioContext のサンプルレート (default 16000) */
   sampleRateHz: z.number().int().positive().optional(),
+  /**
+   * `chrome.tabCapture.getMediaStreamId` で取得した stream id。
+   * IMPL-610: offscreen 側で `navigator.mediaDevices.getUserMedia({
+   *   audio: { mandatory: { chromeMediaSource: 'tab', chromeMediaSourceId: tabStreamId } }
+   * })` を呼び MediaStream を確保するのに必要。tab source 以外では省略 (microphone は
+   * offscreen 側で deviceId ベースの getUserMedia を直接呼ぶ設計)。
+   */
+  tabStreamId: z.string().min(1).optional(),
 });
 
 const audioCloseSchema = z.object({
@@ -49,6 +57,7 @@ export type OffscreenCommand =
       type: 'offscreen.audio.open';
       sessionIdentifier: SessionIdentifier;
       sampleRateHz?: number;
+      tabStreamId?: string;
     }>
   | Readonly<{ type: 'offscreen.audio.close'; sessionIdentifier: SessionIdentifier }>
   | Readonly<{ type: 'offscreen.ping' }>;
@@ -69,15 +78,15 @@ export const parseOffscreenCommand = (raw: unknown): Result<OffscreenCommand, Do
       return ok<OffscreenCommand, DomainError>({ type: 'offscreen.ping' });
     case 'offscreen.audio.open':
       return parseSessionIdentifier(data.sessionIdentifier).map((sessionIdentifier) => {
-        const command: OffscreenCommand =
-          data.sampleRateHz !== undefined
-            ? {
-                type: 'offscreen.audio.open',
-                sessionIdentifier,
-                sampleRateHz: data.sampleRateHz,
-              }
-            : { type: 'offscreen.audio.open', sessionIdentifier };
-        return command;
+        const base: {
+          type: 'offscreen.audio.open';
+          sessionIdentifier: SessionIdentifier;
+          sampleRateHz?: number;
+          tabStreamId?: string;
+        } = { type: 'offscreen.audio.open', sessionIdentifier };
+        if (data.sampleRateHz !== undefined) base.sampleRateHz = data.sampleRateHz;
+        if (data.tabStreamId !== undefined) base.tabStreamId = data.tabStreamId;
+        return base satisfies OffscreenCommand;
       });
     case 'offscreen.audio.close':
       return parseSessionIdentifier(data.sessionIdentifier).map(


### PR DESCRIPTION
## Summary

- `offscreen-commands.ts` の `audioOpenSchema` / `OffscreenCommand` / `parseOffscreenCommand` に optional `tabStreamId: string` を追加
- `OffscreenCommandSender.openAudioContext` の options に `tabStreamId` を追加
- 既存 test に tabStreamId パススルー / 空文字列 reject / sampleRateHz と併用 の 4 ケース追加
- ロードマップ v0.5.5 (Phase 5+ ~65%)

## Context

MV3 offscreen document で MediaStream を確保するには `chrome.tabCapture.getMediaStreamId` の戻り値 streamId を `navigator.mediaDevices.getUserMedia({chromeMediaSource: 'tab', chromeMediaSourceId: streamId})` に渡す必要がある。

- PR #62 (IMPL-609) で streamId 取得経路 (`TabCaptureApi.getMediaStreamId`) を整備
- 本 PR (IMPL-610) で SW → offscreen の message envelope に streamId を乗せる仕組みを追加
- Step 2b-2 で offscreen 側が `audio.open` 受信時に streamId を使って MediaStream を確保する実装を追加

schema / type / parser / sender の 4 箇所で整合性保証。offscreen 側は受信のみで参照なし (未配線)。

## Test Plan

- [x] `pnpm fmt` / `pnpm lint` / `pnpm typecheck` (root)
- [x] `pnpm --filter @perapera/extension test` — 868 tests passing (+4 新規)
- [ ] CI 全 green