### PR TITLE
feat(extension): IMPL-615 WorkletNodeFactory port + adapter (Phase 5+ Step 2d-2a)

### DIFF
--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.5.9'
+version: '0.5.10'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -31,7 +31,7 @@ author: 'Codex'
 | 3.5   | Domain Repository Adapters (IMPL-140〜143)                | ✅ 完了 (#45)                                        |
 | 4     | Relay API (IMPL-400〜451)                                 | ✅ 完了                                              |
 | 5     | 拡張 presentation 層 (IMPL-500〜605)                      | ✅ M2 完了 (実 audio data 転送は Phase 5+ へ分離)    |
-| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~88% (AudioWorklet module 読込配線完了)           |
+| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~90% (WorkletNodeFactory port + adapter 追加)     |
 | 6     | E2E / 性能 / 品質検証                                     | 🟡 開始 (page render smoke 4/5 完了, golden path 未) |
 | 7     | リリース / 運用整備                                       | ⚪ 未着手                                            |
 
@@ -283,13 +283,22 @@ PR #47 時点で `wxt zip` script + CI `build-extension` job の `WXT zip` step 
 - composition で `createChromeTabStreamIdResolver(ports.tabCaptureApi)` を注入
 - 既存 test mock に resolver を追加 + 新規 contract (resolve 呼び出し + tabStreamId 付き openAudioContext)
 
-#### Phase 5+ Step 2d-1: offscreen-audio-host で AudioWorklet module 読込 (✅ 完了, IMPL-614, 本 PR)
+#### Phase 5+ Step 2d-1: offscreen-audio-host で AudioWorklet module 読込 (✅ 完了, IMPL-614, PR #67)
 
 - `OffscreenAudioHostDependencies` に optional `workletModuleUrl` を追加
 - `openEntry` 時に `context.audioWorklet.addModule(workletModuleUrl)` を呼び出し、成功/失敗をログ
 - `offscreen/main.ts` で `chrome.runtime.getURL('/perapera-audio-processor.js')` を注入
 - 3 新規 tests (addModule 呼び出し / rejection で warn + context 維持 / workletModuleUrl 未注入で skip)
 - 次の Step 2d-2 で MediaStream と AudioWorkletNode を接続 (MediaStreamAudioSourceNode 作成)
+
+#### Phase 5+ Step 2d-2a: WorkletNodeFactory port + adapter (✅ 完了, IMPL-615, 本 PR)
+
+- 新規 `packages/extension/src/infrastructure/audio/worklet-node-factory.ts`
+- `AudioWorkletNodeLike` 型 (port.onmessage / connect / disconnect の minimal contract)
+- `WorkletNodeFactory = (context, processorName) => AudioWorkletNodeLike` port
+- `defaultWorkletNodeFactory` — `new AudioWorkletNode(context, processorName)` を wrap (production)
+- 3 unit tests (factory surface / port onmessage 代入可能 / disconnect 呼び出し)
+- 本 PR 時点では offscreen-audio-host からは呼ばれない (Step 2d-2b で MediaStream 接続と同時に配線)
 
 #### Phase 5+ Step 2: Offscreen MediaStream 受け取り + AudioPreprocessor 移管 (未着手, 規模大)
 
@@ -413,3 +422,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.5.7      | 2026-04-22 | IMPL-612 で Phase 5+ Step 2b-2b (offscreen-audio-host に TabStreamApi 配線) を完了。`offscreen-audio-host.ts` に optional `tabStreamApi` 依存を追加し、tabStreamId 付き `audio.open` 受信時に MediaStream を取得・保持、close で tracks stop。`offscreen/main.ts` で `defaultTabStreamApi` を注入。race condition guard + 4 新規 tests (acquire / close tracks stop / acquire Err で context 維持 / tabStreamApi 未注入で後方互換)。§2 Phase 5+ を ~70% → ~80% に。                                            |
 | 0.5.8      | 2026-04-22 | IMPL-613 で Phase 5+ Step 2c (SW UseCase で streamId 解決 → offscreen に転送) を完了。`TabStreamIdResolver` port + `createChromeTabStreamIdResolver` adapter を追加し、`StartSourceSessionUseCase` の granted path で tab source のとき `overlayTarget.tabId` を使って streamId を解決、`offscreenCommandSender.openAudioContext` の `tabStreamId` に乗せる。失敗時は warn して streamId なしで継続 (後方互換)。composition で wiring、既存 test mock + 2 新規 contract tests。§2 Phase 5+ を ~80% → ~85% に。 |
 | 0.5.9      | 2026-04-22 | IMPL-614 で Phase 5+ Step 2d-1 (offscreen-audio-host で AudioWorklet module 読込) を完了。`OffscreenAudioHostDependencies` に optional `workletModuleUrl` を追加し、`audio.open` 受信で `context.audioWorklet.addModule(workletModuleUrl)` を呼ぶ。`offscreen/main.ts` で `chrome.runtime.getURL('/perapera-audio-processor.js')` を注入。3 新規 tests。§2 Phase 5+ を ~85% → ~88% に。                                                                                                                        |
+| 0.5.10     | 2026-04-22 | IMPL-615 で Phase 5+ Step 2d-2a (WorkletNodeFactory port + adapter) を完了。`AudioWorkletNodeLike` 型 (port.onmessage / connect / disconnect) + `WorkletNodeFactory` port + `defaultWorkletNodeFactory` (`new AudioWorkletNode` wrap) を追加。3 unit tests。本 PR 時点では offscreen-audio-host から未配線 (Step 2d-2b で MediaStream 接続と同時に接続)。§2 Phase 5+ を ~88% → ~90% に。                                                                                                                       |

--- a/packages/extension/src/infrastructure/audio/worklet-node-factory.test.ts
+++ b/packages/extension/src/infrastructure/audio/worklet-node-factory.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type AudioContextLike } from './audio-preprocessor';
+import { type AudioWorkletNodeLike, type WorkletNodeFactory } from './worklet-node-factory';
+
+const buildFakeContext = (): AudioContextLike => ({
+  sampleRate: 16000,
+  audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
+  close: vi.fn(() => Promise.resolve()),
+  createMediaStreamSource: vi.fn(() => ({})),
+});
+
+const buildFakeWorkletNode = (): AudioWorkletNodeLike => {
+  const connect = vi.fn();
+  const disconnect = vi.fn();
+  return {
+    port: { onmessage: null },
+    connect,
+    disconnect,
+  };
+};
+
+describe('WorkletNodeFactory contract (IMPL-615)', () => {
+  it('factory returns node with port / connect / disconnect surface', () => {
+    const context = buildFakeContext();
+    const fakeNode = buildFakeWorkletNode();
+    const factory: WorkletNodeFactory = vi.fn(() => fakeNode);
+
+    const node = factory(context, 'perapera-audio-processor');
+
+    expect(factory).toHaveBeenCalledWith(context, 'perapera-audio-processor');
+    expect(node.port).toBeDefined();
+    expect(node.connect).toBeTypeOf('function');
+    expect(node.disconnect).toBeTypeOf('function');
+  });
+
+  it('node supports onmessage assignment (frame listener wiring)', () => {
+    const node = buildFakeWorkletNode();
+    // AudioWorkletNodeLike.port.onmessage は readonly ではない実用上の挙動を
+    // structural に検査 (production / test 両方で代入可能であること)
+    const listener = vi.fn();
+    Object.defineProperty(node.port, 'onmessage', {
+      configurable: true,
+      writable: true,
+      value: listener,
+    });
+    expect(node.port.onmessage).toBe(listener);
+  });
+
+  it('disconnect can be called (stub no-op)', () => {
+    const node = buildFakeWorkletNode();
+    node.disconnect();
+    expect(node.disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/extension/src/infrastructure/audio/worklet-node-factory.ts
+++ b/packages/extension/src/infrastructure/audio/worklet-node-factory.ts
@@ -1,0 +1,46 @@
+import { type AudioContextLike } from './audio-preprocessor';
+
+/**
+ * IMPL-615 AudioWorkletNode abstraction (offscreen 側 port)。
+ *
+ * `AudioWorkletNode` の最小 contract。実装側で必要な property のみを列挙し、
+ * test で minimal stub を注入できるようにする。production の
+ * `AudioWorkletNode` は structurally に本 interface を満たす。
+ *
+ * - `port.onmessage`: worklet processor からの postMessage を受ける
+ *   (次 Step 2d-3 で frame 受信 callback を設定)
+ * - `connect` / `disconnect`: MediaStreamAudioSourceNode 等の destination に接続
+ */
+export type AudioWorkletNodeLike = {
+  readonly port: Readonly<{
+    onmessage: ((event: MessageEvent<unknown>) => void) | null;
+  }>;
+  connect: (destination: AudioNode) => void;
+  disconnect: () => void;
+};
+
+/**
+ * WorkletNode factory port。offscreen-audio-host から DI 経由で呼ばれる。
+ * production では `new AudioWorkletNode(context, processorName)` を wrap。
+ * test では fake を注入する。
+ */
+export type WorkletNodeFactory = (
+  context: AudioContextLike,
+  processorName: string,
+) => AudioWorkletNodeLike;
+
+/**
+ * Production `WorkletNodeFactory`。`context` は `AudioContext` 実体である前提で
+ * `new AudioWorkletNode(context, processorName)` を呼ぶ。
+ *
+ * 注: `AudioContextLike` は structural type だが、`new AudioWorkletNode` の
+ * 第 1 引数は `BaseAudioContext` が必要。production は AudioContext 実体が
+ * 必ず注入される (defaultAudioContextFactory 経由)。offscreen でのみ使われるため。
+ */
+export const defaultWorkletNodeFactory: WorkletNodeFactory = (context, processorName) => {
+  // production: AudioContext 実体 (AudioContextLike の supertype) を前提
+  // test の fake では本 factory を呼ばず、専用 stub factory を注入する
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const ctx = context as unknown as BaseAudioContext;
+  return new AudioWorkletNode(ctx, processorName);
+};


### PR DESCRIPTION
## Summary

- 新規 `packages/extension/src/infrastructure/audio/worklet-node-factory.ts`
- `AudioWorkletNodeLike` 型 (port.onmessage / connect / disconnect)
- `WorkletNodeFactory` port + `defaultWorkletNodeFactory` (`new AudioWorkletNode` wrap)
- 3 unit tests (factory / onmessage 代入 / disconnect 呼び出し)
- ロードマップ v0.5.10 (Phase 5+ ~90%)

## Context

Step 2d-1 (IMPL-614) で AudioWorklet module 読込 (`addModule`) を配線した。本 PR で offscreen-audio-host から AudioWorkletNode を作成するための port を準備。次 Step 2d-2b で MediaStreamAudioSourceNode と組み合わせて実際に接続する。

## Test Plan

- [x] `pnpm fmt` / `pnpm lint` / `pnpm typecheck` (root)
- [x] `pnpm --filter @perapera/extension test` — 884 tests passing (+3 新規)
- [ ] CI 全 green