### PR TITLE
feat(extension): IMPL-616 offscreen MediaStream + AudioWorkletNode 接続 (Phase 5+ Step 2d-2b)

### DIFF
--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.5.10'
+version: '0.5.11'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -22,18 +22,18 @@ author: 'Codex'
 
 ## 2. 現状サマリ (2026-04-22)
 
-| Phase | 範囲                                                      | 状態                                                 |
-| ----- | --------------------------------------------------------- | ---------------------------------------------------- |
-| 0     | 着手前合意 (IMPL-001〜005)                                | ✅ 完了                                              |
-| 1     | ドメイン層 (IMPL-101〜153)                                | ✅ 完了                                              |
-| 2     | アプリケーション層 (IMPL-200〜230)                        | ✅ 完了                                              |
-| 3     | 拡張 infrastructure (IMPL-300〜344)                       | ✅ 完了                                              |
-| 3.5   | Domain Repository Adapters (IMPL-140〜143)                | ✅ 完了 (#45)                                        |
-| 4     | Relay API (IMPL-400〜451)                                 | ✅ 完了                                              |
-| 5     | 拡張 presentation 層 (IMPL-500〜605)                      | ✅ M2 完了 (実 audio data 転送は Phase 5+ へ分離)    |
-| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~90% (WorkletNodeFactory port + adapter 追加)     |
-| 6     | E2E / 性能 / 品質検証                                     | 🟡 開始 (page render smoke 4/5 完了, golden path 未) |
-| 7     | リリース / 運用整備                                       | ⚪ 未着手                                            |
+| Phase | 範囲                                                      | 状態                                                  |
+| ----- | --------------------------------------------------------- | ----------------------------------------------------- |
+| 0     | 着手前合意 (IMPL-001〜005)                                | ✅ 完了                                               |
+| 1     | ドメイン層 (IMPL-101〜153)                                | ✅ 完了                                               |
+| 2     | アプリケーション層 (IMPL-200〜230)                        | ✅ 完了                                               |
+| 3     | 拡張 infrastructure (IMPL-300〜344)                       | ✅ 完了                                               |
+| 3.5   | Domain Repository Adapters (IMPL-140〜143)                | ✅ 完了 (#45)                                         |
+| 4     | Relay API (IMPL-400〜451)                                 | ✅ 完了                                               |
+| 5     | 拡張 presentation 層 (IMPL-500〜605)                      | ✅ M2 完了 (実 audio data 転送は Phase 5+ へ分離)     |
+| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~95% (MediaStream + AudioWorkletNode 接続まで配線) |
+| 6     | E2E / 性能 / 品質検証                                     | 🟡 開始 (page render smoke 4/5 完了, golden path 未)  |
+| 7     | リリース / 運用整備                                       | ⚪ 未着手                                             |
 
 ### Phase 5 拡張 presentation 層 内訳 (PR #47〜#53, 2026-04-22 時点)
 
@@ -291,7 +291,7 @@ PR #47 時点で `wxt zip` script + CI `build-extension` job の `WXT zip` step 
 - 3 新規 tests (addModule 呼び出し / rejection で warn + context 維持 / workletModuleUrl 未注入で skip)
 - 次の Step 2d-2 で MediaStream と AudioWorkletNode を接続 (MediaStreamAudioSourceNode 作成)
 
-#### Phase 5+ Step 2d-2a: WorkletNodeFactory port + adapter (✅ 完了, IMPL-615, 本 PR)
+#### Phase 5+ Step 2d-2a: WorkletNodeFactory port + adapter (✅ 完了, IMPL-615, PR #68)
 
 - 新規 `packages/extension/src/infrastructure/audio/worklet-node-factory.ts`
 - `AudioWorkletNodeLike` 型 (port.onmessage / connect / disconnect の minimal contract)
@@ -299,6 +299,17 @@ PR #47 時点で `wxt zip` script + CI `build-extension` job の `WXT zip` step 
 - `defaultWorkletNodeFactory` — `new AudioWorkletNode(context, processorName)` を wrap (production)
 - 3 unit tests (factory surface / port onmessage 代入可能 / disconnect 呼び出し)
 - 本 PR 時点では offscreen-audio-host からは呼ばれない (Step 2d-2b で MediaStream 接続と同時に配線)
+
+#### Phase 5+ Step 2d-2b: offscreen-audio-host で MediaStream + AudioWorkletNode 接続 (✅ 完了, IMPL-616, 本 PR)
+
+- `offscreen-audio-host.ts` に optional `workletNodeFactory` / `workletProcessorName` 依存追加
+- MediaStream 取得 + addModule 完了を Promise で同期 (addModule 失敗時は false 返して unhandled rejection 回避)
+- `context.createMediaStreamSource(mediaStream)` で SourceNode、`workletNodeFactory(context, 'perapera-audio-processor')` で WorkletNode を作成し、`source.connect(worklet)` で接続
+- close 時に source / worklet の disconnect → tracks stop → context close を順次実行
+- `hasWorkletConnected(sessionId)` API 追加 (test / smoke 用)
+- `offscreen/main.ts` で `defaultWorkletNodeFactory` を注入 (production wiring)
+- 2 新規 tests (MediaStream + WorkletNode 接続 / close で disconnect)
+- 残 Step 2d-3: worklet port.onmessage で frame を受信 → chrome.runtime.sendMessage で SW へ転送
 
 #### Phase 5+ Step 2: Offscreen MediaStream 受け取り + AudioPreprocessor 移管 (未着手, 規模大)
 
@@ -423,3 +434,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.5.8      | 2026-04-22 | IMPL-613 で Phase 5+ Step 2c (SW UseCase で streamId 解決 → offscreen に転送) を完了。`TabStreamIdResolver` port + `createChromeTabStreamIdResolver` adapter を追加し、`StartSourceSessionUseCase` の granted path で tab source のとき `overlayTarget.tabId` を使って streamId を解決、`offscreenCommandSender.openAudioContext` の `tabStreamId` に乗せる。失敗時は warn して streamId なしで継続 (後方互換)。composition で wiring、既存 test mock + 2 新規 contract tests。§2 Phase 5+ を ~80% → ~85% に。 |
 | 0.5.9      | 2026-04-22 | IMPL-614 で Phase 5+ Step 2d-1 (offscreen-audio-host で AudioWorklet module 読込) を完了。`OffscreenAudioHostDependencies` に optional `workletModuleUrl` を追加し、`audio.open` 受信で `context.audioWorklet.addModule(workletModuleUrl)` を呼ぶ。`offscreen/main.ts` で `chrome.runtime.getURL('/perapera-audio-processor.js')` を注入。3 新規 tests。§2 Phase 5+ を ~85% → ~88% に。                                                                                                                        |
 | 0.5.10     | 2026-04-22 | IMPL-615 で Phase 5+ Step 2d-2a (WorkletNodeFactory port + adapter) を完了。`AudioWorkletNodeLike` 型 (port.onmessage / connect / disconnect) + `WorkletNodeFactory` port + `defaultWorkletNodeFactory` (`new AudioWorkletNode` wrap) を追加。3 unit tests。本 PR 時点では offscreen-audio-host から未配線 (Step 2d-2b で MediaStream 接続と同時に接続)。§2 Phase 5+ を ~88% → ~90% に。                                                                                                                       |
+| 0.5.11     | 2026-04-22 | IMPL-616 で Phase 5+ Step 2d-2b (offscreen-audio-host で MediaStream + AudioWorkletNode 接続) を完了。`workletNodeFactory` 依存追加、`createMediaStreamSource(mediaStream)` + `workletNodeFactory(ctx, name)` + `source.connect(worklet)` の audio graph 構築を実装。addModule 失敗時は Promise<boolean> で resolve (unhandled rejection 回避)。close 時に disconnect → tracks stop → context close。`offscreen/main.ts` で `defaultWorkletNodeFactory` を注入。2 新規 tests。§2 Phase 5+ を ~90% → ~95% に。  |

--- a/packages/extension/src/entrypoints/offscreen/main.ts
+++ b/packages/extension/src/entrypoints/offscreen/main.ts
@@ -1,5 +1,6 @@
 import { defaultAudioContextFactory } from '../../infrastructure/audio/audio-preprocessor';
 import { defaultTabStreamApi } from '../../infrastructure/audio/tab-stream-api';
+import { defaultWorkletNodeFactory } from '../../infrastructure/audio/worklet-node-factory';
 import { createOffscreenAudioHost } from './offscreen-audio-host';
 import { parseOffscreenCommand } from './offscreen-commands';
 
@@ -31,6 +32,7 @@ const host = createOffscreenAudioHost({
   audioContextFactory: defaultAudioContextFactory,
   tabStreamApi: defaultTabStreamApi,
   workletModuleUrl: WORKLET_MODULE_URL,
+  workletNodeFactory: defaultWorkletNodeFactory,
 });
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {

--- a/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.test.ts
+++ b/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.test.ts
@@ -290,7 +290,10 @@ describe('createOffscreenAudioHost (IMPL-561)', () => {
       sampleRate: 16000,
       audioWorklet: { addModule },
       close: vi.fn(() => Promise.resolve()),
-      createMediaStreamSource: vi.fn(() => ({})),
+      createMediaStreamSource: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      })),
       closeFn: vi.fn(),
     };
     const factory = vi.fn<AudioContextFactory>(() => context);
@@ -299,5 +302,89 @@ describe('createOffscreenAudioHost (IMPL-561)', () => {
     host.dispatch({ type: 'offscreen.audio.open', sessionIdentifier: identifierA });
 
     expect(addModule).not.toHaveBeenCalled();
+  });
+
+  // IMPL-616: MediaStream + WorkletNode 接続
+  it('connects MediaStreamAudioSourceNode → AudioWorkletNode when all deps injected', async () => {
+    const sourceNode = { connect: vi.fn(), disconnect: vi.fn() };
+    const workletNode = {
+      port: { onmessage: null },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    const createMediaStreamSource = vi.fn(() => sourceNode);
+    const context = {
+      sampleRate: 16000,
+      audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
+      close: vi.fn(() => Promise.resolve()),
+      createMediaStreamSource,
+    };
+    const factory = vi.fn<AudioContextFactory>(() => context);
+    const mediaStream = new MediaStream();
+    const workletNodeFactory = vi.fn(() => workletNode);
+
+    const host = createOffscreenAudioHost({
+      audioContextFactory: factory,
+      workletModuleUrl: '/perapera-audio-processor.js',
+      tabStreamApi: { acquire: vi.fn(() => okAsync<MediaStream, DomainError>(mediaStream)) },
+      workletNodeFactory,
+    });
+
+    host.dispatch({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: identifierA,
+      tabStreamId: 'tab-stream-id-fixture',
+    });
+    // addModule + acquire 両方の microtask を flush
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(createMediaStreamSource).toHaveBeenCalledWith(mediaStream);
+    expect(workletNodeFactory).toHaveBeenCalledWith(context, 'perapera-audio-processor');
+    expect(sourceNode.connect).toHaveBeenCalledWith(workletNode);
+    expect(host.hasWorkletConnected(identifierA)).toBe(true);
+  });
+
+  it('disconnects source / worklet on close (IMPL-616)', async () => {
+    const sourceNode = { connect: vi.fn(), disconnect: vi.fn() };
+    const workletNode = {
+      port: { onmessage: null },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    const context = {
+      sampleRate: 16000,
+      audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
+      close: vi.fn(() => Promise.resolve()),
+      createMediaStreamSource: vi.fn(() => sourceNode),
+    };
+    const factory = vi.fn<AudioContextFactory>(() => context);
+    const mediaStream = new MediaStream();
+    const host = createOffscreenAudioHost({
+      audioContextFactory: factory,
+      workletModuleUrl: '/perapera-audio-processor.js',
+      tabStreamApi: { acquire: vi.fn(() => okAsync<MediaStream, DomainError>(mediaStream)) },
+      workletNodeFactory: vi.fn(() => workletNode),
+    });
+
+    host.dispatch({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: identifierA,
+      tabStreamId: 'tab-stream-id-fixture',
+    });
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    host.dispatch({ type: 'offscreen.audio.close', sessionIdentifier: identifierA });
+
+    expect(sourceNode.disconnect).toHaveBeenCalledOnce();
+    expect(workletNode.disconnect).toHaveBeenCalledOnce();
   });
 });

--- a/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.ts
+++ b/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.ts
@@ -3,6 +3,10 @@ import {
   type AudioContextLike,
 } from '../../infrastructure/audio/audio-preprocessor';
 import { type TabStreamApi } from '../../infrastructure/audio/tab-stream-api';
+import {
+  type AudioWorkletNodeLike,
+  type WorkletNodeFactory,
+} from '../../infrastructure/audio/worklet-node-factory';
 import { describeDomainError } from '../../domain/shared/errors';
 import { type SessionIdentifier } from '../../domain/session/session-identifier';
 import { type OffscreenCommand } from './offscreen-commands';
@@ -32,6 +36,8 @@ export type OffscreenAudioHost = Readonly<{
   has: (sessionIdentifier: SessionIdentifier) => boolean;
   /** sessionId に対する MediaStream が現在確保されているか (test/smoke 用) */
   hasStream: (sessionIdentifier: SessionIdentifier) => boolean;
+  /** sessionId に対する AudioWorkletNode が接続済か (test/smoke 用, IMPL-616) */
+  hasWorkletConnected: (sessionIdentifier: SessionIdentifier) => boolean;
   /** 登録中の全 AudioContext + MediaStream を破棄 (entry shutdown 用) */
   dispose: () => void;
 }>;
@@ -52,6 +58,17 @@ export type OffscreenAudioHostDependencies = Readonly<{
    * 未指定の場合は addModule を呼ばない (後方互換)。
    */
   workletModuleUrl?: string;
+  /**
+   * Optional。`tabStreamApi` + `workletModuleUrl` と揃って注入された場合、
+   * addModule 完了 + MediaStream 取得後に本 factory で AudioWorkletNode を
+   * 作成し、`MediaStreamAudioSourceNode.connect(workletNode)` で接続する
+   * (IMPL-616)。frame port.onmessage の配線は後続 step で実装。
+   *
+   * 未指定の場合は MediaStream だけを保持 (後方互換)。
+   */
+  workletNodeFactory?: WorkletNodeFactory;
+  /** Worklet processor 名 (default `'perapera-audio-processor'`) */
+  workletProcessorName?: string;
   /** 操作のログ sink。既定は console */
   logger?: Readonly<{
     debug: (message: string) => void;
@@ -69,11 +86,51 @@ const DEFAULT_LOGGER = {
 };
 
 const DEFAULT_SAMPLE_RATE = 16000 as const;
+const DEFAULT_WORKLET_PROCESSOR_NAME = 'perapera-audio-processor';
+
+/**
+ * source node は Web Audio API の standard AudioNode 実装 (production の
+ * `MediaStreamAudioSourceNode`)。structural type で connect / disconnect の
+ * minimal contract のみ表現。offscreen-audio-host 内でのみ利用。
+ */
+type SourceNodeLike = Readonly<{
+  connect: (destination: unknown) => void;
+  disconnect: () => void;
+}>;
 
 type ActiveEntry = Readonly<{
   context: AudioContextLike;
   mediaStream?: MediaStream;
+  sourceNode?: SourceNodeLike;
+  workletNode?: AudioWorkletNodeLike;
+  /**
+   * addModule の結果。resolve 型は `boolean` (成功 true / 失敗 false)。
+   * rejection を握りつぶして unhandled rejection を防ぐ設計。
+   */
+  workletModuleReadyPromise?: Promise<boolean>;
 }>;
+
+/**
+ * `context.createMediaStreamSource` の戻り値 (型: unknown) を SourceNodeLike
+ * に narrowing。production では MediaStreamAudioSourceNode (AudioNode) が
+ * 返され、connect/disconnect を持つため安全に呼べる。
+ */
+const asSourceNode = (raw: unknown): SourceNodeLike => {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new TypeError(
+      '[perapera] offscreen-audio-host: createMediaStreamSource returned a non-object value',
+    );
+  }
+  const connect: unknown = Reflect.get(raw, 'connect');
+  const disconnect: unknown = Reflect.get(raw, 'disconnect');
+  if (typeof connect !== 'function' || typeof disconnect !== 'function') {
+    throw new TypeError(
+      '[perapera] offscreen-audio-host: createMediaStreamSource returned an object without connect/disconnect',
+    );
+  }
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return raw as SourceNodeLike;
+};
 
 const hasStopMethod = (value: unknown): value is { stop: () => void } => {
   if (typeof value !== 'object' || value === null) return false;
@@ -93,6 +150,30 @@ export const createOffscreenAudioHost = (
   const entries = new Map<SessionIdentifier, ActiveEntry>();
   const logger = deps.logger ?? DEFAULT_LOGGER;
 
+  const connectWorklet = (sessionIdentifier: SessionIdentifier, mediaStream: MediaStream): void => {
+    if (deps.workletNodeFactory === undefined) return;
+    const entry = entries.get(sessionIdentifier);
+    if (entry === undefined) return;
+    try {
+      const sourceNode = asSourceNode(entry.context.createMediaStreamSource(mediaStream));
+      const workletNode = deps.workletNodeFactory(
+        entry.context,
+        deps.workletProcessorName ?? DEFAULT_WORKLET_PROCESSOR_NAME,
+      );
+      sourceNode.connect(workletNode);
+      entries.set(sessionIdentifier, { ...entry, sourceNode, workletNode });
+      logger.debug(
+        `[perapera] offscreen-audio-host connected MediaStreamAudioSourceNode → AudioWorkletNode for ${sessionIdentifier}`,
+      );
+    } catch (cause) {
+      logger.warn(
+        `[perapera] offscreen-audio-host worklet connect failed for ${sessionIdentifier}: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      );
+    }
+  };
+
   const attachMediaStream = (sessionIdentifier: SessionIdentifier, tabStreamId: string): void => {
     if (deps.tabStreamApi === undefined) {
       logger.debug(
@@ -104,8 +185,7 @@ export const createOffscreenAudioHost = (
     if (existing === undefined) return;
     void deps.tabStreamApi.acquire(tabStreamId).match(
       (mediaStream) => {
-        // openContext と同期処理の間に close が入る可能性を考えて、取得時点の
-        // 既存 entry をもう一度確認する
+        // acquire 完了までの間に close が入った可能性を確認
         const current = entries.get(sessionIdentifier);
         if (current === undefined || current !== existing) {
           stopAllTracks(mediaStream);
@@ -118,6 +198,19 @@ export const createOffscreenAudioHost = (
         logger.debug(
           `[perapera] offscreen-audio-host attached MediaStream for ${sessionIdentifier} (tracks=${String(mediaStream.getTracks().length)})`,
         );
+        // worklet 接続は addModule 完了後 (成功時のみ)
+        const workletReadyPromise = current.workletModuleReadyPromise;
+        if (workletReadyPromise !== undefined) {
+          void workletReadyPromise.then((success) => {
+            if (!success) return;
+            // 再度 entry 存在確認 (close 可能性)
+            const afterModule = entries.get(sessionIdentifier);
+            if (afterModule === undefined) return;
+            connectWorklet(sessionIdentifier, mediaStream);
+          });
+        } else {
+          connectWorklet(sessionIdentifier, mediaStream);
+        }
       },
       (error) => {
         logger.warn(
@@ -133,6 +226,21 @@ export const createOffscreenAudioHost = (
     const entry = entries.get(sessionIdentifier);
     if (entry === undefined) return;
     entries.delete(sessionIdentifier);
+    // Worklet / source の disconnect を先に呼んで audio graph を切る
+    if (entry.sourceNode !== undefined) {
+      try {
+        entry.sourceNode.disconnect();
+      } catch {
+        /* すでに disconnect 済など — 無視 */
+      }
+    }
+    if (entry.workletNode !== undefined) {
+      try {
+        entry.workletNode.disconnect();
+      } catch {
+        /* すでに disconnect 済など — 無視 */
+      }
+    }
     if (entry.mediaStream !== undefined) {
       stopAllTracks(entry.mediaStream);
     }
@@ -160,27 +268,35 @@ export const createOffscreenAudioHost = (
       const context = deps.audioContextFactory({
         sampleRate: sampleRateHz ?? DEFAULT_SAMPLE_RATE,
       });
-      entries.set(sessionIdentifier, { context });
-      logger.debug(
-        `[perapera] offscreen-audio-host opened AudioContext for ${sessionIdentifier} (sampleRate=${String(context.sampleRate)})`,
-      );
+      let workletModuleReadyPromise: Promise<boolean> | undefined;
       if (deps.workletModuleUrl !== undefined) {
         const moduleUrl = deps.workletModuleUrl;
-        void context.audioWorklet.addModule(moduleUrl).then(
-          () => {
+        workletModuleReadyPromise = context.audioWorklet.addModule(moduleUrl).then(
+          (): boolean => {
             logger.debug(
               `[perapera] offscreen-audio-host registered AudioWorklet module for ${sessionIdentifier}: ${moduleUrl}`,
             );
+            return true;
           },
-          (cause: unknown) => {
+          (cause: unknown): boolean => {
             logger.warn(
               `[perapera] offscreen-audio-host addModule failed for ${sessionIdentifier}: ${
                 cause instanceof Error ? cause.message : String(cause)
               }`,
             );
+            return false;
           },
         );
       }
+      entries.set(
+        sessionIdentifier,
+        workletModuleReadyPromise !== undefined
+          ? { context, workletModuleReadyPromise }
+          : { context },
+      );
+      logger.debug(
+        `[perapera] offscreen-audio-host opened AudioContext for ${sessionIdentifier} (sampleRate=${String(context.sampleRate)})`,
+      );
       if (tabStreamId !== undefined) {
         attachMediaStream(sessionIdentifier, tabStreamId);
       }
@@ -209,6 +325,8 @@ export const createOffscreenAudioHost = (
     },
     has: (sessionIdentifier) => entries.has(sessionIdentifier),
     hasStream: (sessionIdentifier) => entries.get(sessionIdentifier)?.mediaStream !== undefined,
+    hasWorkletConnected: (sessionIdentifier) =>
+      entries.get(sessionIdentifier)?.workletNode !== undefined,
     dispose: () => {
       for (const [sessionIdentifier] of entries) {
         closeEntry(sessionIdentifier);

--- a/packages/extension/src/infrastructure/audio/worklet-node-factory.ts
+++ b/packages/extension/src/infrastructure/audio/worklet-node-factory.ts
@@ -3,13 +3,14 @@ import { type AudioContextLike } from './audio-preprocessor';
 /**
  * IMPL-615 AudioWorkletNode abstraction (offscreen 側 port)。
  *
- * `AudioWorkletNode` の最小 contract。実装側で必要な property のみを列挙し、
- * test で minimal stub を注入できるようにする。production の
- * `AudioWorkletNode` は structurally に本 interface を満たす。
+ * `AudioWorkletNode` の最小 contract。production の `AudioWorkletNode` は
+ * structurally に本 interface を満たす。
  *
  * - `port.onmessage`: worklet processor からの postMessage を受ける
  *   (次 Step 2d-3 で frame 受信 callback を設定)
- * - `connect` / `disconnect`: MediaStreamAudioSourceNode 等の destination に接続
+ * - `connect` / `disconnect`: audio graph の接続 / 切断
+ *
+ * 接続は offscreen-audio-host 内の安全な wrapper (`unknown` 経由) で行う。
  */
 export type AudioWorkletNodeLike = {
   readonly port: Readonly<{


### PR DESCRIPTION
## Summary

- `offscreen-audio-host.ts` で `audio.open` 受信 → MediaStream 取得 → AudioWorklet module register → `MediaStreamAudioSourceNode → AudioWorkletNode` 接続まで audio graph を構築
- addModule 失敗時は Promise<boolean> で resolve して unhandled rejection を回避
- close 時に source / worklet disconnect → tracks stop → context close の順で解放
- `offscreen/main.ts` で `defaultWorkletNodeFactory` を production 注入
- `hasWorkletConnected(sessionId)` API 追加 (test / smoke 用)
- 2 新規 tests (接続成功 / close で disconnect)
- ロードマップ v0.5.11 (Phase 5+ ~95%)

## Context

本 PR で **SW → offscreen → MediaStream → AudioWorkletNode** のすべてが実装され、worklet processor に実音声 samples が流れ始める状態に到達。残るは worklet port.onmessage で受信した frame を `chrome.runtime.sendMessage` で SW に転送する経路 (Step 2d-3)。

## Test Plan

- [x] `pnpm fmt` / `pnpm lint` / `pnpm typecheck` (root)
- [x] `pnpm --filter @perapera/extension test` — 886 tests passing (+2 新規)
- [x] `pnpm --filter @perapera/extension build` — smoke OK
- [ ] CI 全 green