### PR TITLE
feat(extension): IMPL-617 forward worklet frames to SW (Phase 5+ Step 2d-3)

### DIFF
--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.5.11'
+version: '0.5.12'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -31,7 +31,7 @@ author: 'Codex'
 | 3.5   | Domain Repository Adapters (IMPL-140〜143)                | ✅ 完了 (#45)                                         |
 | 4     | Relay API (IMPL-400〜451)                                 | ✅ 完了                                               |
 | 5     | 拡張 presentation 層 (IMPL-500〜605)                      | ✅ M2 完了 (実 audio data 転送は Phase 5+ へ分離)     |
-| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~95% (MediaStream + AudioWorkletNode 接続まで配線) |
+| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~98% (offscreen→SW frame 転送完了、残 SW receiver) |
 | 6     | E2E / 性能 / 品質検証                                     | 🟡 開始 (page render smoke 4/5 完了, golden path 未)  |
 | 7     | リリース / 運用整備                                       | ⚪ 未着手                                             |
 
@@ -311,6 +311,16 @@ PR #47 時点で `wxt zip` script + CI `build-extension` job の `WXT zip` step 
 - 2 新規 tests (MediaStream + WorkletNode 接続 / close で disconnect)
 - 残 Step 2d-3: worklet port.onmessage で frame を受信 → chrome.runtime.sendMessage で SW へ転送
 
+#### Phase 5+ Step 2d-3: worklet port.onmessage で frame 受信 + SW 転送 (✅ 完了, IMPL-617, 本 PR)
+
+- `AudioWorkletNodeLike.port` を mutable に (port 自体は readonly、`port.onmessage` は代入可)
+- `OffscreenAudioHostDependencies` に optional `onAudioFrame(sessionId, data)` callback を追加
+- `connectWorklet` で worklet を接続した直後に `workletNode.port.onmessage = (event) => onAudioFrame(sessionId, event.data)` を設定
+- callback throw を try/catch で吸収 (listener は外れない)
+- `offscreen/main.ts` で `chrome.runtime.sendMessage({ type: 'audio.frame.forward', sessionIdentifier, data })` に転送する callback を注入
+- 2 新規 tests (frame forward / callback throw catching)
+- 残 Step 2d-4: SW で `audio.frame.forward` を受信 → audioFramePump に流す receiver を実装
+
 #### Phase 5+ Step 2: Offscreen MediaStream 受け取り + AudioPreprocessor 移管 (未着手, 規模大)
 
 - **新規**: `packages/extension/public/audio-worklet.js` (mono 化 + 16kHz 再サンプル + 100ms バッファ → postMessage)
@@ -435,3 +445,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.5.9      | 2026-04-22 | IMPL-614 で Phase 5+ Step 2d-1 (offscreen-audio-host で AudioWorklet module 読込) を完了。`OffscreenAudioHostDependencies` に optional `workletModuleUrl` を追加し、`audio.open` 受信で `context.audioWorklet.addModule(workletModuleUrl)` を呼ぶ。`offscreen/main.ts` で `chrome.runtime.getURL('/perapera-audio-processor.js')` を注入。3 新規 tests。§2 Phase 5+ を ~85% → ~88% に。                                                                                                                        |
 | 0.5.10     | 2026-04-22 | IMPL-615 で Phase 5+ Step 2d-2a (WorkletNodeFactory port + adapter) を完了。`AudioWorkletNodeLike` 型 (port.onmessage / connect / disconnect) + `WorkletNodeFactory` port + `defaultWorkletNodeFactory` (`new AudioWorkletNode` wrap) を追加。3 unit tests。本 PR 時点では offscreen-audio-host から未配線 (Step 2d-2b で MediaStream 接続と同時に接続)。§2 Phase 5+ を ~88% → ~90% に。                                                                                                                       |
 | 0.5.11     | 2026-04-22 | IMPL-616 で Phase 5+ Step 2d-2b (offscreen-audio-host で MediaStream + AudioWorkletNode 接続) を完了。`workletNodeFactory` 依存追加、`createMediaStreamSource(mediaStream)` + `workletNodeFactory(ctx, name)` + `source.connect(worklet)` の audio graph 構築を実装。addModule 失敗時は Promise<boolean> で resolve (unhandled rejection 回避)。close 時に disconnect → tracks stop → context close。`offscreen/main.ts` で `defaultWorkletNodeFactory` を注入。2 新規 tests。§2 Phase 5+ を ~90% → ~95% に。  |
+| 0.5.12     | 2026-04-22 | IMPL-617 で Phase 5+ Step 2d-3 (worklet port.onmessage で frame 受信 + SW 転送) を完了。`AudioWorkletNodeLike.port` を mutable 化し、`OffscreenAudioHost` に `onAudioFrame` callback 依存を追加、`connectWorklet` 内で `port.onmessage` listener を設定。callback throw は try/catch で吸収。`offscreen/main.ts` で `chrome.runtime.sendMessage({type:'audio.frame.forward',...})` を転送として注入。2 新規 tests。§2 Phase 5+ を ~95% → ~98% に。                                                             |

--- a/packages/extension/src/entrypoints/offscreen/main.ts
+++ b/packages/extension/src/entrypoints/offscreen/main.ts
@@ -33,6 +33,22 @@ const host = createOffscreenAudioHost({
   tabStreamApi: defaultTabStreamApi,
   workletModuleUrl: WORKLET_MODULE_URL,
   workletNodeFactory: defaultWorkletNodeFactory,
+  // IMPL-617: worklet frame を SW へ転送。chrome.runtime.sendMessage で
+  // broadcast し、SW の audio.frame.forward listener が audioFramePump に流す。
+  onAudioFrame: (sessionIdentifier, data) => {
+    void chrome.runtime
+      .sendMessage({
+        type: 'audio.frame.forward',
+        sessionIdentifier,
+        data,
+      })
+      .catch((cause: unknown) => {
+        console.warn(
+          '[perapera] offscreen audio.frame.forward sendMessage failed:',
+          cause instanceof Error ? cause.message : String(cause),
+        );
+      });
+  },
 });
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {

--- a/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.test.ts
+++ b/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.test.ts
@@ -5,6 +5,7 @@ import {
   type AudioContextFactory,
 } from '../../infrastructure/audio/audio-preprocessor';
 import { type TabStreamApi } from '../../infrastructure/audio/tab-stream-api';
+import { type AudioWorkletNodeLike } from '../../infrastructure/audio/worklet-node-factory';
 import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
 import {
   parseSessionIdentifier,
@@ -307,7 +308,7 @@ describe('createOffscreenAudioHost (IMPL-561)', () => {
   // IMPL-616: MediaStream + WorkletNode 接続
   it('connects MediaStreamAudioSourceNode → AudioWorkletNode when all deps injected', async () => {
     const sourceNode = { connect: vi.fn(), disconnect: vi.fn() };
-    const workletNode = {
+    const workletNode: AudioWorkletNodeLike = {
       port: { onmessage: null },
       connect: vi.fn(),
       disconnect: vi.fn(),
@@ -351,7 +352,7 @@ describe('createOffscreenAudioHost (IMPL-561)', () => {
 
   it('disconnects source / worklet on close (IMPL-616)', async () => {
     const sourceNode = { connect: vi.fn(), disconnect: vi.fn() };
-    const workletNode = {
+    const workletNode: AudioWorkletNodeLike = {
       port: { onmessage: null },
       connect: vi.fn(),
       disconnect: vi.fn(),
@@ -386,5 +387,109 @@ describe('createOffscreenAudioHost (IMPL-561)', () => {
 
     expect(sourceNode.disconnect).toHaveBeenCalledOnce();
     expect(workletNode.disconnect).toHaveBeenCalledOnce();
+  });
+
+  // IMPL-617: worklet port.onmessage で frame を受け、onAudioFrame callback へ転送
+  it('forwards AudioWorkletNode port.onmessage payload via onAudioFrame (IMPL-617)', async () => {
+    const workletNode: AudioWorkletNodeLike = {
+      port: { onmessage: null },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    const sourceNode = { connect: vi.fn(), disconnect: vi.fn() };
+    const context = {
+      sampleRate: 16000,
+      audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
+      close: vi.fn(() => Promise.resolve()),
+      createMediaStreamSource: vi.fn(() => sourceNode),
+    };
+    const factory = vi.fn<AudioContextFactory>(() => context);
+    const mediaStream = new MediaStream();
+    const onAudioFrame = vi.fn();
+
+    const host = createOffscreenAudioHost({
+      audioContextFactory: factory,
+      workletModuleUrl: '/perapera-audio-processor.js',
+      tabStreamApi: { acquire: vi.fn(() => okAsync<MediaStream, DomainError>(mediaStream)) },
+      workletNodeFactory: vi.fn(() => workletNode),
+      onAudioFrame,
+    });
+
+    host.dispatch({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: identifierA,
+      tabStreamId: 'tab-stream-id-fixture',
+    });
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(typeof workletNode.port.onmessage).toBe('function');
+    // worklet processor が postMessage した想定のイベントを直接発火
+    const framePayload = {
+      type: 'audio.frame',
+      sequenceNumber: 1,
+      sampleRate: 16000,
+      channels: 1,
+      durationMs: 100,
+      capturedAt: '2026-04-22T00:00:00.000Z',
+      pcm16Base64: 'AAAA',
+    };
+    // MessageEvent 型の厳密な constructor は jsdom で利用可能
+    workletNode.port.onmessage?.(new MessageEvent('message', { data: framePayload }));
+
+    expect(onAudioFrame).toHaveBeenCalledWith(identifierA, framePayload);
+  });
+
+  it('catches onAudioFrame callback throw without detaching the listener (IMPL-617)', async () => {
+    const logger = buildLogger();
+    const workletNode: AudioWorkletNodeLike = {
+      port: { onmessage: null },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    const sourceNode = { connect: vi.fn(), disconnect: vi.fn() };
+    const context = {
+      sampleRate: 16000,
+      audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
+      close: vi.fn(() => Promise.resolve()),
+      createMediaStreamSource: vi.fn(() => sourceNode),
+    };
+    const factory = vi.fn<AudioContextFactory>(() => context);
+    const mediaStream = new MediaStream();
+    const onAudioFrame = vi.fn(() => {
+      throw new Error('boom');
+    });
+
+    const host = createOffscreenAudioHost({
+      audioContextFactory: factory,
+      workletModuleUrl: '/perapera-audio-processor.js',
+      tabStreamApi: { acquire: vi.fn(() => okAsync<MediaStream, DomainError>(mediaStream)) },
+      workletNodeFactory: vi.fn(() => workletNode),
+      onAudioFrame,
+      logger,
+    });
+
+    host.dispatch({
+      type: 'offscreen.audio.open',
+      sessionIdentifier: identifierA,
+      tabStreamId: 'tab-stream-id-fixture',
+    });
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+
+    workletNode.port.onmessage?.(new MessageEvent('message', { data: { type: 'audio.frame' } }));
+    workletNode.port.onmessage?.(new MessageEvent('message', { data: { type: 'audio.frame' } }));
+
+    // 2 回呼ばれている (1 回目で throw しても listener は外れない)
+    expect(onAudioFrame).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('boom'));
   });
 });

--- a/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.ts
+++ b/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.ts
@@ -69,6 +69,13 @@ export type OffscreenAudioHostDependencies = Readonly<{
   workletNodeFactory?: WorkletNodeFactory;
   /** Worklet processor 名 (default `'perapera-audio-processor'`) */
   workletProcessorName?: string;
+  /**
+   * Optional。AudioWorkletNode.port.onmessage で受信した frame data を上位層
+   * (通常は chrome.runtime.sendMessage 経由で SW へ転送) に引き渡す callback
+   * (IMPL-617)。`data` は worklet processor が `port.postMessage` で送る任意
+   * object (通常 `{ type: 'audio.frame', pcm16Base64, sequenceNumber, ... }`)。
+   */
+  onAudioFrame?: (sessionIdentifier: SessionIdentifier, data: unknown) => void;
   /** 操作のログ sink。既定は console */
   logger?: Readonly<{
     debug: (message: string) => void;
@@ -161,6 +168,23 @@ export const createOffscreenAudioHost = (
         deps.workletProcessorName ?? DEFAULT_WORKLET_PROCESSOR_NAME,
       );
       sourceNode.connect(workletNode);
+      // IMPL-617: worklet processor から送られてくる frame を上位層 (SW) に
+      // 転送する。onAudioFrame callback が注入されているときのみ listener を
+      // 設定。callback 例外で listener が外れないよう try/catch で囲む。
+      if (deps.onAudioFrame !== undefined) {
+        const forward = deps.onAudioFrame;
+        workletNode.port.onmessage = (event): void => {
+          try {
+            forward(sessionIdentifier, event.data);
+          } catch (cause) {
+            logger.warn(
+              `[perapera] offscreen-audio-host onAudioFrame threw for ${sessionIdentifier}: ${
+                cause instanceof Error ? cause.message : String(cause)
+              }`,
+            );
+          }
+        };
+      }
       entries.set(sessionIdentifier, { ...entry, sourceNode, workletNode });
       logger.debug(
         `[perapera] offscreen-audio-host connected MediaStreamAudioSourceNode → AudioWorkletNode for ${sessionIdentifier}`,

--- a/packages/extension/src/infrastructure/audio/worklet-node-factory.ts
+++ b/packages/extension/src/infrastructure/audio/worklet-node-factory.ts
@@ -13,9 +13,14 @@ import { type AudioContextLike } from './audio-preprocessor';
  * 接続は offscreen-audio-host 内の安全な wrapper (`unknown` 経由) で行う。
  */
 export type AudioWorkletNodeLike = {
-  readonly port: Readonly<{
+  /**
+   * port 自体は readonly (一度作られたら差し替え不可) だが、`port.onmessage` は
+   * worklet processor からの postMessage を listen するため mutable に
+   * (`workletNode.port.onmessage = listener` で代入可能)。
+   */
+  readonly port: {
     onmessage: ((event: MessageEvent<unknown>) => void) | null;
-  }>;
+  };
   connect: (destination: AudioNode) => void;
   disconnect: () => void;
 };


### PR DESCRIPTION
## Summary

- `AudioWorkletNodeLike.port` を mutable 化 (port 自体は readonly、`port.onmessage` は代入可能)
- `OffscreenAudioHostDependencies` に optional `onAudioFrame(sessionId, data)` callback 追加
- `connectWorklet` 内で `workletNode.port.onmessage` listener を設定し、callback 経由で上位層へ転送
- `offscreen/main.ts` で `chrome.runtime.sendMessage({type:'audio.frame.forward',...})` を注入
- callback throw を try/catch で吸収 (listener は外れない)
- 2 新規 tests (frame forward / callback throw catching)
- ロードマップ v0.5.12 (Phase 5+ ~98%)

## Context

本 PR で **offscreen → SW の frame pipeline が完成**。worklet processor が出す PCM16 frame が `chrome.runtime.sendMessage` で SW へ届くようになる。

残 Step 2d-4 (最終段): SW 側で `audio.frame.forward` を受信し、`audioFramePump` に流す receiver を実装すれば Phase 5+ 全体が完成。

## Test Plan

- [x] `pnpm fmt` / `pnpm lint` / `pnpm typecheck` (root)
- [x] `pnpm --filter @perapera/extension test` — 888 tests passing (+2 新規)
- [ ] CI 全 green