### PR TITLE
feat(extension): IMPL-618 SW receives audio.frame.forward → relayGateway.sendAudioFrame (Phase 5+ 完結)

### DIFF
--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.5.12'
+version: '0.5.13'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -22,18 +22,18 @@ author: 'Codex'
 
 ## 2. 現状サマリ (2026-04-22)
 
-| Phase | 範囲                                                      | 状態                                                  |
-| ----- | --------------------------------------------------------- | ----------------------------------------------------- |
-| 0     | 着手前合意 (IMPL-001〜005)                                | ✅ 完了                                               |
-| 1     | ドメイン層 (IMPL-101〜153)                                | ✅ 完了                                               |
-| 2     | アプリケーション層 (IMPL-200〜230)                        | ✅ 完了                                               |
-| 3     | 拡張 infrastructure (IMPL-300〜344)                       | ✅ 完了                                               |
-| 3.5   | Domain Repository Adapters (IMPL-140〜143)                | ✅ 完了 (#45)                                         |
-| 4     | Relay API (IMPL-400〜451)                                 | ✅ 完了                                               |
-| 5     | 拡張 presentation 層 (IMPL-500〜605)                      | ✅ M2 完了 (実 audio data 転送は Phase 5+ へ分離)     |
-| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | 🟡 ~98% (offscreen→SW frame 転送完了、残 SW receiver) |
-| 6     | E2E / 性能 / 品質検証                                     | 🟡 開始 (page render smoke 4/5 完了, golden path 未)  |
-| 7     | リリース / 運用整備                                       | ⚪ 未着手                                             |
+| Phase | 範囲                                                      | 状態                                                   |
+| ----- | --------------------------------------------------------- | ------------------------------------------------------ |
+| 0     | 着手前合意 (IMPL-001〜005)                                | ✅ 完了                                                |
+| 1     | ドメイン層 (IMPL-101〜153)                                | ✅ 完了                                                |
+| 2     | アプリケーション層 (IMPL-200〜230)                        | ✅ 完了                                                |
+| 3     | 拡張 infrastructure (IMPL-300〜344)                       | ✅ 完了                                                |
+| 3.5   | Domain Repository Adapters (IMPL-140〜143)                | ✅ 完了 (#45)                                          |
+| 4     | Relay API (IMPL-400〜451)                                 | ✅ 完了                                                |
+| 5     | 拡張 presentation 層 (IMPL-500〜605)                      | ✅ M2 完了 (実 audio data 転送は Phase 5+ へ分離)      |
+| 5+    | Audio data routing (AudioWorklet + offscreen MediaStream) | ✅ 完了 (SW → offscreen → worklet → SW → relay 全結線) |
+| 6     | E2E / 性能 / 品質検証                                     | 🟡 開始 (page render smoke 4/5 完了, golden path 未)   |
+| 7     | リリース / 運用整備                                       | ⚪ 未着手                                              |
 
 ### Phase 5 拡張 presentation 層 内訳 (PR #47〜#53, 2026-04-22 時点)
 
@@ -311,7 +311,7 @@ PR #47 時点で `wxt zip` script + CI `build-extension` job の `WXT zip` step 
 - 2 新規 tests (MediaStream + WorkletNode 接続 / close で disconnect)
 - 残 Step 2d-3: worklet port.onmessage で frame を受信 → chrome.runtime.sendMessage で SW へ転送
 
-#### Phase 5+ Step 2d-3: worklet port.onmessage で frame 受信 + SW 転送 (✅ 完了, IMPL-617, 本 PR)
+#### Phase 5+ Step 2d-3: worklet port.onmessage で frame 受信 + SW 転送 (✅ 完了, IMPL-617, PR #70)
 
 - `AudioWorkletNodeLike.port` を mutable に (port 自体は readonly、`port.onmessage` は代入可)
 - `OffscreenAudioHostDependencies` に optional `onAudioFrame(sessionId, data)` callback を追加
@@ -320,6 +320,18 @@ PR #47 時点で `wxt zip` script + CI `build-extension` job の `WXT zip` step 
 - `offscreen/main.ts` で `chrome.runtime.sendMessage({ type: 'audio.frame.forward', sessionIdentifier, data })` に転送する callback を注入
 - 2 新規 tests (frame forward / callback throw catching)
 - 残 Step 2d-4: SW で `audio.frame.forward` を受信 → audioFramePump に流す receiver を実装
+
+#### Phase 5+ Step 2d-4: SW で audio.frame.forward 受信 → relayGateway.sendAudioFrame (✅ 完了, IMPL-618, 本 PR)
+
+- 新規 `application/services/audio-frame-forward-receiver.ts`
+- zod schema で `{ type: 'audio.frame.forward', sessionIdentifier, data: { pcm16Base64, sequenceNumber, ... } }` を validate
+- parse 成功 → `AudioFrameEnvelope` に変換 → `relayGateway.sendAudioFrame(envelope)` を直接呼ぶ
+- 非該当 message は silent ignore、malformed は ignore + sendAudioFrame 呼ばず
+- composition: `audioFrameForwardReceiver` を `ExtensionApp` に公開
+- `background.ts` の `chrome.runtime.onMessage` listener で `app.audioFrameForwardReceiver.receive(message)` を先に呼び、続けて既存 `dispatch` (silent ignore で他 message type と共存)
+- 10 unit tests + composition smoke
+
+**Phase 5+ 完了**: SW → offscreen の `audio.open` (streamId 付き) → offscreen で MediaStream 取得 + AudioWorkletNode 接続 → worklet processor が 100ms PCM16 フレーム生成 → port.onmessage で offscreen 受信 → `chrome.runtime.sendMessage('audio.frame.forward', ...)` で SW へ → `audioFrameForwardReceiver` が `relayGateway.sendAudioFrame` に流す。**実 audio data が Relay API まで到達可能**
 
 #### Phase 5+ Step 2: Offscreen MediaStream 受け取り + AudioPreprocessor 移管 (未着手, 規模大)
 
@@ -446,3 +458,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.5.10     | 2026-04-22 | IMPL-615 で Phase 5+ Step 2d-2a (WorkletNodeFactory port + adapter) を完了。`AudioWorkletNodeLike` 型 (port.onmessage / connect / disconnect) + `WorkletNodeFactory` port + `defaultWorkletNodeFactory` (`new AudioWorkletNode` wrap) を追加。3 unit tests。本 PR 時点では offscreen-audio-host から未配線 (Step 2d-2b で MediaStream 接続と同時に接続)。§2 Phase 5+ を ~88% → ~90% に。                                                                                                                       |
 | 0.5.11     | 2026-04-22 | IMPL-616 で Phase 5+ Step 2d-2b (offscreen-audio-host で MediaStream + AudioWorkletNode 接続) を完了。`workletNodeFactory` 依存追加、`createMediaStreamSource(mediaStream)` + `workletNodeFactory(ctx, name)` + `source.connect(worklet)` の audio graph 構築を実装。addModule 失敗時は Promise<boolean> で resolve (unhandled rejection 回避)。close 時に disconnect → tracks stop → context close。`offscreen/main.ts` で `defaultWorkletNodeFactory` を注入。2 新規 tests。§2 Phase 5+ を ~90% → ~95% に。  |
 | 0.5.12     | 2026-04-22 | IMPL-617 で Phase 5+ Step 2d-3 (worklet port.onmessage で frame 受信 + SW 転送) を完了。`AudioWorkletNodeLike.port` を mutable 化し、`OffscreenAudioHost` に `onAudioFrame` callback 依存を追加、`connectWorklet` 内で `port.onmessage` listener を設定。callback throw は try/catch で吸収。`offscreen/main.ts` で `chrome.runtime.sendMessage({type:'audio.frame.forward',...})` を転送として注入。2 新規 tests。§2 Phase 5+ を ~95% → ~98% に。                                                             |
+| 0.5.13     | 2026-04-22 | **IMPL-618 で Phase 5+ Step 2d-4 (SW で audio.frame.forward 受信 → relayGateway.sendAudioFrame) を完了、Phase 5+ 完結**。新規 `AudioFrameForwardReceiver` + zod schema validation + `background.ts` onMessage listener で配線。10 unit tests + composition smoke。実 audio data が SW → offscreen → worklet → SW → Relay API までフル接続 (端到端での audio routing foundation 完成)。§2 Phase 5+ を ~98% → ✅ 完了 に。                                                                                       |

--- a/packages/extension/src/application/services/audio-frame-forward-receiver.test.ts
+++ b/packages/extension/src/application/services/audio-frame-forward-receiver.test.ts
@@ -1,0 +1,141 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { describe, expect, it, vi } from 'vitest';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import { type RelayGateway } from '../ports/relay-gateway';
+import {
+  createAudioFrameForwardReceiver,
+  tryParseAudioFrameForwardMessage,
+} from './audio-frame-forward-receiver';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+
+const buildFrameMessage = (overrides: Record<string, unknown> = {}): unknown => ({
+  type: 'audio.frame.forward',
+  sessionIdentifier: SESSION_ID,
+  data: {
+    type: 'audio.frame',
+    sequenceNumber: 1,
+    sampleRate: 16000,
+    channels: 1,
+    pcm16Base64: 'AAAA',
+    capturedAt: '2026-04-22T00:00:00.100Z',
+    durationMs: 100,
+    ...overrides,
+  },
+});
+
+const buildGateway = (overrides: Partial<RelayGateway> = {}): RelayGateway => ({
+  openSession: vi.fn(() => okAsync(undefined)),
+  sendAudioFrame: vi.fn<RelayGateway['sendAudioFrame']>(() => okAsync(undefined)),
+  closeSession: vi.fn(() => okAsync(undefined)),
+  subscribe: vi.fn(() => () => {
+    /* noop */
+  }),
+  ...overrides,
+});
+
+describe('tryParseAudioFrameForwardMessage (IMPL-618)', () => {
+  it('parses a valid audio.frame.forward payload', () => {
+    const result = tryParseAudioFrameForwardMessage(buildFrameMessage());
+    expect(result).not.toBeNull();
+    expect(result?.envelope.sequenceNumber).toBe(1);
+    expect(result?.envelope.pcm16Base64).toBe('AAAA');
+  });
+
+  it('returns null for non-matching type', () => {
+    expect(tryParseAudioFrameForwardMessage({ type: 'offscreen.ping' })).toBeNull();
+  });
+
+  it('returns null for non-object message', () => {
+    expect(tryParseAudioFrameForwardMessage(null)).toBeNull();
+    expect(tryParseAudioFrameForwardMessage(42)).toBeNull();
+    expect(tryParseAudioFrameForwardMessage('audio.frame.forward')).toBeNull();
+  });
+
+  it('returns null when sessionIdentifier is malformed (not ULID)', () => {
+    const result = tryParseAudioFrameForwardMessage({
+      type: 'audio.frame.forward',
+      sessionIdentifier: 'not-ulid',
+      data: {
+        type: 'audio.frame',
+        sequenceNumber: 1,
+        sampleRate: 16000,
+        channels: 1,
+        pcm16Base64: 'AAAA',
+        capturedAt: '2026-04-22T00:00:00.100Z',
+        durationMs: 100,
+      },
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when required fields are missing', () => {
+    const partial: Record<string, unknown> = {
+      type: 'audio.frame.forward',
+      sessionIdentifier: SESSION_ID,
+      // data 欠落
+    };
+    expect(tryParseAudioFrameForwardMessage(partial)).toBeNull();
+  });
+
+  it('returns null when pcm16Base64 is empty string', () => {
+    expect(tryParseAudioFrameForwardMessage(buildFrameMessage({ pcm16Base64: '' }))).toBeNull();
+  });
+});
+
+describe('createAudioFrameForwardReceiver (IMPL-618)', () => {
+  it('forwards valid frame to relayGateway.sendAudioFrame', async () => {
+    const relayGateway = buildGateway();
+    const receiver = createAudioFrameForwardReceiver({ relayGateway });
+
+    const result = await receiver.receive(buildFrameMessage());
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBe('forwarded');
+    expect(relayGateway.sendAudioFrame).toHaveBeenCalledTimes(1);
+    const envelope = vi.mocked(relayGateway.sendAudioFrame).mock.calls[0]?.[0];
+    expect(envelope?.sessionIdentifier).toBe(SESSION_ID);
+    expect(envelope?.pcm16Base64).toBe('AAAA');
+  });
+
+  it('returns "ignored" for non-matching message types (silent ignore)', async () => {
+    const relayGateway = buildGateway();
+    const receiver = createAudioFrameForwardReceiver({ relayGateway });
+
+    const result = await receiver.receive({ type: 'offscreen.ping' });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBe('ignored');
+    expect(relayGateway.sendAudioFrame).not.toHaveBeenCalled();
+  });
+
+  it('logs warn and propagates Err when sendAudioFrame fails', async () => {
+    const logWarn = vi.fn();
+    const relayGateway = buildGateway({
+      sendAudioFrame: vi.fn(() =>
+        errAsync<void, DomainError>(
+          invariantViolationError({ invariant: 'relay-send-failed', details: 'socket closed' }),
+        ),
+      ),
+    });
+    const receiver = createAudioFrameForwardReceiver({ relayGateway, logWarn });
+
+    const result = await receiver.receive(buildFrameMessage());
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('invariant-violation');
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining('invariant-violation'));
+  });
+
+  it('returns "ignored" for malformed messages without calling sendAudioFrame', async () => {
+    const relayGateway = buildGateway();
+    const receiver = createAudioFrameForwardReceiver({ relayGateway });
+
+    const malformed: unknown = { type: 'audio.frame.forward', sessionIdentifier: 'bad' };
+    const result = await receiver.receive(malformed);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toBe('ignored');
+    expect(relayGateway.sendAudioFrame).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/src/application/services/audio-frame-forward-receiver.ts
+++ b/packages/extension/src/application/services/audio-frame-forward-receiver.ts
@@ -1,0 +1,123 @@
+import { errAsync, okAsync, type ResultAsync } from 'neverthrow';
+import { z } from 'zod';
+import { parseSessionIdentifier } from '../../domain/session/session-identifier';
+import { validationError, type DomainError } from '../../domain/shared/errors';
+import { type AudioFrameEnvelope } from '../ports/audio-preprocessor';
+import { type RelayGateway } from '../ports/relay-gateway';
+
+/**
+ * IMPL-618 AudioFrameForwardReceiver (application service)。
+ *
+ * Offscreen document から `chrome.runtime.sendMessage({
+ *   type: 'audio.frame.forward',
+ *   sessionIdentifier: <ulid>,
+ *   data: { type: 'audio.frame', pcm16Base64, sequenceNumber, ... }
+ * })` で送信される message を SW 側で受信し、`RelayGateway.sendAudioFrame`
+ * に流す receiver。
+ *
+ * worklet processor (IMPL-607) が出す frame 形式と Relay API の
+ * `AudioFrameEnvelope` はほぼ一致しており、本 service は薄い validator +
+ * forwarder として機能する。
+ *
+ * **本番実装で mock を使わない設計**:
+ * - `relayGateway` は必須 DI (default なし)
+ * - test では fake gateway を注入
+ */
+
+// worklet processor が port.postMessage で送信するペイロード (IMPL-607)
+const audioFrameDataSchema = z.object({
+  type: z.literal('audio.frame'),
+  sequenceNumber: z.number().int().nonnegative(),
+  sampleRate: z.literal(16000),
+  channels: z.literal(1),
+  pcm16Base64: z.string().min(1),
+  capturedAt: z.string().datetime(),
+  durationMs: z.number().int().positive(),
+});
+
+const audioFrameForwardSchema = z.object({
+  type: z.literal('audio.frame.forward'),
+  sessionIdentifier: z.string().min(1),
+  data: audioFrameDataSchema,
+});
+
+/**
+ * `chrome.runtime.sendMessage` 経由で受け取った任意の unknown を
+ * `AudioFrameForwardMessage` として解釈できるかを検査する。
+ * 本 message type でなければ `null` を返し、receiver 側で silent ignore する。
+ */
+export const tryParseAudioFrameForwardMessage = (
+  raw: unknown,
+): { readonly type: 'audio.frame.forward'; readonly envelope: AudioFrameEnvelope } | null => {
+  if (raw === null || typeof raw !== 'object' || !('type' in raw)) return null;
+  const maybeType: unknown = Reflect.get(raw, 'type');
+  if (maybeType !== 'audio.frame.forward') return null;
+  const parsed = audioFrameForwardSchema.safeParse(raw);
+  if (!parsed.success) return null;
+  const sessionResult = parseSessionIdentifier(parsed.data.sessionIdentifier);
+  if (sessionResult.isErr()) return null;
+  return {
+    type: 'audio.frame.forward',
+    envelope: {
+      sessionIdentifier: sessionResult.value,
+      sequenceNumber: parsed.data.data.sequenceNumber,
+      sampleRate: parsed.data.data.sampleRate,
+      channels: parsed.data.data.channels,
+      pcm16Base64: parsed.data.data.pcm16Base64,
+      capturedAt: parsed.data.data.capturedAt,
+      durationMs: parsed.data.data.durationMs,
+    },
+  };
+};
+
+export type AudioFrameForwardReceiver = Readonly<{
+  /**
+   * 任意の `chrome.runtime.onMessage` message を受け取り、`audio.frame.forward`
+   * に該当すれば `RelayGateway.sendAudioFrame` に流す。該当しなければ
+   * silent ignore (他 message type との listener 共有を想定)。
+   * 返り値の Result は test / smoke 検証用で、本番 onMessage では無視可。
+   */
+  receive: (rawMessage: unknown) => ResultAsync<'forwarded' | 'ignored', DomainError>;
+}>;
+
+export type AudioFrameForwardReceiverDependencies = Readonly<{
+  relayGateway: RelayGateway;
+  /** Err ログ sink。default console.warn */
+  logWarn?: (message: string) => void;
+}>;
+
+const defaultLogWarn = (message: string): void => {
+  console.warn(message);
+};
+
+export const createAudioFrameForwardReceiver = (
+  deps: AudioFrameForwardReceiverDependencies,
+): AudioFrameForwardReceiver => {
+  const logWarn = deps.logWarn ?? defaultLogWarn;
+  return {
+    receive: (rawMessage) => {
+      const parsed = tryParseAudioFrameForwardMessage(rawMessage);
+      if (parsed === null) {
+        return okAsync<'forwarded' | 'ignored', DomainError>('ignored');
+      }
+      return deps.relayGateway
+        .sendAudioFrame(parsed.envelope)
+        .map((): 'forwarded' | 'ignored' => 'forwarded')
+        .orElse((error): ResultAsync<'forwarded' | 'ignored', DomainError> => {
+          logWarn(
+            `[perapera] audio-frame-forward-receiver sendAudioFrame failed for ${parsed.envelope.sessionIdentifier}: ${
+              'kind' in error ? error.kind : String(error)
+            }`,
+          );
+          return errAsync<'forwarded' | 'ignored', DomainError>(error);
+        });
+    },
+  };
+};
+
+// re-export type for convenience (application 層が schema 的な型情報に触れずに済む)
+export type AudioFrameDataPayload = z.infer<typeof audioFrameDataSchema>;
+
+// 未使用を防ぐため validationError を内部 doc に残す (schema 検証失敗時の
+// 将来的な詳細ログ用、現状は null 返却で silent ignore)
+void validationError;

--- a/packages/extension/src/composition/extension-composition.test.ts
+++ b/packages/extension/src/composition/extension-composition.test.ts
@@ -133,6 +133,8 @@ describe('createExtensionApp (IMPL-500)', () => {
     expect(app.audioFramePump.activeCount()).toBe(0);
     expect(app.offscreenCommandSender).toBeDefined();
     expect(app.offscreenCommandSender.openAudioContext).toBeTypeOf('function');
+    expect(app.audioFrameForwardReceiver).toBeDefined();
+    expect(app.audioFrameForwardReceiver.receive).toBeTypeOf('function');
     expect(app.orphanSessionCleanup).toBeDefined();
     expect(app.orphanSessionCleanup.cleanup).toBeTypeOf('function');
     expect(app.transcriptAssembler).toBeDefined();

--- a/packages/extension/src/composition/extension-composition.ts
+++ b/packages/extension/src/composition/extension-composition.ts
@@ -15,6 +15,10 @@ import {
   createCaptureOrchestrator,
   type CaptureOrchestrator,
 } from '../application/services/capture-orchestrator';
+import {
+  createAudioFrameForwardReceiver,
+  type AudioFrameForwardReceiver,
+} from '../application/services/audio-frame-forward-receiver';
 import { createExportService, type ExportService } from '../application/services/export-service';
 import {
   createOffscreenCommandSender,
@@ -210,6 +214,7 @@ export type ExtensionApp = Readonly<{
   captureOrchestrator: CaptureOrchestrator;
   audioFramePump: AudioFramePump;
   offscreenCommandSender: OffscreenCommandSender;
+  audioFrameForwardReceiver: AudioFrameForwardReceiver;
   orphanSessionCleanup: OrphanSessionCleanupService;
   transcriptAssembler: TranscriptAssembler;
   close: () => Promise<void>;
@@ -323,6 +328,9 @@ export const createExtensionApp = (
     bridge: runtimeMessageBridge,
   });
   const tabStreamIdResolver = createChromeTabStreamIdResolver(ports.tabCaptureApi);
+  const audioFrameForwardReceiver: AudioFrameForwardReceiver = createAudioFrameForwardReceiver({
+    relayGateway,
+  });
   const orphanSessionCleanup: OrphanSessionCleanupService = createOrphanSessionCleanupService({
     sourceSessionRepository,
     clock: ports.clockIso,
@@ -410,6 +418,7 @@ export const createExtensionApp = (
     captureOrchestrator,
     audioFramePump,
     offscreenCommandSender,
+    audioFrameForwardReceiver,
     orphanSessionCleanup,
     transcriptAssembler,
     close: async () => {

--- a/packages/extension/src/entrypoints/background.ts
+++ b/packages/extension/src/entrypoints/background.ts
@@ -110,8 +110,21 @@ export default defineBackground(() => {
    * chrome.runtime.onMessage listener。`sendResponse` は Promise 連携のため
    * `return true` で非同期応答を宣言し、dispatcher の Promise を解決したら
    * `sendResponse` に渡す (Chrome の仕様)。
+   *
+   * IMPL-618: offscreen document から転送された `audio.frame.forward` を
+   * audioFrameForwardReceiver に先に渡す。receiver は該当しない message を
+   * silent ignore するため、続けて dispatcher にも同じ message を流す。
    */
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    void app.audioFrameForwardReceiver.receive(message).match(
+      () => undefined,
+      (error) => {
+        console.warn(
+          '[perapera] audio-frame-forward-receiver failed:',
+          'kind' in error ? error.kind : String(error),
+        );
+      },
+    );
     void dispatch(message)
       .then((response) => {
         sendResponse(response);


### PR DESCRIPTION
## Summary

**🎉 Phase 5+ 完結**: SW → offscreen → worklet → SW → Relay API までの audio data pipeline が端到端でフル接続されました。

- 新規 `AudioFrameForwardReceiver` (application service) + zod schema validation
- `background.ts` onMessage listener 先頭で `receive(message)` を呼び、非該当 message は silent ignore して既存 dispatcher と共存
- composition で `ExtensionApp.audioFrameForwardReceiver` 公開
- 10 unit tests + composition smoke
- ロードマップ v0.5.13 (Phase 5+ ✅ 完了)

## End-to-End Pipeline 完成

1. Popup → SW: startSource (sourceType='tab', overlayTarget.tabId)
2. SW: `tabStreamIdResolver.resolve(tabId)` → streamId 取得
3. SW → offscreen: `audio.open` (tabStreamId 付き)
4. offscreen: `tabStreamApi.acquire(streamId)` → MediaStream 確保
5. offscreen: `audioWorklet.addModule('/perapera-audio-processor.js')`
6. offscreen: `workletNodeFactory(ctx, name)` → AudioWorkletNode 作成
7. offscreen: `createMediaStreamSource.connect(workletNode)` → graph 接続
8. worklet processor: 100ms PCM16 fraMe 生成 → `port.postMessage`
9. offscreen: `workletNode.port.onmessage` で受信 → `chrome.runtime.sendMessage('audio.frame.forward', ...)`
10. **SW: `audioFrameForwardReceiver.receive` → `relayGateway.sendAudioFrame` ← 本 PR で追加**
11. Relay WebSocket: STT provider へ audio.frame event 送信

## Phase 5+ 全 PR (13 連続)

IMPL-602/603 (PR #54/#55): audioFramePump / orphan cleanup
IMPL-604/605 (PR #56/#57): E2E smoke
IMPL-606/607 (PR #59/#60): Offscreen command sender / audio worklet processor
IMPL-608/609 (PR #61/#62): pcm-utils / tabCapture streamId
IMPL-610/611 (PR #63/#64): audio.open schema / TabStreamApi
IMPL-612/613 (PR #65/#66): offscreen MediaStream 接続 / tabStreamIdResolver
IMPL-614/615 (PR #67/#68): worklet module load / WorkletNodeFactory
IMPL-616/617 (PR #69/#70): MediaStream 接続 / frame 転送
IMPL-618 (本 PR): SW receiver

## Test Plan

- [x] `pnpm fmt` / `pnpm lint` / `pnpm typecheck` (root)
- [x] `pnpm --filter @perapera/extension test` — 898 tests passing (+10 新規)
- [x] `pnpm --filter @perapera/extension build` — 481.83 kB chrome-mv3 出力成功
- [ ] CI 全 green
- [ ] 手動 smoke: unpacked 拡張で tab capture → 実音声が Relay API に到達すること