### PR TITLE
test(relay-api): IMPL-610 add ws-relay k6 scenario (Phase 6 Step 1)

### DIFF
--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.5.15'
+version: '0.5.16'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -410,7 +410,11 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 **範囲:**
 
 - IMPL-600 Playwright E2E (拡張 unpacked + Relay mock provider で翻訳ループを閉じる) — 🟡 進行中 (page render smoke 4/5 完了, golden path / permission denied 未)
-- IMPL-610 k6 負荷試験 (Relay 同時 3 接続、SLO 計測) — ⚪ 未着手
+- IMPL-610 k6 負荷試験 (Relay 同時 3 接続、SLO 計測) — 🟡 Step 1 完了:
+  - `perf/scenarios/ws-relay.js` を新規追加。`POST /sessions` → WebSocket `/relay` → `session.ready` 受信までを同時 3 VU (SessionConcurrencyPolicy 準拠) で 30 秒維持。SLO 閾値: ws_connecting p95 < 3000ms / session_ready_latency p95 < 1000ms / http_req_duration p95 < 500ms
+  - `perf/scenarios/create-session.js` の誤った `/api/v1/sessions` を実装 Fastify route の `/sessions` に fix (`relayUrl` announce path と Fastify route は別レイヤーの命名)
+  - `justfile` に `perf-ws` エイリアス追加、`perf/README.md` に scenario 表と CI 未連携の注記を更新
+  - 残: `.github/workflows/k6-smoke.yml` による weekly + dispatch の自動実行 (次 PR)、`translation-hotpath.js` で transcript.final → translation.final p95 800ms end-to-end 検証 (別 PR)
 - IMPL-620 脅威モデル最終確認 (security-design §3 threat matrix と実装の突き合わせ) — ⚪ 未着手
 - IMPL-630 `pnpm audit` + dependabot 定期化 — ✅ 完了:
   - `.github/dependabot.yml` — npm / github-actions / docker の 3 ecosystem を weekly monday 09:00 JST で回す。npm は production / development で group 化 (major bump は個別 PR)。target は `develop`
@@ -465,3 +469,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.5.13     | 2026-04-22 | **IMPL-618 で Phase 5+ Step 2d-4 (SW で audio.frame.forward 受信 → relayGateway.sendAudioFrame) を完了、Phase 5+ 完結**。新規 `AudioFrameForwardReceiver` + zod schema validation + `background.ts` onMessage listener で配線。10 unit tests + composition smoke。実 audio data が SW → offscreen → worklet → SW → Relay API までフル接続 (端到端での audio routing foundation 完成)。§2 Phase 5+ を ~98% → ✅ 完了 に。                                                                                                                                                    |
 | 0.5.14     | 2026-04-22 | IMPL-630 (`pnpm audit` + dependabot 定期化) を完了。`.github/dependabot.yml` で npm / github-actions / docker の 3 ecosystem を weekly monday 09:00 JST・`target-branch: develop` でスケジュール (npm は production/development で group 化、major は個別 PR)。`.github/workflows/audit.yml` で `pnpm audit --audit-level moderate` を weekly + 依存ファイル変更 PR + workflow_dispatch で実行。`branch-name-check.yml` / `.husky/pre-push` に `^dependabot/.+$` を OR 追加し、Dependabot 生成 branch が命名規約 CI を通るようにした。§8 Phase 6 の IMPL-630 を ✅ に更新。 |
 | 0.5.15     | 2026-04-22 | IMPL-630 初回実行で検出された transitive 脆弱性 8 件 (`wxt>giget>tar` x6 high / `vitest>vite` moderate / `vitest>vite>esbuild` moderate) を `package.json > pnpm.overrides` で解消。`tar ^7.5.13` / `vite ^6.4.2` / `esbuild ^0.25.0` に強制し、`pnpm audit --audit-level moderate` が 0 件を返すことを確認。extension (898) / relay-api (184) tests / typecheck / wxt build いずれも override 後に通過。                                                                                                                                                                   |
+| 0.5.16     | 2026-04-22 | IMPL-610 Step 1 として WebSocket ホットパスの k6 scenario を追加。`perf/scenarios/ws-relay.js` で `POST /sessions` → WS `/relay` → `session.ready` 受信までを同時 3 VU × 30s で計測し、ws_connecting p95 < 3000ms / session_ready_latency p95 < 1000ms / http_req_duration p95 < 500ms を閾値化。既存 `create-session.js` の誤 path (`/api/v1/sessions`) を実装 Fastify route の `/sessions` に合わせて修正、`justfile` / `perf/README.md` も更新。CI 連携と translation-hotpath scenario は後続 PR で扱う。                                                                |

--- a/justfile
+++ b/justfile
@@ -74,6 +74,9 @@ e2e:
 perf-sessions:
     k6 run packages/relay-api/perf/scenarios/create-session.js
 
+perf-ws:
+    k6 run packages/relay-api/perf/scenarios/ws-relay.js
+
 # -- Docker（ローカル検証） --
 
 docker-build-relay:

--- a/packages/relay-api/perf/README.md
+++ b/packages/relay-api/perf/README.md
@@ -13,25 +13,36 @@ Go バイナリで動く [k6](https://k6.io/) を使った負荷試験シナリ�
 
 ## シナリオ一覧
 
-| ファイル                      | 目的                                                                 |
-| ----------------------------- | -------------------------------------------------------------------- |
-| `scenarios/create-session.js` | `POST /sessions` の p95 500ms SLO（operations-design.md §2.2）を検証 |
+| ファイル                      | 目的                                                                                                           |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `scenarios/create-session.js` | `POST /sessions` の p95 500ms SLO（operations-design.md §2.2）を検証                                           |
+| `scenarios/ws-relay.js`       | `POST /sessions` → WebSocket `/relay` → `session.ready` 受信までの p95 レイテンシを同時 3 VU で検証 (IMPL-610) |
 
-今後追加予定: `ws-relay.js`（WebSocket ホットパス、`translation.final` p95 検証）
+今後追加予定: `translation-hotpath.js`（`transcript.final` → `translation.final` p95 800ms の end-to-end 検証）
 
 ## 実行例
 
 ```sh
-# Relay API を別プロセスで立ち上げておく
-pnpm --filter @perapera/relay-api dev
+# Relay API を別プロセスで立ち上げておく (mock provider を選択)
+STT_PROVIDER=mock TRANSLATION_PROVIDER=mock pnpm --filter @perapera/relay-api dev
 
-# 別ターミナルから負荷試験
+# 別ターミナルから負荷試験 (個別)
 k6 run packages/relay-api/perf/scenarios/create-session.js
+k6 run packages/relay-api/perf/scenarios/ws-relay.js
 
 # 別 URL / 別トークンで動かす場合
 RELAY_BASE_URL=https://stg-relay.example.com \
   ACCESS_TOKEN=<token> \
-  k6 run packages/relay-api/perf/scenarios/create-session.js
+  k6 run packages/relay-api/perf/scenarios/ws-relay.js
+
+# WebSocket だけ別 URL にする (`BASE_URL` から http→ws 変換されるが上書き可能)
+RELAY_BASE_URL=http://localhost:3001 \
+  RELAY_WS_BASE_URL=ws://localhost:3001 \
+  k6 run packages/relay-api/perf/scenarios/ws-relay.js
 ```
 
-`justfile` には `just perf-sessions` エイリアスを用意しています。
+`justfile` には `just perf-sessions` / `just perf-ws` エイリアスを用意しています。
+
+## CI 連携
+
+現時点で GitHub Actions からの自動実行は未配線 (IMPL-610 の後続 PR で `.github/workflows/k6-smoke.yml` を追加予定)。手動検証と stg 環境に対する smoke に限定して運用する。

--- a/packages/relay-api/perf/scenarios/create-session.js
+++ b/packages/relay-api/perf/scenarios/create-session.js
@@ -28,7 +28,7 @@ export default function () {
     client: { extensionVersion: '0.0.0', protocolVersion: '1.0' },
   });
 
-  const response = http.post(`${BASE_URL}/api/v1/sessions`, payload, {
+  const response = http.post(`${BASE_URL}/sessions`, payload, {
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${ACCESS_TOKEN}`,

--- a/packages/relay-api/perf/scenarios/ws-relay.js
+++ b/packages/relay-api/perf/scenarios/ws-relay.js
@@ -1,0 +1,126 @@
+import http from 'k6/http';
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+
+// IMPL-610 k6 scenario: WebSocket ホットパスの SLO 検証。
+//
+// フロー (api-specification §3 / operations-design §4.4):
+//   1. POST /sessions で streamToken を取得 (HTTP Bearer access token 付き)
+//   2. wss://…/relay?sessionId=<id>&protocolVersion=1.0 に
+//      Authorization: Bearer <streamToken> で接続
+//   3. session.ready server event を受信 → レイテンシ計測
+//   4. 接続クローズ
+//
+// SLO 閾値:
+//   - ws_connecting p95 < 3000ms   (WebSocket ハンドシェイク)
+//   - session_ready_latency p95 < 1000ms  (接続後の server event 応答)
+//   - http_req_duration p95 < 500ms (POST /sessions 本体)
+//
+// Relay 側の同時セッション上限は 3 (SessionConcurrencyPolicy, DD-240) のため
+// VUs は 3 固定。constant-vus executor で 30s 維持。
+
+export const options = {
+  scenarios: {
+    concurrent_relay: {
+      executor: 'constant-vus',
+      vus: 3,
+      duration: '30s',
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.01'],
+    ws_connecting: ['p(95)<3000'],
+    session_ready_latency_ms: ['p(95)<1000'],
+    ws_session_errors: ['count<5'],
+  },
+};
+
+const BASE_URL = __ENV.RELAY_BASE_URL ?? 'http://localhost:3001';
+const WS_BASE_URL = __ENV.RELAY_WS_BASE_URL ?? BASE_URL.replace(/^http/, 'ws');
+const ACCESS_TOKEN = __ENV.ACCESS_TOKEN ?? 'dev-access-token';
+const PROTOCOL_VERSION = '1.0';
+
+const sessionReadyLatency = new Trend('session_ready_latency_ms');
+const wsSessionErrors = new Counter('ws_session_errors');
+
+export default function () {
+  const postStart = Date.now();
+  const payload = JSON.stringify({
+    sourceType: 'tab',
+    displayName: 'k6 ws-relay',
+    sourceLanguage: 'en-US',
+    autoDetectLanguage: false,
+    targetLanguage: 'ja-JP',
+    overlayTarget: { kind: 'tab', tabId: __VU },
+    client: { extensionVersion: '0.0.0', protocolVersion: PROTOCOL_VERSION },
+  });
+
+  const sessionResponse = http.post(`${BASE_URL}/sessions`, payload, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
+    },
+    tags: { endpoint: 'post-sessions' },
+  });
+
+  const created = check(sessionResponse, {
+    'session created (201/200)': (r) => r.status === 201 || r.status === 200,
+  });
+  if (!created) {
+    wsSessionErrors.add(1);
+    return;
+  }
+
+  const body = sessionResponse.json();
+  const data = body?.data ?? body;
+  const sessionId = data?.sessionId;
+  const streamToken = data?.streamToken;
+  if (typeof sessionId !== 'string' || typeof streamToken !== 'string') {
+    wsSessionErrors.add(1);
+    return;
+  }
+
+  const wsUrl = `${WS_BASE_URL}/relay?sessionId=${encodeURIComponent(sessionId)}&protocolVersion=${PROTOCOL_VERSION}`;
+  const connectStart = Date.now();
+  let sessionReadyObserved = false;
+
+  const wsResponse = ws.connect(
+    wsUrl,
+    { headers: { Authorization: `Bearer ${streamToken}` }, tags: { endpoint: 'ws-relay' } },
+    (socket) => {
+      socket.on('message', (raw) => {
+        try {
+          const event = JSON.parse(raw);
+          if (event && event.type === 'session.ready') {
+            sessionReadyLatency.add(Date.now() - connectStart);
+            sessionReadyObserved = true;
+            socket.close();
+          }
+        } catch {
+          wsSessionErrors.add(1);
+          socket.close();
+        }
+      });
+      socket.on('error', () => {
+        wsSessionErrors.add(1);
+      });
+      // 5 秒経っても session.ready が来なければ abort (SLO 閾値の上限)
+      socket.setTimeout(() => {
+        if (!sessionReadyObserved) wsSessionErrors.add(1);
+        socket.close();
+      }, 5000);
+    },
+  );
+
+  check(wsResponse, {
+    'ws handshake accepted (101)': (r) => r && r.status === 101,
+  });
+
+  // POST レスポンスタイムを可観測化 (thresholds で assert される http_req_duration とは別のログ用)
+  const postDuration = Date.now() - postStart;
+  if (postDuration > 2000) {
+    console.warn(`[vu=${__VU}] POST /sessions took ${postDuration}ms`);
+  }
+}


### PR DESCRIPTION
## Summary

- `perf/scenarios/ws-relay.js` (新規): POST /sessions → WebSocket /relay → `session.ready` 受信までを同時 3 VU × 30s で計測。SLO: ws_connecting p95 < 3000ms / session_ready_latency p95 < 1000ms / http_req_duration p95 < 500ms。
- `perf/scenarios/create-session.js`: 誤 path `/api/v1/sessions` を実装 Fastify route の `/sessions` に修正。`/api/v1` prefix は `relayUrl` announce 用で、Fastify route 自体は prefix なし。
- `justfile` に `perf-ws` エイリアス追加、`perf/README.md` の scenario 表と CI 未連携の注記を更新。
- Roadmap v0.5.16: IMPL-610 を 🟡 Step 1 完了に更新、後続 PR (CI 統合 / translation-hotpath) を明示。

## Why

IMPL-630 完了後の Phase 6 §8 残タスク消化。WS ホットパスの SLO を k6 threshold で自動検証する基盤を先に入れる。CI 連携 (`.github/workflows/k6-smoke.yml`) と translation-hotpath scenario は別 PR で段階追加する方針。

## Test plan

- [x] `pnpm lint`
- [x] `pnpm fmt:check`
- [ ] 手動: `STT_PROVIDER=mock TRANSLATION_PROVIDER=mock pnpm --filter @perapera/relay-api dev` → `just perf-ws` で thresholds pass を確認 (k6 CLI 要)
- [ ] CI `All Green` (scenario 追加のみなので既存 job には影響しない想定)