### PR TITLE
ci(relay-api): IMPL-610 k6 smoke CI workflow (Phase 6 Step 2)

### DIFF
--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -1,0 +1,120 @@
+name: Relay API k6 Smoke
+
+# IMPL-610 Step 2 — k6 シナリオを CI で定期実行し、ホットパスの SLO 閾値を
+# 回帰的に監視する。
+#
+# - schedule: 毎週月曜 11:00 UTC (Asia/Tokyo 20:00)
+# - pull_request: relay-api 実装 / perf scenario / workflow 変更時
+# - workflow_dispatch: 手動実行
+#
+# シナリオは Docker image `grafana/k6:latest` で実行し、host network mode で
+# ローカル起動した Relay API (port 3001) にアクセスする。
+#
+# Deepgram / DeepL の API Key factory 側 length>0 check のみで、stream / HTTP
+# 呼び出しは audio.frame / transcript.final client event を送った場合にのみ
+# 発生する。create-session.js / ws-relay.js はいずれも stream を start しない
+# ため、ダミー API Key で起動すれば十分 (real provider に到達しない)。
+#
+# 実コードで mock / in-memory を使わない原則を守りつつ、provider 依存の CI
+# 不安定性を持ち込まないため、mock provider を entrypoint に配線する代わりに
+# 「provider factory を dummy key で初期化し、実行時には到達しない」構成を
+# 採る。
+
+on:
+  schedule:
+    - cron: '0 11 * * 1'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'packages/relay-api/src/**'
+      - 'packages/relay-api/perf/**'
+      - 'packages/relay-api/package.json'
+      - '.github/workflows/k6-smoke.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: k6-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  k6-smoke:
+    name: k6 smoke (create-session + ws-relay)
+    # actrun ローカル実行では Docker pull と relay 起動が重いため skip。
+    if: ${{ !env.ACTRUN_LOCAL }}
+    runs-on: ubuntu-latest
+    env:
+      # 32+ chars required (server.ts line 115)
+      STREAM_TOKEN_SECRET: k6-smoke-stream-token-secret-0123456789abcdef
+      STREAM_TOKEN_ISSUER: https://relay.k6-smoke.local
+      STREAM_TOKEN_AUDIENCE: perapera-extension-k6
+      RELAY_PUBLIC_URL: ws://localhost:3001/relay
+      # 16+ chars required per token (static-access-token-verifier)
+      ACCESS_TOKENS: dev-access-token
+      # factory は length>0 のみ validate、stream 起動しない限り API には到達しない
+      DEEPGRAM_API_KEY: k6-smoke-dummy-deepgram-key
+      DEEPL_API_KEY: k6-smoke-dummy-deepl-key
+      PORT: '3001'
+      HOST: '0.0.0.0'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build relay-api
+        run: pnpm --filter @perapera/relay-api build
+      - name: Start Relay API in background
+        run: |
+          pnpm --filter @perapera/relay-api start > relay.log 2>&1 &
+          echo $! > relay.pid
+          echo "Relay PID=$(cat relay.pid)"
+      - name: Wait for Relay API /health
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:3001/health > /dev/null 2>&1; then
+              echo "Relay ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Relay failed to start in 30s. Log tail:"
+          tail -n 50 relay.log || true
+          exit 1
+      - name: k6 create-session scenario
+        run: |
+          docker run --rm --network=host \
+            -v "$GITHUB_WORKSPACE:/src" -w /src \
+            -e ACCESS_TOKEN=dev-access-token \
+            -e RELAY_BASE_URL=http://localhost:3001 \
+            grafana/k6:latest \
+            run packages/relay-api/perf/scenarios/create-session.js
+      - name: k6 ws-relay scenario
+        run: |
+          docker run --rm --network=host \
+            -v "$GITHUB_WORKSPACE:/src" -w /src \
+            -e ACCESS_TOKEN=dev-access-token \
+            -e RELAY_BASE_URL=http://localhost:3001 \
+            -e RELAY_WS_BASE_URL=ws://localhost:3001 \
+            grafana/k6:latest \
+            run packages/relay-api/perf/scenarios/ws-relay.js
+      - name: Stop Relay API
+        if: always()
+        run: |
+          if [ -f relay.pid ]; then
+            PID=$(cat relay.pid)
+            if kill -0 "$PID" 2>/dev/null; then
+              kill "$PID" || true
+              sleep 1
+              kill -9 "$PID" 2>/dev/null || true
+            fi
+          fi
+      - name: Upload Relay log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: relay-log
+          path: relay.log
+          retention-days: 7

--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.5.16'
+version: '0.5.17'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -410,11 +410,10 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 **範囲:**
 
 - IMPL-600 Playwright E2E (拡張 unpacked + Relay mock provider で翻訳ループを閉じる) — 🟡 進行中 (page render smoke 4/5 完了, golden path / permission denied 未)
-- IMPL-610 k6 負荷試験 (Relay 同時 3 接続、SLO 計測) — 🟡 Step 1 完了:
-  - `perf/scenarios/ws-relay.js` を新規追加。`POST /sessions` → WebSocket `/relay` → `session.ready` 受信までを同時 3 VU (SessionConcurrencyPolicy 準拠) で 30 秒維持。SLO 閾値: ws_connecting p95 < 3000ms / session_ready_latency p95 < 1000ms / http_req_duration p95 < 500ms
-  - `perf/scenarios/create-session.js` の誤った `/api/v1/sessions` を実装 Fastify route の `/sessions` に fix (`relayUrl` announce path と Fastify route は別レイヤーの命名)
-  - `justfile` に `perf-ws` エイリアス追加、`perf/README.md` に scenario 表と CI 未連携の注記を更新
-  - 残: `.github/workflows/k6-smoke.yml` による weekly + dispatch の自動実行 (次 PR)、`translation-hotpath.js` で transcript.final → translation.final p95 800ms end-to-end 検証 (別 PR)
+- IMPL-610 k6 負荷試験 (Relay 同時 3 接続、SLO 計測) — ✅ 完了 (Step 1 + Step 2):
+  - Step 1 (PR #74): `perf/scenarios/ws-relay.js` 新規 (`POST /sessions` → WS `/relay` → `session.ready` を同時 3 VU × 30s で計測、SLO: ws_connecting p95 < 3000ms / session_ready_latency p95 < 1000ms / http_req_duration p95 < 500ms)。`create-session.js` path fix、`justfile` / `perf/README.md` 更新
+  - Step 2 (本 PR): `.github/workflows/k6-smoke.yml` を新設。weekly monday 11:00 UTC + perf/src 変更 PR + workflow_dispatch で trigger。relay-api を bg 起動し Docker `grafana/k6:latest` で 2 シナリオを実行。provider factory は dummy API key で length check を通過し、scenarios が stream を start しないため real provider に到達しない (mock を production entrypoint に配線せずに済む)
+  - 残: `translation-hotpath.js` で transcript.final → translation.final p95 800ms の end-to-end 検証 (別 PR、mock provider を entrypoint 設計として組み込む必要あるため規模中)
 - IMPL-620 脅威モデル最終確認 (security-design §3 threat matrix と実装の突き合わせ) — ⚪ 未着手
 - IMPL-630 `pnpm audit` + dependabot 定期化 — ✅ 完了:
   - `.github/dependabot.yml` — npm / github-actions / docker の 3 ecosystem を weekly monday 09:00 JST で回す。npm は production / development で group 化 (major bump は個別 PR)。target は `develop`
@@ -470,3 +469,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.5.14     | 2026-04-22 | IMPL-630 (`pnpm audit` + dependabot 定期化) を完了。`.github/dependabot.yml` で npm / github-actions / docker の 3 ecosystem を weekly monday 09:00 JST・`target-branch: develop` でスケジュール (npm は production/development で group 化、major は個別 PR)。`.github/workflows/audit.yml` で `pnpm audit --audit-level moderate` を weekly + 依存ファイル変更 PR + workflow_dispatch で実行。`branch-name-check.yml` / `.husky/pre-push` に `^dependabot/.+$` を OR 追加し、Dependabot 生成 branch が命名規約 CI を通るようにした。§8 Phase 6 の IMPL-630 を ✅ に更新。 |
 | 0.5.15     | 2026-04-22 | IMPL-630 初回実行で検出された transitive 脆弱性 8 件 (`wxt>giget>tar` x6 high / `vitest>vite` moderate / `vitest>vite>esbuild` moderate) を `package.json > pnpm.overrides` で解消。`tar ^7.5.13` / `vite ^6.4.2` / `esbuild ^0.25.0` に強制し、`pnpm audit --audit-level moderate` が 0 件を返すことを確認。extension (898) / relay-api (184) tests / typecheck / wxt build いずれも override 後に通過。                                                                                                                                                                   |
 | 0.5.16     | 2026-04-22 | IMPL-610 Step 1 として WebSocket ホットパスの k6 scenario を追加。`perf/scenarios/ws-relay.js` で `POST /sessions` → WS `/relay` → `session.ready` 受信までを同時 3 VU × 30s で計測し、ws_connecting p95 < 3000ms / session_ready_latency p95 < 1000ms / http_req_duration p95 < 500ms を閾値化。既存 `create-session.js` の誤 path (`/api/v1/sessions`) を実装 Fastify route の `/sessions` に合わせて修正、`justfile` / `perf/README.md` も更新。CI 連携と translation-hotpath scenario は後続 PR で扱う。                                                                |
+| 0.5.17     | 2026-04-22 | IMPL-610 Step 2 として k6 smoke を CI に統合。`.github/workflows/k6-smoke.yml` で weekly monday 11:00 UTC + perf/src 変更 PR + workflow_dispatch を trigger に、relay-api を bg 起動 (build → start) → `/health` 待機 → Docker `grafana/k6:latest` で create-session / ws-relay scenarios 実行 → relay.log artifact を upload。provider factory は length>0 check のみで stream 起動しない限り real provider に到達しないため、dummy API key で初期化し mock を production entrypoint に混ぜない構成。IMPL-610 を ✅ 完了に更新。                                           |


### PR DESCRIPTION
## Summary

- `.github/workflows/k6-smoke.yml` (新規): relay-api を bg 起動 (build → start) → `/health` 待機 → Docker `grafana/k6:latest` で `create-session.js` と `ws-relay.js` を実行 → 失敗時は relay.log を artifact として upload。
- trigger: weekly monday 11:00 UTC + perf/src 変更 PR + workflow_dispatch。
- provider factory は `length > 0` check のみで、scenarios が stream を start しないため dummy API key で real Deepgram / DeepL に到達しない構成。mock を production entrypoint に混ぜずに roadmap §3.1 原則を維持。
- Roadmap v0.5.17: IMPL-610 を ✅ 完了に更新。

## Why

Phase 6 §8 IMPL-610 の仕上げ。Step 1 (PR #74) で k6 scenario を入れ、本 PR で CI 統合することで SLO 閾値 (ws_connecting p95 < 3000ms / session_ready_latency p95 < 1000ms / http_req_duration p95 < 500ms) を回帰的に監視可能にする。

## Test plan

- [x] `pnpm lint` / `pnpm fmt:check`
- [ ] CI `All Green` + 新設 `k6 smoke` job 通過
- [ ] `k6 smoke` 初回実行で thresholds pass を確認 (本 PR が pull_request trigger に該当するため自動実行されるはず)
- [ ] relay.log artifact に ERROR が混入しない (dummy API key で起動できる想定)