### PR TITLE
infra(relay-api): IMPL-700 Step 1 Cloud Run deploy workflow 雛形

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -1,0 +1,148 @@
+name: Deploy Relay API to Cloud Run
+
+# IMPL-700 Step 1 — Phase 7 M4 リリースパイプラインの雛形。
+#
+# infrastructure-design.md §4.2 デプロイ手順:
+#   1. main merge で CI 起動 (ci.yml)
+#   2. Lint / Test / Build (ci.yml)
+#   3. Relay Image build → Artifact Registry (本 workflow)
+#   4. Staging deploy + smoke (本 workflow)
+#   5. Approval 後 production deploy (本 workflow)
+#   6. Extension は Chrome Web Store 公開 (IMPL-710, 別 workflow)
+#
+# 現時点の位置付け:
+# - trigger は `workflow_dispatch` のみ。main push による自動 deploy は
+#   GCP 設定完了 (WIF provider / SA / GAR repo / Cloud Run service) 後に
+#   enable する (IMPL-700 Step 2)。
+# - vars/secrets が未設定の環境では最初のガード step で skip。
+# - Workload Identity Federation を使い、長期 SA key を GitHub Secrets に
+#   置かない (security-design §5.2 極秘データ取り扱い)。
+#
+# 必要な GitHub configuration (IMPL-700 Step 2 で config):
+#   vars:
+#     GCP_PROJECT_ID          = GCP プロジェクト ID
+#     GCP_REGION              = asia-northeast1 (既定)
+#     GAR_REPOSITORY          = perapera (既定)
+#   secrets:
+#     GCP_WORKLOAD_IDENTITY_PROVIDER = projects/<num>/locations/global/workloadIdentityPools/<pool>/providers/<provider>
+#     GCP_DEPLOY_SERVICE_ACCOUNT     = deploy-sa@<project>.iam.gserviceaccount.com
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Deploy target environment
+        type: choice
+        options:
+          - staging
+          - production
+        default: staging
+
+concurrency:
+  group: deploy-relay-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+  GCP_REGION: ${{ vars.GCP_REGION || 'asia-northeast1' }}
+  GAR_REPOSITORY: ${{ vars.GAR_REPOSITORY || 'perapera' }}
+  IMAGE_NAME: relay-api
+
+jobs:
+  deploy:
+    name: Build image + deploy (${{ github.event.inputs.environment }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CLOUD_RUN_SERVICE: ${{ github.event.inputs.environment == 'production' && 'perapera-relay-api' || 'perapera-relay-api-staging' }}
+    steps:
+      - name: Guard — require GCP configuration
+        id: guard
+        run: |
+          if [ -z "${GCP_PROJECT_ID}" ]; then
+            echo "::warning::GCP_PROJECT_ID variable is not configured; skipping deploy job."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}" ]; then
+            echo "::warning::GCP_WORKLOAD_IDENTITY_PROVIDER secret is not configured; skipping deploy job."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}" ]; then
+            echo "::warning::GCP_DEPLOY_SERVICE_ACCOUNT secret is not configured; skipping deploy job."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.guard.outputs.ready == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Authenticate to GCP (Workload Identity Federation)
+        if: steps.guard.outputs.ready == 'true'
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        if: steps.guard.outputs.ready == 'true'
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Configure Docker auth for Artifact Registry
+        if: steps.guard.outputs.ready == 'true'
+        run: gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
+
+      - name: Set up Docker Buildx
+        if: steps.guard.outputs.ready == 'true'
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Build and push image to Artifact Registry
+        if: steps.guard.outputs.ready == 'true'
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          file: packages/relay-api/Dockerfile
+          push: true
+          tags: |
+            ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.environment }}-latest
+          cache-from: type=gha,scope=relay-api
+          cache-to: type=gha,mode=max,scope=relay-api
+
+      - name: Deploy to Cloud Run
+        if: steps.guard.outputs.ready == 'true'
+        uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522 # v2
+        with:
+          service: ${{ env.CLOUD_RUN_SERVICE }}
+          region: ${{ env.GCP_REGION }}
+          image: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          flags: |
+            --memory=512Mi
+            --cpu=1
+            --concurrency=80
+            --min-instances=0
+            --max-instances=10
+            --allow-unauthenticated
+
+      - name: Smoke test /health
+        if: steps.guard.outputs.ready == 'true'
+        run: |
+          URL=$(gcloud run services describe "${CLOUD_RUN_SERVICE}" \
+            --region="${GCP_REGION}" --format='value(status.url)')
+          echo "Deployed service URL: $URL"
+          for i in $(seq 1 30); do
+            if curl -fsS "${URL}/health" > /dev/null; then
+              echo "Smoke OK"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Smoke failed after 60s"
+          exit 1

--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.5.18'
+version: '0.5.19'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -428,10 +428,13 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 
 **範囲:**
 
-- IMPL-700 Cloud Run デプロイ pipeline (GitHub Actions + `gh` auth)
-- IMPL-710 Chrome Web Store manifest + packaging (署名鍵管理)
-- IMPL-720 ランブック / インシデント対応手順
-- IMPL-730 ベータ配布 → 一般公開
+- IMPL-700 Cloud Run デプロイ pipeline (GitHub Actions + `gh` auth) — 🟡 Step 1 完了 (workflow 雛形):
+  - `.github/workflows/deploy-relay.yml` 新設。workflow_dispatch only、WIF auth → Artifact Registry push → Cloud Run deploy → `/health` smoke の骨組み
+  - GCP vars/secrets が未設定の環境では guard step で no-op (develop merge 後も副作用なし)
+  - Step 2 (実運用設定): GCP プロジェクト作成、WIF pool/provider、GAR repository、Service Account 権限、GitHub vars/secrets 配置、main push trigger enable
+- IMPL-710 Chrome Web Store manifest + packaging (署名鍵管理) — ⚪ 未着手
+- IMPL-720 ランブック / インシデント対応手順 — ⚪ 未着手
+- IMPL-730 ベータ配布 → 一般公開 — ⚪ 未着手
 
 ## 10. 直近で閉じたい設計論点 (ロードマップ外の宿題)
 
@@ -474,3 +477,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.5.16     | 2026-04-22 | IMPL-610 Step 1 として WebSocket ホットパスの k6 scenario を追加。`perf/scenarios/ws-relay.js` で `POST /sessions` → WS `/relay` → `session.ready` 受信までを同時 3 VU × 30s で計測し、ws_connecting p95 < 3000ms / session_ready_latency p95 < 1000ms / http_req_duration p95 < 500ms を閾値化。既存 `create-session.js` の誤 path (`/api/v1/sessions`) を実装 Fastify route の `/sessions` に合わせて修正、`justfile` / `perf/README.md` も更新。CI 連携と translation-hotpath scenario は後続 PR で扱う。                                                                |
 | 0.5.17     | 2026-04-22 | IMPL-610 Step 2 として k6 smoke を CI に統合。`.github/workflows/k6-smoke.yml` で weekly monday 11:00 UTC + perf/src 変更 PR + workflow_dispatch を trigger に、relay-api を bg 起動 (build → start) → `/health` 待機 → Docker `grafana/k6:latest` で create-session / ws-relay scenarios 実行 → relay.log artifact を upload。provider factory は length>0 check のみで stream 起動しない限り real provider に到達しないため、dummy API key で初期化し mock を production entrypoint に混ぜない構成。IMPL-610 を ✅ 完了に更新。                                           |
 | 0.5.18     | 2026-04-22 | IMPL-620 (脅威モデル最終確認) を完了。`docs/09-security-design/threat-matrix-impl-mapping.md` を新設し、security-design §2 STRIDE 6 カテゴリ × 実装 IMPL 番号 / ファイルパスを trace。主対策 (短命 JWT / Bearer + JWT 認証 / 生音声非永続化 / ログマスキング / レートリミット / circuit breaker / degraded / MV3 最小権限 / CORS / helmet / dependabot+audit) は全て実装済を確認。3 件の低優先 gap (client event sequence / IndexedDB TTL / 本番 manifest host_permissions 切替) を note として記録、Phase 7 IMPL-700/710 に委譲。                                          |
+| 0.5.19     | 2026-04-22 | Phase 7 IMPL-700 Step 1 として Cloud Run deploy workflow 雛形を追加。`.github/workflows/deploy-relay.yml` で workflow_dispatch only trigger、WIF (`google-github-actions/auth@v2` SHA pin) → Artifact Registry push → `deploy-cloudrun@v2` → `/health` smoke の骨組み。GCP vars/secrets 未設定時は guard step で no-op (develop merge 後も副作用なし)。実運用設定 (GCP プロジェクト / WIF / GAR / SA / vars/secrets 配置) は Step 2 へ委譲。§9 Phase 7 の IMPL-700 を 🟡 Step 1 完了に更新。                                                                                |


### PR DESCRIPTION
## Summary

- `.github/workflows/deploy-relay.yml` (新規): workflow_dispatch only、WIF auth → Artifact Registry push → Cloud Run deploy → `/health` smoke の骨組み。
- Guard step で GCP vars / secrets が未設定なら no-op (develop merge 後も副作用なし)。
- 全 third-party action は SHA pin (google-github-actions/auth@v2 c200f36 / setup-gcloud@v2 e427ad8 / deploy-cloudrun@v2 251330b)。
- Roadmap v0.5.19: §9 Phase 7 の IMPL-700 を 🟡 Step 1 完了に更新。

## Context

Phase 6 §8 の IMPL-610/620/630 が完了し、IMPL-600 (E2E 残 2 spec) は規模大で loop 継続に不向き。本 PR から Phase 7 M4 Release pipeline に進む。本 PR は雛形のみで、Step 2 (GCP プロジェクト作成 / WIF pool/provider / GAR repo / Service Account 権限 / GitHub vars+secrets 配置) は別作業。

## Test plan

- [x] `pnpm lint` / `pnpm fmt:check`
- [ ] CI `All Green` (新 workflow は手動 trigger only で自動実行されない)
- [ ] 将来 GCP config 投入後に workflow_dispatch から staging deploy 成功を確認