### PR TITLE
infra(extension): IMPL-710 Step 1 Chrome Web Store publish workflow 雛形

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,153 @@
+name: Publish Extension to Chrome Web Store
+
+# IMPL-710 Step 1 — Chrome Web Store 公開パイプラインの雛形。
+#
+# infrastructure-design.md §4.2 (拡張は Relay API と独立して段階公開) に準拠。
+#
+# trigger:
+#   - tag push (v*.*.* / Chrome Web Store 公開は `release/` ブランチ発行後の
+#     semver tag を基準にする)
+#   - workflow_dispatch (手動上書き用)
+#
+# flow:
+#   1. wxt build + zip (既存 ci.yml / release.yml と同じ手順)
+#   2. Chrome Web Store API (OAuth2 refresh token) で新バージョンをアップロード
+#   3. 公開 (`--publish` フラグ付き) は input で選択。初期運用では未公開
+#      アップロード → 手動レビューで publish
+#
+# 必要な GitHub configuration (Step 2 で config):
+#   vars:
+#     CHROME_EXTENSION_ID = Chrome Web Store で割り当てられる拡張 ID
+#   secrets:
+#     CHROME_CLIENT_ID     = OAuth2 Client ID (Google Cloud Console)
+#     CHROME_CLIENT_SECRET = OAuth2 Client Secret
+#     CHROME_REFRESH_TOKEN = OAuth2 refresh token (手動で取得した長期 token)
+#
+# guard: CHROME_EXTENSION_ID / secrets のいずれかが未設定なら job 全体を skip。
+#
+# third-party action: `chrome-webstore-upload/publish` は upstream 提供が
+# 薄いため、`chrome-webstore-upload-cli` を直接 npm install して CLI から
+# 呼ぶ方式を採用 (supply chain 面で信頼できる chrome-webstore-upload-cli は
+# >10 年運用実績あり)。
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish immediately after upload
+        type: boolean
+        default: false
+      target:
+        description: Publish target (default / trustedTesters)
+        type: choice
+        options:
+          - default
+          - trustedTesters
+        default: trustedTesters
+
+concurrency:
+  group: publish-extension-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  EXTENSION_ID: ${{ vars.CHROME_EXTENSION_ID }}
+
+jobs:
+  publish:
+    name: Upload + publish (${{ github.event.inputs.target || 'trustedTesters' }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Guard — require Chrome Web Store configuration
+        id: guard
+        run: |
+          if [ -z "${EXTENSION_ID}" ]; then
+            echo "::warning::CHROME_EXTENSION_ID variable is not configured; skipping publish."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "${{ secrets.CHROME_CLIENT_ID }}" ] || [ -z "${{ secrets.CHROME_CLIENT_SECRET }}" ] || [ -z "${{ secrets.CHROME_REFRESH_TOKEN }}" ]; then
+            echo "::warning::CHROME_CLIENT_ID / CHROME_CLIENT_SECRET / CHROME_REFRESH_TOKEN secrets are not configured; skipping publish."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.guard.outputs.ready == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        if: steps.guard.outputs.ready == 'true'
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        if: steps.guard.outputs.ready == 'true'
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.guard.outputs.ready == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build + zip extension
+        if: steps.guard.outputs.ready == 'true'
+        run: |
+          pnpm --filter @perapera/extension build
+          pnpm --filter @perapera/extension zip
+
+      - name: Resolve zip artifact path
+        if: steps.guard.outputs.ready == 'true'
+        id: zip
+        run: |
+          ZIP_PATH=$(ls packages/extension/.output/*.zip | head -n 1)
+          if [ -z "${ZIP_PATH}" ]; then
+            echo "::error::wxt zip produced no artifact"
+            exit 1
+          fi
+          echo "path=${ZIP_PATH}" >> "$GITHUB_OUTPUT"
+          echo "Uploading ${ZIP_PATH}"
+
+      - name: Upload to Chrome Web Store
+        if: steps.guard.outputs.ready == 'true'
+        env:
+          CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+        run: |
+          npx --yes chrome-webstore-upload-cli@3 upload \
+            --source "${{ steps.zip.outputs.path }}" \
+            --extension-id "${EXTENSION_ID}" \
+            --client-id "${CLIENT_ID}" \
+            --client-secret "${CLIENT_SECRET}" \
+            --refresh-token "${REFRESH_TOKEN}"
+
+      - name: Publish to Chrome Web Store
+        # `publish: true` のときだけ publish step を実行。
+        # 初期運用 (β / 限定公開) は upload のみで手動レビューに委ねる想定。
+        if: >
+          steps.guard.outputs.ready == 'true' &&
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
+        env:
+          CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+        run: |
+          npx --yes chrome-webstore-upload-cli@3 publish \
+            --extension-id "${EXTENSION_ID}" \
+            --client-id "${CLIENT_ID}" \
+            --client-secret "${CLIENT_SECRET}" \
+            --refresh-token "${REFRESH_TOKEN}" \
+            --target "${{ github.event.inputs.target || 'trustedTesters' }}"
+
+      - name: Upload zip artifact
+        if: always() && steps.guard.outputs.ready == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: extension-release-zip
+          path: packages/extension/.output/*.zip
+          retention-days: 30

--- a/docs/in-progress/12-implementation-tasks/roadmap.md
+++ b/docs/in-progress/12-implementation-tasks/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: 実装ロードマップ
-version: '0.5.19'
+version: '0.5.20'
 status: in-progress
 created: '2026-04-21'
 last_updated: '2026-04-22'
@@ -432,7 +432,11 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
   - `.github/workflows/deploy-relay.yml` 新設。workflow_dispatch only、WIF auth → Artifact Registry push → Cloud Run deploy → `/health` smoke の骨組み
   - GCP vars/secrets が未設定の環境では guard step で no-op (develop merge 後も副作用なし)
   - Step 2 (実運用設定): GCP プロジェクト作成、WIF pool/provider、GAR repository、Service Account 権限、GitHub vars/secrets 配置、main push trigger enable
-- IMPL-710 Chrome Web Store manifest + packaging (署名鍵管理) — ⚪ 未着手
+- IMPL-710 Chrome Web Store manifest + packaging (署名鍵管理) — 🟡 Step 1 完了 (publish workflow 雛形):
+  - `.github/workflows/publish-extension.yml` 新設。tag push (`v*.*.*`) + workflow_dispatch trigger、wxt build + zip → `chrome-webstore-upload-cli@3` で Chrome Web Store API にアップロード → 任意で publish (target: default / trustedTesters 切替)
+  - guard step で `CHROME_EXTENSION_ID` / `CHROME_CLIENT_ID` / `CHROME_CLIENT_SECRET` / `CHROME_REFRESH_TOKEN` が未設定なら skip (develop merge 後も副作用なし)
+  - 初期運用 (β / 限定公開) は upload 止まりで手動レビューに委ね、`publish: true` input のときだけ publish step が走る設計
+  - Step 2 (実運用設定): Chrome Developer Dashboard での拡張登録、OAuth2 client + refresh token 取得、GitHub vars/secrets 配置、`wxt.config.ts` に環境別 manifest 生成設定追加
 - IMPL-720 ランブック / インシデント対応手順 — ⚪ 未着手
 - IMPL-730 ベータ配布 → 一般公開 — ⚪ 未着手
 
@@ -478,3 +482,4 @@ Phase 4 で D1 / D2 を消化、D4 は設計書方針を明示的に確認。残
 | 0.5.17     | 2026-04-22 | IMPL-610 Step 2 として k6 smoke を CI に統合。`.github/workflows/k6-smoke.yml` で weekly monday 11:00 UTC + perf/src 変更 PR + workflow_dispatch を trigger に、relay-api を bg 起動 (build → start) → `/health` 待機 → Docker `grafana/k6:latest` で create-session / ws-relay scenarios 実行 → relay.log artifact を upload。provider factory は length>0 check のみで stream 起動しない限り real provider に到達しないため、dummy API key で初期化し mock を production entrypoint に混ぜない構成。IMPL-610 を ✅ 完了に更新。                                           |
 | 0.5.18     | 2026-04-22 | IMPL-620 (脅威モデル最終確認) を完了。`docs/09-security-design/threat-matrix-impl-mapping.md` を新設し、security-design §2 STRIDE 6 カテゴリ × 実装 IMPL 番号 / ファイルパスを trace。主対策 (短命 JWT / Bearer + JWT 認証 / 生音声非永続化 / ログマスキング / レートリミット / circuit breaker / degraded / MV3 最小権限 / CORS / helmet / dependabot+audit) は全て実装済を確認。3 件の低優先 gap (client event sequence / IndexedDB TTL / 本番 manifest host_permissions 切替) を note として記録、Phase 7 IMPL-700/710 に委譲。                                          |
 | 0.5.19     | 2026-04-22 | Phase 7 IMPL-700 Step 1 として Cloud Run deploy workflow 雛形を追加。`.github/workflows/deploy-relay.yml` で workflow_dispatch only trigger、WIF (`google-github-actions/auth@v2` SHA pin) → Artifact Registry push → `deploy-cloudrun@v2` → `/health` smoke の骨組み。GCP vars/secrets 未設定時は guard step で no-op (develop merge 後も副作用なし)。実運用設定 (GCP プロジェクト / WIF / GAR / SA / vars/secrets 配置) は Step 2 へ委譲。§9 Phase 7 の IMPL-700 を 🟡 Step 1 完了に更新。                                                                                |
+| 0.5.20     | 2026-04-22 | Phase 7 IMPL-710 Step 1 として Chrome Web Store publish workflow 雛形を追加。`.github/workflows/publish-extension.yml` で tag push (`v*.*.*`) + workflow_dispatch trigger、wxt build + zip → `chrome-webstore-upload-cli@3` で upload → `publish: true` のときだけ publish step (target: default / trustedTesters)。guard で `CHROME_EXTENSION_ID` / OAuth2 secrets 未設定時は skip。実運用 (Chrome Developer Dashboard 登録 / refresh token 取得 / vars+secrets 配置 / env 別 manifest 生成) は Step 2 へ委譲。§9 Phase 7 の IMPL-710 を 🟡 Step 1 完了に更新。            |


### PR DESCRIPTION
## Summary

- `.github/workflows/publish-extension.yml` (新規): tag push (`v*.*.*`) + workflow_dispatch trigger、wxt build + zip → `chrome-webstore-upload-cli@3` で upload → `publish: true` input のときだけ publish (target: default / trustedTesters)。
- Guard step で `CHROME_EXTENSION_ID` + OAuth2 secrets 未設定時は skip (develop merge 後も副作用なし)。
- 既存 `release.yml` (scaffold) は zip build artifact 用にそのまま維持、本 workflow は Chrome Web Store API publish 専用。
- Roadmap v0.5.20: §9 Phase 7 の IMPL-710 を 🟡 Step 1 完了に更新。

## Context

Phase 7 IMPL-700 Step 1 (Cloud Run deploy workflow, PR #77) に続く拡張配布側の雛形。初期運用は upload のみ → 手動レビューで publish の想定、fully-automated publish は Step 2 で enable。

## Test plan

- [x] `pnpm lint` / `pnpm fmt:check`
- [ ] CI `All Green` (新 workflow は guard step で no-op)
- [ ] 将来 Chrome Developer Dashboard 登録 + OAuth2 refresh token 取得後に workflow_dispatch から β 配布 smoke を確認