### PR TITLE
fix(extension): permission coordinator に contains short-circuit を追加

### DIFF
--- a/packages/extension/src/composition/extension-composition.test.ts
+++ b/packages/extension/src/composition/extension-composition.test.ts
@@ -41,6 +41,7 @@ const createTestPorts = (overrides: Partial<ExtensionRuntimePorts> = {}): Extens
   const storage = overrides.chromeStorageAdapter ?? createFakeStorage();
   return {
     chromePermissionsApi: {
+      contains: vi.fn(() => Promise.resolve(true)),
       request: vi.fn(() => Promise.resolve(true)),
     },
     chromeStorageAdapter: storage,
@@ -198,7 +199,10 @@ describe('createExtensionApp (IMPL-500)', () => {
 
     const ports = createTestPorts({
       chromeStorageAdapter: storage,
-      chromePermissionsApi: { request: vi.fn(() => Promise.resolve(false)) },
+      chromePermissionsApi: {
+        contains: vi.fn(() => Promise.resolve(false)),
+        request: vi.fn(() => Promise.resolve(false)),
+      },
     });
     app = createExtensionApp(config, ports);
     const result = await app.sessionCommandService.startSource({

--- a/packages/extension/src/infrastructure/permission/chrome-permission-coordinator.test.ts
+++ b/packages/extension/src/infrastructure/permission/chrome-permission-coordinator.test.ts
@@ -1,30 +1,51 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   createChromePermissionCoordinator,
   type ChromePermissionsApi,
 } from './chrome-permission-coordinator';
 
-const createFakeApi = (granted: boolean | Error): ChromePermissionsApi => ({
-  request: () => (granted instanceof Error ? Promise.reject(granted) : Promise.resolve(granted)),
+type FakeConfig = Readonly<{
+  contains?: boolean | Error;
+  request?: boolean | Error;
+}>;
+
+const resolveOrReject = (value: boolean | Error): Promise<boolean> =>
+  value instanceof Error ? Promise.reject(value) : Promise.resolve(value);
+
+const createFakeApi = (config: FakeConfig): ChromePermissionsApi => ({
+  contains: vi.fn(() => resolveOrReject(config.contains ?? false)),
+  request: vi.fn(() => resolveOrReject(config.request ?? false)),
 });
 
 describe('createChromePermissionCoordinator (IMPL-318, DD-001)', () => {
-  it('returns granted when chrome.permissions.request resolves true for tab', async () => {
-    const coordinator = createChromePermissionCoordinator({
-      chromePermissionsApi: createFakeApi(true),
-    });
+  it('returns granted without calling request when permission is already contained (manifest-declared)', async () => {
+    const api = createFakeApi({ contains: true });
+    const coordinator = createChromePermissionCoordinator({ chromePermissionsApi: api });
     const result = await coordinator.requestFor('tab');
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value.status).toBe('granted');
       expect(result.value.sourceType).toBe('tab');
     }
+    expect(api.contains).toHaveBeenCalledTimes(1);
+    expect(api.request).not.toHaveBeenCalled();
   });
 
-  it('returns denied when chrome.permissions.request resolves false for desktop', async () => {
-    const coordinator = createChromePermissionCoordinator({
-      chromePermissionsApi: createFakeApi(false),
-    });
+  it('falls back to request when contains resolves false and request grants', async () => {
+    const api = createFakeApi({ contains: false, request: true });
+    const coordinator = createChromePermissionCoordinator({ chromePermissionsApi: api });
+    const result = await coordinator.requestFor('desktop');
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.status).toBe('granted');
+    }
+    expect(api.contains).toHaveBeenCalledTimes(1);
+    expect(api.request).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns denied when contains is false and request resolves false', async () => {
+    const api = createFakeApi({ contains: false, request: false });
+    const coordinator = createChromePermissionCoordinator({ chromePermissionsApi: api });
     const result = await coordinator.requestFor('desktop');
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -33,29 +54,38 @@ describe('createChromePermissionCoordinator (IMPL-318, DD-001)', () => {
     }
   });
 
-  it('returns system-error DomainError when chrome.permissions.request rejects', async () => {
-    const coordinator = createChromePermissionCoordinator({
-      chromePermissionsApi: createFakeApi(new Error('permission api down')),
-    });
+  it('returns system-error DomainError when contains rejects', async () => {
+    const api = createFakeApi({ contains: new Error('contains api down') });
+    const coordinator = createChromePermissionCoordinator({ chromePermissionsApi: api });
     const result = await coordinator.requestFor('tab');
     expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.kind).toBe('invariant-violation');
-      if (result.error.kind === 'invariant-violation') {
-        expect(result.error.invariant).toBe('permission-coordinator-system-error');
-      }
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('permission-coordinator-system-error');
+      expect(result.error.details).toContain('contains');
+    }
+  });
+
+  it('returns system-error DomainError when request rejects after contains is false', async () => {
+    const api = createFakeApi({ contains: false, request: new Error('request api down') });
+    const coordinator = createChromePermissionCoordinator({ chromePermissionsApi: api });
+    const result = await coordinator.requestFor('tab');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('permission-coordinator-system-error');
+      expect(result.error.details).toContain('request');
     }
   });
 
   it('returns granted synchronously for microphone (getUserMedia UA prompt handles consent)', async () => {
-    const coordinator = createChromePermissionCoordinator({
-      chromePermissionsApi: createFakeApi(new Error('should not be called')),
-    });
+    const api = createFakeApi({ contains: new Error('should not be called') });
+    const coordinator = createChromePermissionCoordinator({ chromePermissionsApi: api });
     const result = await coordinator.requestFor('microphone');
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value.status).toBe('granted');
       expect(result.value.sourceType).toBe('microphone');
     }
+    expect(api.contains).not.toHaveBeenCalled();
+    expect(api.request).not.toHaveBeenCalled();
   });
 });

--- a/packages/extension/src/infrastructure/permission/chrome-permission-coordinator.ts
+++ b/packages/extension/src/infrastructure/permission/chrome-permission-coordinator.ts
@@ -10,22 +10,28 @@ import { invariantViolationError, type DomainError } from '../../domain/shared/e
  * chrome.permissions API の最小 contract。production では chrome.permissions を
  * そのまま利用する default 実装を、test では minimal fake を注入する。
  *
- * MVP では `request` のみを使う ( `contains` / `remove` は将来拡張)。
+ * `contains` を必須にしたのは MV3 の manifest 宣言済み permission に対し
+ * `request` を呼ぶと Chrome 版によっては user gesture 要求で reject する
+ * ケースがあるため (Popup → background の async gap で user gesture が
+ * 失効する)。`contains` は user gesture 非依存で常に動き、manifest 宣言済
+ * permission は install 時に granted 済みのため即 true を返す。
  */
 export type ChromePermissionsApi = Readonly<{
+  contains: (permissions: chrome.permissions.Permissions) => Promise<boolean>;
   request: (permissions: chrome.permissions.Permissions) => Promise<boolean>;
 }>;
 
-/**
- * Production `ChromePermissionsApi` 実装 (mock ではない)。
- * `chrome.permissions.request` の callback API を Promise に wrap する。
- * `chrome.runtime.lastError` は Promise reject に変換する。
- */
-export const defaultChromePermissionsApi: ChromePermissionsApi = {
-  request: (permissions) =>
+const wrapCallbackPromise =
+  (
+    scope: (
+      permissions: chrome.permissions.Permissions,
+      callback: (granted: boolean) => void,
+    ) => void,
+  ) =>
+  (permissions: chrome.permissions.Permissions): Promise<boolean> =>
     new Promise<boolean>((resolve, reject) => {
       try {
-        chrome.permissions.request(permissions, (granted) => {
+        scope(permissions, (granted) => {
           const lastError = chrome.runtime.lastError;
           if (lastError !== undefined) {
             reject(new Error(lastError.message ?? 'unknown chrome.permissions error'));
@@ -36,7 +42,15 @@ export const defaultChromePermissionsApi: ChromePermissionsApi = {
       } catch (cause) {
         reject(cause instanceof Error ? cause : new Error(String(cause)));
       }
-    }),
+    });
+
+/**
+ * Production `ChromePermissionsApi` 実装 (mock ではない)。
+ * `chrome.permissions.contains` / `request` の callback API を Promise に wrap。
+ */
+export const defaultChromePermissionsApi: ChromePermissionsApi = {
+  contains: wrapCallbackPromise((perms, cb) => chrome.permissions.contains(perms, cb)),
+  request: wrapCallbackPromise((perms, cb) => chrome.permissions.request(perms, cb)),
 };
 
 /**
@@ -72,6 +86,14 @@ export type ChromePermissionCoordinatorDependencies = Readonly<{
   chromePermissionsApi: ChromePermissionsApi;
 }>;
 
+const toSystemError =
+  (scope: 'contains' | 'request') =>
+  (cause: unknown): DomainError =>
+    invariantViolationError({
+      invariant: 'permission-coordinator-system-error',
+      details: `${scope}: ${cause instanceof Error ? cause.message : String(cause)}`,
+    });
+
 export const createChromePermissionCoordinator = (
   deps: ChromePermissionCoordinatorDependencies,
 ): PermissionCoordinator => ({
@@ -89,21 +111,35 @@ export const createChromePermissionCoordinator = (
           }),
       );
     }
+    // manifest 宣言済み permission は install 時に granted 済みなので、
+    // まず `contains` で確認し既に granted なら request を skip する
+    // (`request` は user gesture 要求で reject するケースがあるため)。
     return ResultAsync.fromPromise<boolean, DomainError>(
-      deps.chromePermissionsApi.request(permissions),
-      (cause) =>
-        invariantViolationError({
-          invariant: 'permission-coordinator-system-error',
-          details: cause instanceof Error ? cause.message : String(cause),
-        }),
-    ).map<PermissionGrant>((granted) =>
-      granted
-        ? { status: 'granted', sourceType }
-        : {
-            status: 'denied',
-            sourceType,
-            reason: `user denied ${sourceType} permission`,
-          },
-    );
+      deps.chromePermissionsApi.contains(permissions),
+      toSystemError('contains'),
+    ).andThen<PermissionGrant, DomainError>((alreadyGranted) => {
+      if (alreadyGranted) {
+        return ResultAsync.fromPromise<PermissionGrant, DomainError>(
+          Promise.resolve<PermissionGrant>({ status: 'granted', sourceType }),
+          () =>
+            invariantViolationError({
+              invariant: 'permission-coordinator-impossible',
+              details: 'already-granted resolved synchronously cannot error',
+            }),
+        );
+      }
+      return ResultAsync.fromPromise<boolean, DomainError>(
+        deps.chromePermissionsApi.request(permissions),
+        toSystemError('request'),
+      ).map<PermissionGrant>((granted) =>
+        granted
+          ? { status: 'granted', sourceType }
+          : {
+              status: 'denied',
+              sourceType,
+              reason: `user denied ${sourceType} permission`,
+            },
+      );
+    });
   },
 });


### PR DESCRIPTION
## Summary

Popup から「開始」を押すと SW 側で `domain invariant violated: permission-coordinator-system-error` で失敗する問題を修正。

## Root cause

- manifest に宣言済みの permission (tabCapture / desktopCapture) に対し `chrome.permissions.request` を呼ぶと、一部 Chrome 版で `This function must be called during a user gesture` により reject する。Popup → background のメッセージ経由で request を呼ぶと、async gap で user gesture が失効するため該当しやすい。
- `chrome.permissions.request` は manifest 宣言済 permission について install 時点で granted のため本来 request 不要。

## Fix

1. `ChromePermissionsApi` に `contains` を必須フィールドとして追加。
2. `defaultChromePermissionsApi.contains` を `chrome.permissions.contains` の Promise wrap で実装。
3. `createChromePermissionCoordinator.requestFor` が先に `contains` を呼び、`true` なら request を skip して即 granted。`false` のときだけ既存通り request にフォールバック。
4. system-error の `details` に `contains:` / `request:` prefix を付与して発生箇所を判別可能に。

## Test plan

- [x] `pnpm --filter @perapera/extension typecheck`
- [x] `pnpm --filter @perapera/extension test` — 900 passed (+2 新規: already-contained / contains-reject)
- [x] `pnpm --filter @perapera/extension build` — 481.73 kB chrome-mv3
- [x] `pnpm lint`
- [ ] 手動: Chrome に unpacked を再 load → Popup から「開始」→ SW コンソールに `permission-coordinator-system-error` が出ないこと

## CI

- [ ] All Green