### PR TITLE
fix(extension): CaptureOrchestrator を SW-safe な placeholder に

### DIFF
--- a/packages/extension/src/application/services/capture-orchestrator.test.ts
+++ b/packages/extension/src/application/services/capture-orchestrator.test.ts
@@ -1,165 +1,63 @@
-import { errAsync, okAsync } from 'neverthrow';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   parseSessionIdentifier,
   type SessionIdentifier,
 } from '../../domain/session/session-identifier';
-import { invariantViolationError } from '../../domain/shared/errors';
-import { type AudioFrameChannel, type AudioPreprocessor } from '../ports/audio-preprocessor';
-import {
-  type SourceAdapter,
-  type SourceAdapterFactory,
-  type StartSourceCommand,
-} from '../ports/source-adapter';
+import { type StartSourceCommand } from '../ports/source-adapter';
 import { createCaptureOrchestrator } from './capture-orchestrator';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const sessionIdentifier: SessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
 
-const buildCommand = (): StartSourceCommand => ({
+const buildMicCommand = (): StartSourceCommand => ({
   sourceType: 'microphone',
   sessionIdentifier,
   deviceId: 'default',
 });
 
-const buildFrameChannel = (): AudioFrameChannel & { close: ReturnType<typeof vi.fn> } => ({
-  frames: {
-    [Symbol.asyncIterator]: () => ({
-      next: () => Promise.resolve({ done: true as const, value: undefined }),
-    }),
-  },
-  close: vi.fn(),
+const buildTabCommand = (): StartSourceCommand => ({
+  sourceType: 'tab',
+  sessionIdentifier,
 });
 
-const buildAdapter = (): SourceAdapter & {
-  open: ReturnType<typeof vi.fn>;
-  close: ReturnType<typeof vi.fn>;
-} => {
-  const stream = new MediaStream();
-  const open = vi.fn(() => okAsync<MediaStream, never>(stream));
-  const close = vi.fn(() => okAsync<void, never>(undefined));
-  return { open, close };
-};
-
-const buildFactory = (
-  adapter: SourceAdapter,
-): SourceAdapterFactory & {
-  create: ReturnType<typeof vi.fn>;
-} => {
-  const create = vi.fn(() => adapter);
-  return { create };
-};
-
-const buildPreprocessor = (
-  channel: AudioFrameChannel,
-): AudioPreprocessor & {
-  attach: ReturnType<typeof vi.fn>;
-  detach: ReturnType<typeof vi.fn>;
-} => ({
-  attach: vi.fn(() => okAsync<AudioFrameChannel, never>(channel)),
-  detach: vi.fn(() => okAsync<void, never>(undefined)),
-});
-
-describe('createCaptureOrchestrator (IMPL-341)', () => {
-  it('connect opens the adapter and attaches preprocessor, returning ActiveCapture', async () => {
-    const adapter = buildAdapter();
-    const factory = buildFactory(adapter);
-    const channel = buildFrameChannel();
-    const preprocessor = buildPreprocessor(channel);
-    const orchestrator = createCaptureOrchestrator({
-      sourceAdapterFactory: factory,
-      audioPreprocessor: preprocessor,
-    });
-    const result = await orchestrator.connect(buildCommand());
+describe('createCaptureOrchestrator (IMPL-341, SW-safe placeholder)', () => {
+  it('connect returns ActiveCapture with empty frame channel for tab source', async () => {
+    const orchestrator = createCaptureOrchestrator();
+    const result = await orchestrator.connect(buildTabCommand());
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value.sessionIdentifier).toBe(sessionIdentifier);
-      expect(result.value.frameChannel).toBe(channel);
+      expect(result.value.sourceType).toBe('tab');
+      // frame channel is empty: iterate 即 done (offscreen 経路が実 stream を持つ)
+      const iter = result.value.frameChannel.frames[Symbol.asyncIterator]();
+      const first = await iter.next();
+      expect(first.done).toBe(true);
     }
-    expect(factory.create).toHaveBeenCalledWith('microphone');
-    expect(adapter.open).toHaveBeenCalledTimes(1);
-    expect(preprocessor.attach).toHaveBeenCalledTimes(1);
   });
 
-  it('connect surfaces adapter open failure', async () => {
-    const adapter: SourceAdapter = {
-      open: () =>
-        errAsync(invariantViolationError({ invariant: 'source-open-failed', details: 'boom' })),
-      close: () => okAsync<void, never>(undefined),
-    };
-    const orchestrator = createCaptureOrchestrator({
-      sourceAdapterFactory: buildFactory(adapter),
-      audioPreprocessor: buildPreprocessor(buildFrameChannel()),
-    });
-    const result = await orchestrator.connect(buildCommand());
-    expect(result.isErr()).toBe(true);
-  });
-
-  it('connect surfaces preprocessor attach failure', async () => {
-    const adapter = buildAdapter();
-    const factory = buildFactory(adapter);
-    const preprocessor: AudioPreprocessor = {
-      attach: () =>
-        errAsync(
-          invariantViolationError({
-            invariant: 'audio-context-unavailable',
-            details: 'no AudioContext',
-          }),
-        ),
-      detach: () => okAsync<void, never>(undefined),
-    };
-    const orchestrator = createCaptureOrchestrator({
-      sourceAdapterFactory: factory,
-      audioPreprocessor: preprocessor,
-    });
-    const result = await orchestrator.connect(buildCommand());
-    expect(result.isErr()).toBe(true);
-  });
-
-  it('disconnect closes the frame channel and the adapter', async () => {
-    const adapter = buildAdapter();
-    const factory = buildFactory(adapter);
-    const channel = buildFrameChannel();
-    const preprocessor = buildPreprocessor(channel);
-    const orchestrator = createCaptureOrchestrator({
-      sourceAdapterFactory: factory,
-      audioPreprocessor: preprocessor,
-    });
-    await orchestrator.connect(buildCommand());
-    const result = await orchestrator.disconnect(sessionIdentifier);
+  it('connect returns ActiveCapture for microphone / desktop sources as well', async () => {
+    const orchestrator = createCaptureOrchestrator();
+    const result = await orchestrator.connect(buildMicCommand());
     expect(result.isOk()).toBe(true);
-    expect(channel.close).toHaveBeenCalledTimes(1);
-    expect(preprocessor.detach).toHaveBeenCalledWith(sessionIdentifier);
-    expect(adapter.close).toHaveBeenCalledWith(sessionIdentifier);
+    if (result.isOk()) {
+      expect(result.value.sourceType).toBe('microphone');
+    }
+  });
+
+  it('disconnect closes the frame channel and removes the session', async () => {
+    const orchestrator = createCaptureOrchestrator();
+    const connectResult = await orchestrator.connect(buildTabCommand());
+    expect(connectResult.isOk()).toBe(true);
+    const disconnectResult = await orchestrator.disconnect(sessionIdentifier);
+    expect(disconnectResult.isOk()).toBe(true);
+    // 再度 disconnect は no-op
+    const repeatResult = await orchestrator.disconnect(sessionIdentifier);
+    expect(repeatResult.isOk()).toBe(true);
   });
 
   it('disconnect is a no-op for an unknown session', async () => {
-    const adapter = buildAdapter();
-    const preprocessor = buildPreprocessor(buildFrameChannel());
-    const orchestrator = createCaptureOrchestrator({
-      sourceAdapterFactory: buildFactory(adapter),
-      audioPreprocessor: preprocessor,
-    });
+    const orchestrator = createCaptureOrchestrator();
     const result = await orchestrator.disconnect(sessionIdentifier);
     expect(result.isOk()).toBe(true);
-    expect(preprocessor.detach).not.toHaveBeenCalled();
-    expect(adapter.close).not.toHaveBeenCalled();
-  });
-
-  it('disconnect after a failed connect is still a no-op', async () => {
-    const adapter: SourceAdapter = {
-      open: () =>
-        errAsync(invariantViolationError({ invariant: 'source-open-failed', details: 'boom' })),
-      close: vi.fn(() => okAsync<void, never>(undefined)),
-    };
-    const preprocessor = buildPreprocessor(buildFrameChannel());
-    const orchestrator = createCaptureOrchestrator({
-      sourceAdapterFactory: buildFactory(adapter),
-      audioPreprocessor: preprocessor,
-    });
-    await orchestrator.connect(buildCommand());
-    const result = await orchestrator.disconnect(sessionIdentifier);
-    expect(result.isOk()).toBe(true);
-    expect(preprocessor.detach).not.toHaveBeenCalled();
   });
 });

--- a/packages/extension/src/application/services/capture-orchestrator.ts
+++ b/packages/extension/src/application/services/capture-orchestrator.ts
@@ -2,77 +2,83 @@ import { okAsync, type ResultAsync } from 'neverthrow';
 import { type SessionIdentifier } from '../../domain/session/session-identifier';
 import { type SourceType } from '../../domain/session/source-type';
 import { type DomainError } from '../../domain/shared/errors';
-import { type AudioFrameChannel, type AudioPreprocessor } from '../ports/audio-preprocessor';
-import { type SourceAdapterFactory, type StartSourceCommand } from '../ports/source-adapter';
+import { type AudioFrameChannel } from '../ports/audio-preprocessor';
+import { type StartSourceCommand } from '../ports/source-adapter';
 
 /**
  * Active な音声キャプチャ 1 本の実体。
- * - `stream`: Source Adapter で開いた `MediaStream`
- * - `frameChannel`: AudioPreprocessor で attach した PCM フレーム配信 channel
- * - `sourceType`: disconnect 時に SourceAdapter を再取得するため保持
+ *
+ * MV3 Service Worker では `MediaStream` / `AudioContext` が利用できない
+ * ため、実 stream と AudioWorklet は **offscreen document 側**で保持する
+ * (IMPL-612〜618)。SW 側の `ActiveCapture` は session identity / source
+ * type / empty frame channel の placeholder に留める。実フレームは
+ * offscreen → SW へ `audio.frame.forward` メッセージで転送され、
+ * `AudioFrameForwardReceiver` 経由で Relay へ届く。
  */
 export type ActiveCapture = Readonly<{
   sessionIdentifier: SessionIdentifier;
   sourceType: SourceType;
-  stream: MediaStream;
   frameChannel: AudioFrameChannel;
-}>;
-
-export type CaptureOrchestratorDependencies = Readonly<{
-  sourceAdapterFactory: SourceAdapterFactory;
-  audioPreprocessor: AudioPreprocessor;
 }>;
 
 /**
  * IMPL-341 CaptureOrchestrator (detailed-design §2.2)。
  *
- * `SourceAdapter` と `AudioPreprocessor` を束ねる application service。
- * `connect(command)` でソース接続 → 音声前処理 attach を一括で行い、
- * `ActiveCapture` を返す。`disconnect(sessionIdentifier)` で逆順に解放する。
+ * SW 側での session ごとの placeholder 管理を担う。
  *
  * **本番実装で mock が利用されない設計**:
- * - `sourceAdapterFactory` / `audioPreprocessor` は必須 DI (default なし)
- * - production entrypoint で対応する infrastructure adapter を明示的に渡す
+ * - 依存は不要 (state 保持のみ)。production entrypoint でそのまま `createCaptureOrchestrator()` を呼ぶ
  *
- * 注: pause / resume は MVP の scope 外。Relay gateway 側のセッション
- * 状態変更で実現する (AudioContext suspend は AudioPreprocessor の
- * port interface に現時点では存在しない)。
+ * **MV3 制約との整合**: `chrome.tabCapture.capture` / `AudioContext` は
+ * SW で動作しないため、`connect` では実 MediaStream を取得せず empty
+ * frame channel を返す。SW → offscreen の `audio.open` コマンドで
+ * offscreen 側が `chrome.tabCapture.getMediaStreamId` + `getUserMedia`
+ * 経由で stream を取得し、AudioWorklet → `audio.frame.forward` 経由で
+ * PCM16 フレームを Relay へ流す。
  */
 export type CaptureOrchestrator = Readonly<{
   connect: (command: StartSourceCommand) => ResultAsync<ActiveCapture, DomainError>;
   disconnect: (sessionIdentifier: SessionIdentifier) => ResultAsync<void, DomainError>;
 }>;
 
-export const createCaptureOrchestrator = (
-  deps: CaptureOrchestratorDependencies,
-): CaptureOrchestrator => {
+const createEmptyFrameChannel = (): AudioFrameChannel => {
+  let closed = false;
+  return {
+    frames: {
+      [Symbol.asyncIterator]: () => ({
+        next: () =>
+          Promise.resolve<IteratorResult<never>>({
+            done: true,
+            value: undefined,
+          }),
+      }),
+    },
+    close: () => {
+      closed = true;
+      void closed;
+    },
+  };
+};
+
+export const createCaptureOrchestrator = (): CaptureOrchestrator => {
   const active = new Map<SessionIdentifier, ActiveCapture>();
 
   return {
     connect: (command) => {
-      const adapter = deps.sourceAdapterFactory.create(command.sourceType);
-      return adapter.open(command).andThen((stream) =>
-        deps.audioPreprocessor.attach(stream, command.sessionIdentifier).map((frameChannel) => {
-          const capture: ActiveCapture = {
-            sessionIdentifier: command.sessionIdentifier,
-            sourceType: command.sourceType,
-            stream,
-            frameChannel,
-          };
-          active.set(command.sessionIdentifier, capture);
-          return capture;
-        }),
-      );
+      const capture: ActiveCapture = {
+        sessionIdentifier: command.sessionIdentifier,
+        sourceType: command.sourceType,
+        frameChannel: createEmptyFrameChannel(),
+      };
+      active.set(command.sessionIdentifier, capture);
+      return okAsync<ActiveCapture, DomainError>(capture);
     },
     disconnect: (sessionIdentifier) => {
       const capture = active.get(sessionIdentifier);
       if (capture === undefined) return okAsync<void, DomainError>(undefined);
       active.delete(sessionIdentifier);
       capture.frameChannel.close();
-      const adapter = deps.sourceAdapterFactory.create(capture.sourceType);
-      return deps.audioPreprocessor
-        .detach(sessionIdentifier)
-        .andThen(() => adapter.close(sessionIdentifier));
+      return okAsync<void, DomainError>(undefined);
     },
   };
 };

--- a/packages/extension/src/application/services/index.ts
+++ b/packages/extension/src/application/services/index.ts
@@ -2,7 +2,6 @@ export {
   createCaptureOrchestrator,
   type ActiveCapture,
   type CaptureOrchestrator,
-  type CaptureOrchestratorDependencies,
 } from './capture-orchestrator';
 export {
   createExportService,

--- a/packages/extension/src/composition/extension-composition.ts
+++ b/packages/extension/src/composition/extension-composition.ts
@@ -49,23 +49,18 @@ import {
 import { type GetSessionMonitorStateQuery } from '../application/use-cases/get-session-monitor-state-query';
 import { type SourceSession } from '../domain/session/source-session';
 import {
-  createAudioPreprocessor,
   defaultAudioContextFactory,
   type AudioContextFactory,
 } from '../infrastructure/audio/audio-preprocessor';
 import {
-  createDesktopCaptureSourceAdapter,
   defaultDesktopCaptureApi,
   type DesktopCaptureApi,
 } from '../infrastructure/capture/desktop-capture-source-adapter';
-import { createSourceAdapterFactory } from '../infrastructure/capture/source-adapter-factory';
 import {
-  createTabCaptureSourceAdapter,
   defaultTabCaptureApi,
   type TabCaptureApi,
 } from '../infrastructure/capture/tab-capture-source-adapter';
 import {
-  createUserMediaSourceAdapter,
   defaultUserMediaApi,
   type UserMediaApi,
 } from '../infrastructure/capture/user-media-source-adapter';
@@ -248,25 +243,10 @@ export const createExtensionApp = (
   );
 
   // --------------- Capture / Audio ---------------
-  const tabCaptureSourceAdapter = createTabCaptureSourceAdapter({
-    tabCaptureApi: ports.tabCaptureApi,
-  });
-  const userMediaSourceAdapter = createUserMediaSourceAdapter({
-    userMediaApi: ports.userMediaApi,
-  });
-  const desktopCaptureSourceAdapter = createDesktopCaptureSourceAdapter({
-    desktopCaptureApi: ports.desktopCaptureApi,
-  });
-  const sourceAdapterFactory = createSourceAdapterFactory({
-    tabCaptureSourceAdapter,
-    userMediaSourceAdapter,
-    desktopCaptureSourceAdapter,
-  });
-  const audioPreprocessor = createAudioPreprocessor({
-    audioContextFactory: ports.audioContextFactory,
-    workletModuleUrl: config.workletModuleUrl,
-    clock: ports.clockMs,
-  });
+  // SW 側 CaptureOrchestrator は placeholder のため、SourceAdapter / AudioPreprocessor
+  // は SW では生成しない。実 stream / AudioWorklet は offscreen document 側で
+  // TabStreamApi / defaultAudioContextFactory / defaultWorkletNodeFactory を直接使う
+  // (packages/extension/src/entrypoints/offscreen/main.ts)。
 
   // --------------- Permission + Relay ---------------
   const permissionCoordinator = createChromePermissionCoordinator({
@@ -299,10 +279,10 @@ export const createExtensionApp = (
   });
 
   // --------------- Application services (先に構築: circular dep 回避) ---------------
-  const captureOrchestrator = createCaptureOrchestrator({
-    sourceAdapterFactory,
-    audioPreprocessor,
-  });
+  // MV3 SW では MediaStream / AudioContext が動作しないため、CaptureOrchestrator は
+  // SW-safe な placeholder (empty frame channel) として動作。実 stream / AudioWorklet
+  // は offscreen document 側が担う (IMPL-612〜618)。
+  const captureOrchestrator = createCaptureOrchestrator();
 
   // relaySessionSubscriber は handleEvent を late-bind する形で参照する。
   // SessionCommandService を先に構築したいが、sessionCommandService は


### PR DESCRIPTION
## Summary

Popup から「開始」を押した際に `domain invariant violated: tab-capture-failed` で失敗する問題を修正。

## Root cause

`CaptureOrchestrator.connect` が SW 側で `SourceAdapter.open` → `chrome.tabCapture.capture()` を呼び、`AudioPreprocessor.attach` → `new AudioContext()` を評価していたが、MV3 Service Worker は `MediaStream` / `AudioContext` を扱えないため chrome.tabCapture.capture が常に reject して `tab-capture-failed` invariant violation を発生させていた。

IMPL-613〜618 で既に正しい経路 (SW は `getMediaStreamId` で streamId のみ取得 → offscreen document 側が `getUserMedia` + AudioWorklet → `audio.frame.forward` → Relay) が実装済み。SW 側 CaptureOrchestrator の旧経路が remnant として残っていた。

## Fix

- `CaptureOrchestrator` から `sourceAdapterFactory` / `audioPreprocessor` 依存を削除。`connect` は empty frame channel と session identity のみ保持する placeholder。実 stream / AudioWorklet は offscreen が担う。
- `disconnect` も frame channel close と state 削除のみ。
- composition で SW 側の `SourceAdapter` (tab / mic / desktop) / `AudioPreprocessor` 生成を削除。offscreen 側は `entrypoints/offscreen/main.ts` で直接 `defaultAudioContextFactory` / `defaultTabStreamApi` / `defaultWorkletNodeFactory` を使うため影響なし。
- capture-orchestrator unit test を新 placeholder API 用に書き直し (4 ケース)。

## Verify

- [x] `pnpm typecheck`
- [x] `pnpm --filter @perapera/extension test` — 898 passed
- [x] `pnpm --filter @perapera/extension build` — 478.28 kB (-3.5 kB、unused adapter が SW bundle から消えた)
- [x] `pnpm lint`
- [ ] 手動: Chrome で拡張を再読み込み後に Popup → 「開始」→ `tab-capture-failed` が出ないこと