### PR TITLE
fix(extension): POST /sessions envelope unwrap + WS dynamic relayUrl

### DIFF
--- a/packages/extension/src/composition/extension-composition.ts
+++ b/packages/extension/src/composition/extension-composition.ts
@@ -85,7 +85,6 @@ import {
   type ChromePermissionsApi,
 } from '../infrastructure/permission/chrome-permission-coordinator';
 import {
-  createDefaultWsEndpointBuilder,
   createFetchStreamTokenIssuer,
   type OverlayTargetDescriptor,
 } from '../infrastructure/relay/fetch-stream-token-issuer';
@@ -131,8 +130,6 @@ export type ExtensionRuntimeConfig = Readonly<{
   relayApiBaseUrl: string;
   /** POST /sessions 用の Bearer access token。`CLAUDE.md` §データ保存方針に従い chrome.storage 管理 */
   relayAccessToken: string;
-  /** WebSocket パス (default `/api/v1/relay`) */
-  relayWsPath?: string;
   /** 拡張バージョン (manifest.version) */
   extensionVersion: string;
   /** api-specification §4.1 client.protocolVersion */
@@ -268,15 +265,13 @@ export const createExtensionApp = (
     resolveAutoDetectLanguage: config.resolveAutoDetectLanguage ?? DEFAULT_RESOLVE_AUTO_DETECT,
     fetchImpl: ports.fetchImpl,
   });
-  const wsEndpointBuilder = createDefaultWsEndpointBuilder({
-    baseUrl: config.relayApiBaseUrl,
-    ...(config.relayWsPath !== undefined ? { wsPath: config.relayWsPath } : {}),
-  });
+  // WS 接続先は Relay が `POST /sessions` レスポンスで返す `relayUrl`
+  // (`{ data: { relayUrl: 'ws://.../relay' } }`) を dynamic に使う。
+  // config.relayApiBaseUrl に wsPath を足して静的に URL を組み立てない。
   const relayGateway = createRelayWebSocketGateway({
     webSocketFactory: ports.webSocketFactory,
     tokenIssuer,
     clock: ports.clockMs,
-    wsEndpointBuilder,
   });
 
   // --------------- Overlay / presenter ---------------

--- a/packages/extension/src/infrastructure/relay/fetch-stream-token-issuer.test.ts
+++ b/packages/extension/src/infrastructure/relay/fetch-stream-token-issuer.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createLanguagePair } from '../../domain/session/language-pair';
 import { createSourceSession, type SourceSession } from '../../domain/session/source-session';
-import {
-  createDefaultWsEndpointBuilder,
-  createFetchStreamTokenIssuer,
-} from './fetch-stream-token-issuer';
+import { createFetchStreamTokenIssuer } from './fetch-stream-token-issuer';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
@@ -24,8 +21,19 @@ const createFakeResponse = (body: unknown, status = 200): Response =>
     headers: { 'content-type': 'application/json' },
   });
 
+/**
+ * api-specification.md §4.2 envelope shape でレスポンスを包む helper。
+ */
+const enveloped = (
+  data: Record<string, unknown>,
+  requestId = 'req_01HZX8YREQ1ABCDEFGH',
+): { data: Record<string, unknown>; meta: { requestId: string } } => ({
+  data,
+  meta: { requestId },
+});
+
 describe('createFetchStreamTokenIssuer (IMPL-319, DD-401)', () => {
-  it('sends POST /sessions with the expected payload and returns streamToken', async () => {
+  it('sends POST /sessions with the expected payload and returns { streamToken, relayUrl }', async () => {
     const capturedRequests: { url: string; init: RequestInit | undefined }[] = [];
     const normalizeUrl = (url: RequestInfo | URL): string => {
       if (typeof url === 'string') return url;
@@ -46,21 +54,24 @@ describe('createFetchStreamTokenIssuer (IMPL-319, DD-401)', () => {
           init,
         });
         return Promise.resolve(
-          createFakeResponse({
-            sessionId: SESSION_ID,
-            streamToken: 'jwt.stream.token',
-            relayUrl: 'wss://relay.test/api/v1/relay',
-            expiresAt: '2026-04-21T01:00:00.000Z',
-            heartbeatIntervalSec: 15,
-            audio: {
-              encoding: 'pcm_s16le',
-              sampleRateHz: 16000,
-              channels: 1,
-              frameDurationMs: 100,
-              transport: 'json-base64',
-            },
-            limits: { maxConcurrentSessions: 3, maxFrameRatePerSecond: 10 },
-          }),
+          createFakeResponse(
+            enveloped({
+              sessionId: SESSION_ID,
+              streamToken: 'jwt.stream.token',
+              relayUrl: 'wss://relay.test/relay',
+              expiresAt: '2026-04-21T01:00:00.000Z',
+              heartbeatIntervalSec: 15,
+              audio: {
+                encoding: 'pcm_s16le',
+                sampleRateHz: 16000,
+                channels: 1,
+                frameDurationMs: 100,
+                transport: 'json-base64',
+              },
+              limits: { maxConcurrentSessions: 3, maxFrameRatePerSecond: 10 },
+            }),
+            201,
+          ),
         );
       },
     });
@@ -68,7 +79,10 @@ describe('createFetchStreamTokenIssuer (IMPL-319, DD-401)', () => {
     const result = await issuer(buildSession());
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toBe('jwt.stream.token');
+      expect(result.value).toEqual({
+        streamToken: 'jwt.stream.token',
+        relayUrl: 'wss://relay.test/relay',
+      });
     }
     expect(capturedRequests).toHaveLength(1);
     const req = capturedRequests[0];
@@ -105,21 +119,24 @@ describe('createFetchStreamTokenIssuer (IMPL-319, DD-401)', () => {
         const body: unknown = init?.body;
         captured = typeof body === 'string' ? JSON.parse(body) : body;
         return Promise.resolve(
-          createFakeResponse({
-            sessionId: SESSION_ID,
-            streamToken: 't',
-            relayUrl: 'w',
-            expiresAt: '2026-04-21T01:00:00.000Z',
-            heartbeatIntervalSec: 15,
-            audio: {
-              encoding: 'pcm_s16le',
-              sampleRateHz: 16000,
-              channels: 1,
-              frameDurationMs: 100,
-              transport: 'json-base64',
-            },
-            limits: { maxConcurrentSessions: 3, maxFrameRatePerSecond: 10 },
-          }),
+          createFakeResponse(
+            enveloped({
+              sessionId: SESSION_ID,
+              streamToken: 't',
+              relayUrl: 'ws://relay.test/relay',
+              expiresAt: '2026-04-21T01:00:00.000Z',
+              heartbeatIntervalSec: 15,
+              audio: {
+                encoding: 'pcm_s16le',
+                sampleRateHz: 16000,
+                channels: 1,
+                frameDurationMs: 100,
+                transport: 'json-base64',
+              },
+              limits: { maxConcurrentSessions: 3, maxFrameRatePerSecond: 10 },
+            }),
+            201,
+          ),
         );
       },
     });
@@ -173,6 +190,45 @@ describe('createFetchStreamTokenIssuer (IMPL-319, DD-401)', () => {
     }
   });
 
+  it('returns invariantViolationError when response is not wrapped in { data } envelope', async () => {
+    const issuer = createFetchStreamTokenIssuer({
+      baseUrl: 'https://relay.test',
+      accessToken: 'secret-token',
+      extensionVersion: '0.1.0',
+      protocolVersion: '1.0',
+      resolveDisplayName: () => 'n',
+      resolveOverlayTarget: () => ({ kind: 'extension-monitor', pageId: 'monitor' }),
+      resolveAutoDetectLanguage: () => false,
+      // Top-level fields without envelope — should fail schema
+      fetchImpl: () =>
+        Promise.resolve(
+          createFakeResponse({
+            sessionId: SESSION_ID,
+            streamToken: 't',
+            relayUrl: 'ws://relay.test/relay',
+            expiresAt: '2026-04-21T01:00:00.000Z',
+            heartbeatIntervalSec: 15,
+            audio: {
+              encoding: 'pcm_s16le',
+              sampleRateHz: 16000,
+              channels: 1,
+              frameDurationMs: 100,
+              transport: 'json-base64',
+            },
+            limits: { maxConcurrentSessions: 3, maxFrameRatePerSecond: 10 },
+          }),
+        ),
+    });
+    const result = await issuer(buildSession());
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.kind).toBe('invariant-violation');
+      if (result.error.kind === 'invariant-violation') {
+        expect(result.error.details).toMatch(/response schema/);
+      }
+    }
+  });
+
   it('returns invariantViolationError when response schema is invalid', async () => {
     const issuer = createFetchStreamTokenIssuer({
       baseUrl: 'https://relay.test',
@@ -186,35 +242,5 @@ describe('createFetchStreamTokenIssuer (IMPL-319, DD-401)', () => {
     });
     const result = await issuer(buildSession());
     expect(result.isErr()).toBe(true);
-  });
-});
-
-describe('createDefaultWsEndpointBuilder', () => {
-  it('converts https base URL into wss endpoint with query parameters', () => {
-    const builder = createDefaultWsEndpointBuilder({ baseUrl: 'https://relay.test' });
-    const url = builder(SESSION_ID, 'secret-token');
-    expect(url).toBe(`wss://relay.test/api/v1/relay?token=secret-token&sessionId=${SESSION_ID}`);
-  });
-
-  it('converts http base URL into ws endpoint', () => {
-    const builder = createDefaultWsEndpointBuilder({ baseUrl: 'http://localhost:3001' });
-    const url = builder(SESSION_ID, 't');
-    expect(url.startsWith('ws://localhost:3001/api/v1/relay?')).toBe(true);
-  });
-
-  it('respects custom wsPath override', () => {
-    const builder = createDefaultWsEndpointBuilder({
-      baseUrl: 'https://relay.test',
-      wsPath: '/stream',
-    });
-    const url = builder(SESSION_ID, 't');
-    expect(url.startsWith('wss://relay.test/stream?')).toBe(true);
-  });
-
-  it('urlencodes token and sessionId', () => {
-    const builder = createDefaultWsEndpointBuilder({ baseUrl: 'https://relay.test' });
-    const url = builder('sess/ion id', 'tok&en');
-    expect(url).toContain('token=tok%26en');
-    expect(url).toContain('sessionId=sess%2Fion%20id');
   });
 });

--- a/packages/extension/src/infrastructure/relay/fetch-stream-token-issuer.ts
+++ b/packages/extension/src/infrastructure/relay/fetch-stream-token-issuer.ts
@@ -3,15 +3,13 @@ import { z } from 'zod';
 import { type SourceSession } from '../../domain/session/source-session';
 import { type SourceType } from '../../domain/session/source-type';
 import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
-import { type StreamTokenIssuer } from './relay-websocket-gateway';
+import { type StreamTokenIssuer, type StreamTokenIssuerResult } from './relay-websocket-gateway';
 
 /**
- * POST /sessions リクエストボディの shape (api-specification.md §4.1)。
- *
- * `displayName` / `autoDetectLanguage` / `overlayTarget` / `client` は SourceSession
- * に含まれないため、config で解決関数を注入する。
+ * POST /sessions 成功レスポンス (api-specification.md §4.2):
+ * 全体は `{ data: {...}, meta: { requestId } }` envelope。
  */
-const postSessionsResponseSchema = z.object({
+const postSessionsDataSchema = z.object({
   sessionId: z.string().min(1),
   streamToken: z.string().min(1),
   relayUrl: z.string().min(1),
@@ -28,6 +26,14 @@ const postSessionsResponseSchema = z.object({
     maxConcurrentSessions: z.number().int().positive(),
     maxFrameRatePerSecond: z.number().int().positive(),
   }),
+});
+
+const postSessionsResponseSchema = z.object({
+  data: postSessionsDataSchema,
+  meta: z
+    .object({ requestId: z.string().min(1) })
+    .partial()
+    .optional(),
 });
 
 /**
@@ -89,10 +95,13 @@ const buildRequestBody = (
 };
 
 /**
- * IMPL-319 FetchStreamTokenIssuer (DD-401, api-specification.md §4.1)。
+ * IMPL-319 FetchStreamTokenIssuer (DD-401, api-specification.md §4.1 / §4.2)。
  *
  * `StreamTokenIssuer` の production 実装。`POST ${baseUrl}/sessions` に JSON を
- * 送り、Relay API から短命 `streamToken` を取得する。
+ * 送り、Relay API から `{ data: { streamToken, relayUrl, ... }, meta }` envelope を
+ * 受け取って `{ streamToken, relayUrl }` を返す。WebSocket 接続先は Relay から
+ * 返された `relayUrl` をそのまま使うため、SSOT (docs) と impl の path prefix
+ * drift (`/api/v1` 有無) を吸収できる。
  *
  * **本番実装で mock が利用されない設計**:
  * - 全 DI (resolve* callback 含む) が必須引数。default は持たない
@@ -138,45 +147,20 @@ export const createFetchStreamTokenIssuer = (
           toInvariant('json-parse'),
         );
       })
-      .andThen((raw): ResultAsync<string, DomainError> => {
+      .andThen((raw): ResultAsync<StreamTokenIssuerResult, DomainError> => {
         const parsed = postSessionsResponseSchema.safeParse(raw);
         if (!parsed.success) {
-          return errAsync<string, DomainError>(
+          return errAsync<StreamTokenIssuerResult, DomainError>(
             invariantViolationError({
               invariant: 'stream-token-fetch',
               details: `response schema: ${parsed.error.issues.map((i) => i.message).join('; ')}`,
             }),
           );
         }
-        return okAsync<string, DomainError>(parsed.data.streamToken);
+        return okAsync<StreamTokenIssuerResult, DomainError>({
+          streamToken: parsed.data.data.streamToken,
+          relayUrl: parsed.data.data.relayUrl,
+        });
       });
   };
-};
-
-/**
- * `wsEndpointBuilder` の標準実装。Relay API の `relayUrl` を使わず、
- * `config.baseUrl` をそのまま ws(s) に差し替える (MVP 簡易版)。
- *
- * 例: `https://relay.example.com` + streamToken → `wss://relay.example.com/relay?token=...&sessionId=...`
- */
-export type WsEndpointBuilderConfig = Readonly<{
-  /** HTTP base URL (`http(s)://` prefix)。`wss://` に変換される */
-  baseUrl: string;
-  /** WebSocket パス (default `/api/v1/relay`) */
-  wsPath?: string;
-}>;
-
-export const createDefaultWsEndpointBuilder = (
-  config: WsEndpointBuilderConfig,
-): ((sessionIdentifier: string, streamToken: string) => string) => {
-  const wsPath = config.wsPath ?? '/api/v1/relay';
-  const httpPrefix = config.baseUrl.startsWith('https://')
-    ? 'https://'
-    : config.baseUrl.startsWith('http://')
-      ? 'http://'
-      : 'https://';
-  const rest = config.baseUrl.slice(httpPrefix.length);
-  const wsPrefix = httpPrefix === 'https://' ? 'wss://' : 'ws://';
-  return (sessionIdentifier, streamToken) =>
-    `${wsPrefix}${rest}${wsPath}?token=${encodeURIComponent(streamToken)}&sessionId=${encodeURIComponent(sessionIdentifier)}`;
 };

--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.test.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.test.ts
@@ -14,6 +14,7 @@ import type { WebSocketLike } from './websocket-factory';
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
 const STREAM_TOKEN = 'stream-token-xxx';
+const RELAY_URL = 'wss://relay.example/relay';
 
 const sessionIdentifier = parseSessionIdentifier(SESSION_ID)._unsafeUnwrap();
 
@@ -106,29 +107,29 @@ const flushUntilSocketCreated = async (sockets: MockSocket[]): Promise<void> => 
 
 const buildDependencies = (
   overrides: Partial<RelayWebSocketGatewayDependencies> = {},
-): RelayWebSocketGatewayDependencies & { createdSockets: MockSocket[] } => {
+): RelayWebSocketGatewayDependencies & {
+  createdSockets: MockSocket[];
+  createdUrls: string[];
+} => {
   const createdSockets: MockSocket[] = [];
-  const webSocketFactory = vi.fn((_url: string) => {
+  const createdUrls: string[] = [];
+  const webSocketFactory = vi.fn((url: string) => {
+    createdUrls.push(url);
     const socket = createMockSocket();
     createdSockets.push(socket);
     return socket;
   });
-  const tokenIssuer = vi.fn(() => okAsync(STREAM_TOKEN));
-  const wsEndpointBuilder = vi.fn(
-    (id: string, token: string) =>
-      `wss://relay.example/api/v1/relay?sessionId=${id}&token=${token}`,
-  );
+  const tokenIssuer = vi.fn(() => okAsync({ streamToken: STREAM_TOKEN, relayUrl: RELAY_URL }));
   const clock = vi.fn(() => Date.parse('2026-04-21T00:00:00.000Z'));
 
   return Object.assign(
     {
       webSocketFactory,
       tokenIssuer,
-      wsEndpointBuilder,
       clock,
       ...overrides,
     },
-    { createdSockets },
+    { createdSockets, createdUrls },
   );
 };
 
@@ -140,7 +141,7 @@ describe('createRelayWebSocketGateway (IMPL-320, DD-105 / DD-411)', () => {
   });
 
   describe('openSession', () => {
-    it('builds a URL via wsEndpointBuilder with the stream token', async () => {
+    it('uses the relayUrl returned by tokenIssuer to open the WebSocket', async () => {
       const deps = buildDependencies();
       const gateway = createRelayWebSocketGateway(deps);
       const resultPromise = gateway.openSession(buildSession());
@@ -148,10 +149,29 @@ describe('createRelayWebSocketGateway (IMPL-320, DD-105 / DD-411)', () => {
       deps.createdSockets[0]?.simulateOpen();
       const result = await resultPromise;
       expect(result.isOk()).toBe(true);
-      expect(deps.wsEndpointBuilder).toHaveBeenCalledWith(SESSION_ID, STREAM_TOKEN);
-      expect(deps.webSocketFactory).toHaveBeenCalledWith(
-        expect.stringContaining('sessionId=01HZX8Y1R8M7D3Q2P4T5V6W7A1'),
+      const urlArg = deps.createdUrls[0] ?? '';
+      expect(urlArg).toContain(RELAY_URL);
+      expect(urlArg).toContain(`token=${STREAM_TOKEN}`);
+      expect(urlArg).toContain(`sessionId=${SESSION_ID}`);
+    });
+
+    it('supports a custom wsEndpointBuilder override', async () => {
+      const customBuilder = vi.fn(
+        (params: { relayUrl: string; sessionIdentifier: string; streamToken: string }) =>
+          `${params.relayUrl}/custom?t=${params.streamToken}&s=${params.sessionIdentifier}`,
       );
+      const deps = buildDependencies({ wsEndpointBuilder: customBuilder });
+      const gateway = createRelayWebSocketGateway(deps);
+      const resultPromise = gateway.openSession(buildSession());
+      await flushUntilSocketCreated(deps.createdSockets);
+      deps.createdSockets[0]?.simulateOpen();
+      await resultPromise;
+      expect(customBuilder).toHaveBeenCalledWith({
+        relayUrl: RELAY_URL,
+        sessionIdentifier: sessionIdentifier,
+        streamToken: STREAM_TOKEN,
+      });
+      expect(deps.createdUrls[0]).toBe(`${RELAY_URL}/custom?t=${STREAM_TOKEN}&s=${SESSION_ID}`);
     });
 
     it('sends session.start envelope on open', async () => {

--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
@@ -16,23 +16,57 @@ import { parseRelayServerMessage } from './relay-event-mapper';
 import { type WebSocketFactory, type WebSocketLike } from './websocket-factory';
 
 /**
- * Stream token 発行器。`POST /sessions` 経由で Relay API から短命トークンを
- * 取得する HTTP クライアントを注入する。production entrypoint で
+ * Stream token 発行器の結果。`POST /sessions` レスポンス (api-specification.md
+ * §4.2) から `streamToken` と `relayUrl` の 2 値を抽出する。
+ *
+ * `relayUrl` は Relay API 側が環境ごとに提示する WS 接続先 (例:
+ * `ws://localhost:3001/relay`)。extension 側で path を組み立てずに
+ * そのまま使うことで SSOT (docs) と impl の path prefix drift (`/api/v1` 有無)
+ * を吸収する。
+ */
+export type StreamTokenIssuerResult = Readonly<{
+  streamToken: string;
+  relayUrl: string;
+}>;
+
+/**
+ * Stream token 発行器。`POST /sessions` 経由で Relay API から短命トークン + WS
+ * endpoint を取得する HTTP クライアントを注入する。production entrypoint で
  * 実装を渡す (test では okAsync で mock)。
  */
-export type StreamTokenIssuer = (session: SourceSession) => ResultAsync<string, DomainError>;
+export type StreamTokenIssuer = (
+  session: SourceSession,
+) => ResultAsync<StreamTokenIssuerResult, DomainError>;
 
 export type RelayWebSocketGatewayDependencies = Readonly<{
   webSocketFactory: WebSocketFactory;
   tokenIssuer: StreamTokenIssuer;
   clock: () => number;
-  wsEndpointBuilder: (sessionIdentifier: SessionIdentifier, streamToken: string) => string;
+  /**
+   * Relay から返された `relayUrl` (ws:// or wss://) と streamToken / sessionId
+   * から実 WebSocket URL を組み立てる。default は `${relayUrl}?token=<jwt>&sessionId=<ulid>`
+   * で、相対 path や追加 query を本番で override したい場合のみ注入する。
+   */
+  wsEndpointBuilder?: (params: {
+    relayUrl: string;
+    sessionIdentifier: SessionIdentifier;
+    streamToken: string;
+  }) => string;
   /**
    * ハートビート間隔 (ms)。default 15000 (api-specification.md §2.6 準拠)。
    * 定数なので default を許容 (mock ではない)。
    */
   heartbeatIntervalMs?: number;
 }>;
+
+const defaultWsEndpointBuilder = (params: {
+  relayUrl: string;
+  sessionIdentifier: SessionIdentifier;
+  streamToken: string;
+}): string => {
+  const separator = params.relayUrl.includes('?') ? '&' : '?';
+  return `${params.relayUrl}${separator}token=${encodeURIComponent(params.streamToken)}&sessionId=${encodeURIComponent(params.sessionIdentifier)}`;
+};
 
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 15000 as const;
 
@@ -87,6 +121,7 @@ export const createRelayWebSocketGateway = (
   deps: RelayWebSocketGatewayDependencies,
 ): RelayGateway => {
   const heartbeatMs = deps.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const wsEndpointBuilder = deps.wsEndpointBuilder ?? defaultWsEndpointBuilder;
   const connections = new Map<SessionIdentifier, SessionConnection>();
 
   const dispatchMessage = (sessionIdentifier: SessionIdentifier, data: string): void => {
@@ -124,10 +159,14 @@ export const createRelayWebSocketGateway = (
   return {
     openSession: (session) =>
       deps.tokenIssuer(session).andThen(
-        (streamToken): ResultAsync<void, DomainError> =>
+        ({ streamToken, relayUrl }): ResultAsync<void, DomainError> =>
           ResultAsync.fromPromise<void, DomainError>(
             new Promise<void>((resolve, reject) => {
-              const url = deps.wsEndpointBuilder(session.sessionIdentifier, streamToken);
+              const url = wsEndpointBuilder({
+                relayUrl,
+                sessionIdentifier: session.sessionIdentifier,
+                streamToken,
+              });
               const socket = deps.webSocketFactory(url);
 
               const onOpen = (): void => {


### PR DESCRIPTION
## Summary

Popup「開始」→ Relay `201 Created` → extension 側 `stream-token-fetch` invariant が発生する 2 件の Relay 契約 bug を同時修正。

1. **Envelope 不一致**: api-specification.md §4.2 は `{ data: {...}, meta: {requestId} }` の 2 層構造だが、extension 側 Zod schema が top-level を期待していた
2. **WS path drift**: extension は `${baseUrl}/api/v1/relay` を静的に組み立てるが、Relay impl は `/relay` のみ公開 (SSOT vs impl drift)

## Fix

### 1. envelope unwrap

`postSessionsResponseSchema` を `{ data: postSessionsDataSchema, meta: {requestId?}? }` 形式に変更。extension は `parsed.data.data.streamToken` / `parsed.data.data.relayUrl` でアクセス。

### 2. WS endpoint を dynamic relayUrl に変更

- `StreamTokenIssuer` の戻り値: `ResultAsync<string, ...>` → `ResultAsync<StreamTokenIssuerResult, ...>` (`{ streamToken, relayUrl }` の 2 値)
- `createRelayWebSocketGateway` の `wsEndpointBuilder` を optional 化 (default: `${relayUrl}?token=...&sessionId=...`)
- `createDefaultWsEndpointBuilder` / `WsEndpointBuilderConfig` 削除 (役割が gateway 内 default に統合)
- `ExtensionRuntimeConfig.relayWsPath` field 削除

## 設計判断: なぜ relayUrl を dynamic に

- api-spec の path prefix (`/api/v1/...`) と relay-api impl (prefix 無し) の drift が存在
- 拡張側が `relayUrl` を信頼すれば drift に巻き込まれない
- dev: `RELAY_PUBLIC_URL=ws://localhost:3001/relay` → 拡張は `ws://localhost:3001/relay?token=...&sessionId=...` に接続
- prod: `RELAY_PUBLIC_URL=wss://relay.example.com/api/v1/relay` 等 env で切替

## Relay 側実測 (手動 curl で確認)

| path | 返却 | 判定 |
|---|---|---|
| `POST http://localhost:3001/sessions` + valid body | `201 Created` `{ data: {...}, meta: {...} }` | ✅ route 正しい |
| `Upgrade http://localhost:3001/relay` | `401 Unauthorized` | ✅ route 存在 (要 token) |
| `Upgrade http://localhost:3001/api/v1/relay` | `404 Not Found` | ❌ Relay 未公開 (旧 extension default path) |

## 検証

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean (extension + relay-api)
- [x] `pnpm --filter @perapera/extension test --run` 120 files / 902 tests green
- [x] `pnpm --filter @perapera/extension build` 成功

### 新規 / 修正 test ケース

- `createFetchStreamTokenIssuer` (6 tests, 旧 5)
  - 既存 tests を envelope 前提に更新
  - 新規: non-envelope response でも invariant 返す (regression guard)
  - 削除: `createDefaultWsEndpointBuilder` describe (4 tests) → 別責務に移管済
- `createRelayWebSocketGateway` (+2 tests)
  - 新規: `relayUrl` を tokenIssuer から受け取って WS URL を組む smoke
  - 新規: custom `wsEndpointBuilder` override

## Test plan

- [ ] reviewer: 本 PR merge 後、拡張を再 build + Chrome reload → Popup 開始 → SW console で `stream-token-fetch` が消え、以降 WebSocket 接続へ遷移することを確認
- [ ] reviewer: Relay log で `GET /relay` (WS upgrade) に対して 101 Switching Protocols が返り、`session.ready` を extension が受信することを確認
- [ ] reviewer: 拡張 build artifact の `manifest.json host_permissions` は `PERAPERA_RELAY_API_BASE_URL` から自動導出 (PR #84)、`relayUrl` は dynamic なので整合性は Relay 側 `RELAY_PUBLIC_URL` env に揃えれば OK

## 関連 / 経緯

初回ラン連鎖 bug 修正の第 6 本目:

| # | PR | エラー |
|---|---|---|
| 1 | #81 | `secure crypto unusable` (ulid → ulidx) |
| 2 | #82 | `permission-coordinator-system-error` (contains short-circuit) |
| 3 | #83 | `tab-capture-failed` (SW-safe placeholder) |
| 4 | #85 | `ExtensionProfile not found: default` (seed default) |
| 5 | #86 | `overlayTarget` kind 不一致 (`monitor` → `extension-monitor`) |
| 6 | 本 PR | `stream-token-fetch` (envelope + WS path) |

次に出るとしたら:
- WebSocket `session.ready` 前の `relay-handshake-failed` 系
- offscreen 側 AudioWorklet 関連 (`closeAudioContext` warning は既に観測済、別 PR で対応)