### PR TITLE
fix(relay-api,extension): browser WS client auth — token query + protocolVersion

### DIFF
--- a/docs/in-progress/04-api-specification/api-specification.md
+++ b/docs/in-progress/04-api-specification/api-specification.md
@@ -64,6 +64,8 @@ Authorization: Bearer <access_token>
 Authorization: Bearer <stream_token>
 ```
 
+browser WebSocket API (`new WebSocket(url, protocols)`) は custom header を設定できないため、browser client は同等の代替として query parameter `?token=<stream_token>` を使う。Relay は header を優先し、未指定なら query にフォールバックする。server-to-server クライアントは header を使うこと。
+
 ### 2.4 レートリミット
 
 | 対象                        | 制限                            | 超過時                     |

--- a/packages/extension/src/composition/extension-composition.ts
+++ b/packages/extension/src/composition/extension-composition.ts
@@ -272,6 +272,7 @@ export const createExtensionApp = (
     webSocketFactory: ports.webSocketFactory,
     tokenIssuer,
     clock: ports.clockMs,
+    protocolVersion: config.protocolVersion,
   });
 
   // --------------- Overlay / presenter ---------------

--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.test.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.test.ts
@@ -127,6 +127,7 @@ const buildDependencies = (
       webSocketFactory,
       tokenIssuer,
       clock,
+      protocolVersion: '1.0',
       ...overrides,
     },
     { createdSockets, createdUrls },
@@ -153,12 +154,18 @@ describe('createRelayWebSocketGateway (IMPL-320, DD-105 / DD-411)', () => {
       expect(urlArg).toContain(RELAY_URL);
       expect(urlArg).toContain(`token=${STREAM_TOKEN}`);
       expect(urlArg).toContain(`sessionId=${SESSION_ID}`);
+      expect(urlArg).toContain('protocolVersion=1.0');
     });
 
     it('supports a custom wsEndpointBuilder override', async () => {
       const customBuilder = vi.fn(
-        (params: { relayUrl: string; sessionIdentifier: string; streamToken: string }) =>
-          `${params.relayUrl}/custom?t=${params.streamToken}&s=${params.sessionIdentifier}`,
+        (params: {
+          relayUrl: string;
+          sessionIdentifier: string;
+          streamToken: string;
+          protocolVersion: string;
+        }) =>
+          `${params.relayUrl}/custom?t=${params.streamToken}&s=${params.sessionIdentifier}&v=${params.protocolVersion}`,
       );
       const deps = buildDependencies({ wsEndpointBuilder: customBuilder });
       const gateway = createRelayWebSocketGateway(deps);
@@ -170,8 +177,11 @@ describe('createRelayWebSocketGateway (IMPL-320, DD-105 / DD-411)', () => {
         relayUrl: RELAY_URL,
         sessionIdentifier: sessionIdentifier,
         streamToken: STREAM_TOKEN,
+        protocolVersion: '1.0',
       });
-      expect(deps.createdUrls[0]).toBe(`${RELAY_URL}/custom?t=${STREAM_TOKEN}&s=${SESSION_ID}`);
+      expect(deps.createdUrls[0]).toBe(
+        `${RELAY_URL}/custom?t=${STREAM_TOKEN}&s=${SESSION_ID}&v=1.0`,
+      );
     });
 
     it('sends session.start envelope on open', async () => {

--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
@@ -43,14 +43,22 @@ export type RelayWebSocketGatewayDependencies = Readonly<{
   tokenIssuer: StreamTokenIssuer;
   clock: () => number;
   /**
-   * Relay から返された `relayUrl` (ws:// or wss://) と streamToken / sessionId
-   * から実 WebSocket URL を組み立てる。default は `${relayUrl}?token=<jwt>&sessionId=<ulid>`
-   * で、相対 path や追加 query を本番で override したい場合のみ注入する。
+   * api-specification.md §4.1 `client.protocolVersion`。WS upgrade の query
+   * parameter として Relay に送信する。Relay 側は `SUPPORTED_PROTOCOL_VERSIONS`
+   * と照合 (相違時は 401 upgrade reject)。
+   */
+  protocolVersion: string;
+  /**
+   * Relay から返された `relayUrl` (ws:// or wss://) と streamToken / sessionId /
+   * protocolVersion から実 WebSocket URL を組み立てる。default は
+   * `${relayUrl}?token=<jwt>&sessionId=<ulid>&protocolVersion=<ver>` で、
+   * 相対 path や追加 query を本番で override したい場合のみ注入する。
    */
   wsEndpointBuilder?: (params: {
     relayUrl: string;
     sessionIdentifier: SessionIdentifier;
     streamToken: string;
+    protocolVersion: string;
   }) => string;
   /**
    * ハートビート間隔 (ms)。default 15000 (api-specification.md §2.6 準拠)。
@@ -63,9 +71,10 @@ const defaultWsEndpointBuilder = (params: {
   relayUrl: string;
   sessionIdentifier: SessionIdentifier;
   streamToken: string;
+  protocolVersion: string;
 }): string => {
   const separator = params.relayUrl.includes('?') ? '&' : '?';
-  return `${params.relayUrl}${separator}token=${encodeURIComponent(params.streamToken)}&sessionId=${encodeURIComponent(params.sessionIdentifier)}`;
+  return `${params.relayUrl}${separator}token=${encodeURIComponent(params.streamToken)}&sessionId=${encodeURIComponent(params.sessionIdentifier)}&protocolVersion=${encodeURIComponent(params.protocolVersion)}`;
 };
 
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 15000 as const;
@@ -166,6 +175,7 @@ export const createRelayWebSocketGateway = (
                 relayUrl,
                 sessionIdentifier: session.sessionIdentifier,
                 streamToken,
+                protocolVersion: deps.protocolVersion,
               });
               const socket = deps.webSocketFactory(url);
 

--- a/packages/relay-api/src/presentation/ws/relay-auth.test.ts
+++ b/packages/relay-api/src/presentation/ws/relay-auth.test.ts
@@ -31,6 +31,7 @@ describe('authorizeRelayUpgrade', () => {
     const result = await authorizeRelayUpgrade(
       {
         authorizationHeader: 'Bearer valid.jwt.string',
+        tokenQuery: undefined,
         sessionIdQuery: SESSION_ID,
         protocolVersionQuery: '1.0',
       },
@@ -48,6 +49,7 @@ describe('authorizeRelayUpgrade', () => {
     const result = await authorizeRelayUpgrade(
       {
         authorizationHeader: undefined,
+        tokenQuery: undefined,
         sessionIdQuery: SESSION_ID,
         protocolVersionQuery: '1.0',
       },
@@ -63,6 +65,7 @@ describe('authorizeRelayUpgrade', () => {
     const result = await authorizeRelayUpgrade(
       {
         authorizationHeader: 'Basic abc',
+        tokenQuery: undefined,
         sessionIdQuery: SESSION_ID,
         protocolVersionQuery: '1.0',
       },
@@ -75,6 +78,7 @@ describe('authorizeRelayUpgrade', () => {
     const result = await authorizeRelayUpgrade(
       {
         authorizationHeader: 'Bearer ',
+        tokenQuery: undefined,
         sessionIdQuery: SESSION_ID,
         protocolVersionQuery: '1.0',
       },
@@ -90,6 +94,7 @@ describe('authorizeRelayUpgrade', () => {
     const result = await authorizeRelayUpgrade(
       {
         authorizationHeader: 'Bearer expired.jwt',
+        tokenQuery: undefined,
         sessionIdQuery: SESSION_ID,
         protocolVersionQuery: '1.0',
       },
@@ -102,6 +107,7 @@ describe('authorizeRelayUpgrade', () => {
     const result = await authorizeRelayUpgrade(
       {
         authorizationHeader: 'Bearer valid.jwt',
+        tokenQuery: undefined,
         sessionIdQuery: SESSION_ID,
         protocolVersionQuery: undefined,
       },
@@ -117,6 +123,7 @@ describe('authorizeRelayUpgrade', () => {
     const result = await authorizeRelayUpgrade(
       {
         authorizationHeader: 'Bearer valid.jwt',
+        tokenQuery: undefined,
         sessionIdQuery: SESSION_ID,
         protocolVersionQuery: '2.0',
       },
@@ -132,6 +139,7 @@ describe('authorizeRelayUpgrade', () => {
     const result = await authorizeRelayUpgrade(
       {
         authorizationHeader: 'Bearer valid.jwt',
+        tokenQuery: undefined,
         sessionIdQuery: undefined,
         protocolVersionQuery: '1.0',
       },
@@ -147,6 +155,7 @@ describe('authorizeRelayUpgrade', () => {
     const result = await authorizeRelayUpgrade(
       {
         authorizationHeader: 'Bearer valid.jwt',
+        tokenQuery: undefined,
         sessionIdQuery: 'different-session-id',
         protocolVersionQuery: '1.0',
       },
@@ -155,6 +164,74 @@ describe('authorizeRelayUpgrade', () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr() && result.error.kind === 'invariant-violation') {
       expect(result.error.invariant).toBe('relay-session-id-mismatch');
+    }
+  });
+
+  it('accepts token from ?token query when Authorization header is missing (browser WS client path)', async () => {
+    const result = await authorizeRelayUpgrade(
+      {
+        authorizationHeader: undefined,
+        tokenQuery: 'valid.jwt.from.query',
+        sessionIdQuery: SESSION_ID,
+        protocolVersionQuery: '1.0',
+      },
+      okVerifier,
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessionId).toBe(SESSION_ID);
+    }
+  });
+
+  it('prefers Authorization header over tokenQuery when both are present', async () => {
+    let capturedToken: string | null = null;
+    const captureVerifier: JwtVerifier = {
+      verify: (token) => {
+        capturedToken = token;
+        return okAsync<JwtVerifiedPayload, DomainError>(validPayload);
+      },
+    };
+    await authorizeRelayUpgrade(
+      {
+        authorizationHeader: 'Bearer from.header',
+        tokenQuery: 'from.query',
+        sessionIdQuery: SESSION_ID,
+        protocolVersionQuery: '1.0',
+      },
+      captureVerifier,
+    );
+    expect(capturedToken).toBe('from.header');
+  });
+
+  it('rejects when neither Authorization nor tokenQuery is present', async () => {
+    const result = await authorizeRelayUpgrade(
+      {
+        authorizationHeader: undefined,
+        tokenQuery: undefined,
+        sessionIdQuery: SESSION_ID,
+        protocolVersionQuery: '1.0',
+      },
+      okVerifier,
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('relay-missing-authorization');
+    }
+  });
+
+  it('rejects when tokenQuery is empty string and header is missing', async () => {
+    const result = await authorizeRelayUpgrade(
+      {
+        authorizationHeader: undefined,
+        tokenQuery: '',
+        sessionIdQuery: SESSION_ID,
+        protocolVersionQuery: '1.0',
+      },
+      okVerifier,
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && result.error.kind === 'invariant-violation') {
+      expect(result.error.invariant).toBe('relay-missing-authorization');
     }
   });
 });

--- a/packages/relay-api/src/presentation/ws/relay-auth.ts
+++ b/packages/relay-api/src/presentation/ws/relay-auth.ts
@@ -10,13 +10,17 @@ import { invariantViolationError, type DomainError } from '../../domain/shared/e
  * から呼び出し、失敗時は 401 で upgrade を拒否する。
  *
  * 検証項目 (api-specification §6.1):
- * 1. `Authorization: Bearer <stream_token>` ヘッダが存在する
+ * 1. `Authorization: Bearer <stream_token>` ヘッダ **または** `?token=<stream_token>`
+ *    query parameter が存在する (browser WebSocket API は custom header を
+ *    設定できないため、browser client は query を使う。server-to-server は
+ *    header を推奨)
  * 2. stream token が JwtVerifier で verify される
  * 3. クエリの `sessionId` が JWT の `sub` と一致する
  * 4. クエリの `protocolVersion` が既知バージョン ('1.0') と一致する
  */
 export type ExtractAuthInput = Readonly<{
   authorizationHeader: string | undefined;
+  tokenQuery: string | undefined;
   sessionIdQuery: string | undefined;
   protocolVersionQuery: string | undefined;
 }>;
@@ -25,25 +29,34 @@ export const SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = ['1.0'] as const;
 
 const BEARER_PREFIX = 'Bearer ';
 
-const extractBearerToken = (header: string | undefined): Result<string, DomainError> => {
-  if (!header?.startsWith(BEARER_PREFIX)) {
-    return err(
-      invariantViolationError({
-        invariant: 'relay-missing-authorization',
-        details: 'Authorization header with Bearer scheme is required',
-      }),
-    );
+const extractBearerToken = (
+  header: string | undefined,
+  tokenQuery: string | undefined,
+): Result<string, DomainError> => {
+  // Prefer Authorization header (server-to-server / API-spec default)
+  if (header?.startsWith(BEARER_PREFIX)) {
+    const token = header.slice(BEARER_PREFIX.length).trim();
+    if (token.length === 0) {
+      return err(
+        invariantViolationError({
+          invariant: 'relay-empty-authorization',
+          details: 'Bearer token is empty',
+        }),
+      );
+    }
+    return ok(token);
   }
-  const token = header.slice(BEARER_PREFIX.length).trim();
-  if (token.length === 0) {
-    return err(
-      invariantViolationError({
-        invariant: 'relay-empty-authorization',
-        details: 'Bearer token is empty',
-      }),
-    );
+  // Fallback to ?token= query param (browser WebSocket client path)
+  if (tokenQuery !== undefined && tokenQuery.length > 0) {
+    return ok(tokenQuery);
   }
-  return ok(token);
+  return err(
+    invariantViolationError({
+      invariant: 'relay-missing-authorization',
+      details:
+        'Authorization: Bearer header or ?token= query parameter is required for stream token auth',
+    }),
+  );
 };
 
 const validateProtocolVersion = (version: string | undefined): Result<string, DomainError> => {
@@ -104,7 +117,7 @@ export const authorizeRelayUpgrade = (
   input: ExtractAuthInput,
   verifier: JwtVerifier,
 ): ResultAsync<RelayAuthorizedContext, DomainError> =>
-  extractBearerToken(input.authorizationHeader)
+  extractBearerToken(input.authorizationHeader, input.tokenQuery)
     .asyncAndThen((token) => verifier.verify(token))
     .andThen((tokenPayload) =>
       validateProtocolVersion(input.protocolVersionQuery).andThen((protocolVersion) =>

--- a/packages/relay-api/src/presentation/ws/relay-route.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.ts
@@ -43,6 +43,11 @@ const DEFAULT_AUDIO_FRAME_LIMIT_PER_SEC = 10;
 type RelayQuery = Readonly<{
   sessionId?: string;
   protocolVersion?: string;
+  /**
+   * browser WebSocket client は `Authorization` header を設定できないため
+   * `?token=<stream_token>` 形式で受け付ける fallback (relay-auth.ts 参照)。
+   */
+  token?: string;
 }>;
 
 const contextMap = new WeakMap<FastifyRequest, RelayAuthorizedContext>();
@@ -229,6 +234,7 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
         const result = await authorizeRelayUpgrade(
           {
             authorizationHeader: request.headers.authorization,
+            tokenQuery: request.query.token,
             sessionIdQuery: request.query.sessionId,
             protocolVersionQuery: request.query.protocolVersion,
           },


### PR DESCRIPTION
## Summary

PR #87 merge 後の新 blocker: extension 側 WS 接続時に `HTTP Authentication failed; no valid credentials available`。原因 2 件を本 PR で同時修正。

## 問題

1. **Relay**: `authorizeRelayUpgrade` が `Authorization: Bearer` header しか受け付けず、browser WebSocket API (custom header 不可) からは認証不能
2. **Extension**: WS URL に `protocolVersion` query を含めておらず、Relay の `validateProtocolVersion` が 401 で reject

## Fix

### Relay (`packages/relay-api/src/presentation/ws/`)

- `ExtractAuthInput.tokenQuery` を追加、`extractBearerToken(header, tokenQuery)` で header 優先 + query fallback
- `RelayQuery.token` を route の Querystring schema に追加
- 既存 9 tests に `tokenQuery: undefined` を追加 + 新規 4 tests (query 受付 / header 優先 / 両方欠落 reject / 空 query reject)

### Extension (`packages/extension/src/`)

- `RelayWebSocketGatewayDependencies.protocolVersion` を必須追加
- default `wsEndpointBuilder` で `?token=...&sessionId=...&protocolVersion=...` 形式の URL を生成
- custom builder override interface にも `protocolVersion` field 追加
- `extension-composition.ts` で `config.protocolVersion` を gateway に注入

### SSOT (`api-specification.md` §2.3)

browser WebSocket API が custom header を設定できない制約と、`?token=` query fallback が代替仕様である旨を明記。

## 設計判断: なぜ query fallback なのか

| 選択肢 | 採否 | 理由 |
|---|---|---|
| `Sec-WebSocket-Protocol` subprotocol に token 埋め込み | ❌ | Relay 側 101 応答で protocol echo 必須、実装 overhead 大。暗黙的で誤用しやすい |
| 開設後 first message で token 送信 | ❌ | 開設時点で認可したいので、接続後認証は 2-RTT 増やし UX 劣化 |
| `?token=...` query | ✅ | 一般的な web SDK でも採用、`stream_token` は短命 (TTL 30min) で access log リスク小 |

## 検証

### 品質ゲート
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm --filter @perapera/relay-api test --run` 33 files / 188 tests (旧 184 → +4)
- [x] `pnpm --filter @perapera/extension test --run` 120 files / 902 tests
- [x] `pnpm --filter @perapera/extension build` 成功

### 手動確認手順 (PR merge 後)

```sh
# Relay を再起動
set -a; source packages/relay-api/.env.local; set +a
pnpm --filter @perapera/relay-api dev

# 拡張再 build
export PERAPERA_RELAY_API_BASE_URL=http://localhost:3001
export PERAPERA_RELAY_ACCESS_TOKEN=dev-access-token
pnpm --filter @perapera/extension build

# chrome://extensions で perapera リロード → Popup 開始
```

DevTools Network タブで WS URL が以下を含むことを確認:
- `token=<jwt>`
- `sessionId=<ulid>`
- `protocolVersion=1.0`

SW console に以下が出る想定:
- `ws://localhost:3001/relay?... 101 Switching Protocols`
- `session.ready` event 受信ログ

Relay log で `GET /relay 101` が確認できる想定。

## Test plan

- [ ] reviewer: extension WS 接続が 101 へ遷移し `session.ready` を受信
- [ ] reviewer: Relay log に `GET /relay status=101` が残る
- [ ] reviewer: 意図通り URL に `protocolVersion=1.0` が含まれる

## 関連 / 経緯

初回ラン連鎖 bug 修正の 7 本目。残: offscreen `closeAudioContext` warning (stop session teardown) は別 PR で対応予定。

| # | PR | エラー |
|---|---|---|
| 6 | #87 | `stream-token-fetch` (envelope + WS path) |
| 7 | 本 PR | `HTTP Authentication failed` (WS token query + protocolVersion) |