### PR TITLE
fix(extension): use Relay-issued sessionId in WS URL (JWT sub match)

### DIFF
--- a/packages/extension/src/infrastructure/relay/fetch-stream-token-issuer.test.ts
+++ b/packages/extension/src/infrastructure/relay/fetch-stream-token-issuer.test.ts
@@ -82,6 +82,7 @@ describe('createFetchStreamTokenIssuer (IMPL-319, DD-401)', () => {
       expect(result.value).toEqual({
         streamToken: 'jwt.stream.token',
         relayUrl: 'wss://relay.test/relay',
+        sessionId: SESSION_ID,
       });
     }
     expect(capturedRequests).toHaveLength(1);

--- a/packages/extension/src/infrastructure/relay/fetch-stream-token-issuer.ts
+++ b/packages/extension/src/infrastructure/relay/fetch-stream-token-issuer.ts
@@ -160,6 +160,7 @@ export const createFetchStreamTokenIssuer = (
         return okAsync<StreamTokenIssuerResult, DomainError>({
           streamToken: parsed.data.data.streamToken,
           relayUrl: parsed.data.data.relayUrl,
+          sessionId: parsed.data.data.sessionId,
         });
       });
   };

--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.test.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.test.ts
@@ -13,6 +13,7 @@ import type { WebSocketLike } from './websocket-factory';
 
 const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
 const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+const SERVER_SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7C2';
 const STREAM_TOKEN = 'stream-token-xxx';
 const RELAY_URL = 'wss://relay.example/relay';
 
@@ -119,7 +120,9 @@ const buildDependencies = (
     createdSockets.push(socket);
     return socket;
   });
-  const tokenIssuer = vi.fn(() => okAsync({ streamToken: STREAM_TOKEN, relayUrl: RELAY_URL }));
+  const tokenIssuer = vi.fn(() =>
+    okAsync({ streamToken: STREAM_TOKEN, relayUrl: RELAY_URL, sessionId: SERVER_SESSION_ID }),
+  );
   const clock = vi.fn(() => Date.parse('2026-04-21T00:00:00.000Z'));
 
   return Object.assign(
@@ -142,7 +145,7 @@ describe('createRelayWebSocketGateway (IMPL-320, DD-105 / DD-411)', () => {
   });
 
   describe('openSession', () => {
-    it('uses the relayUrl returned by tokenIssuer to open the WebSocket', async () => {
+    it('uses the Relay-issued sessionId (not extension local id) in the WS URL', async () => {
       const deps = buildDependencies();
       const gateway = createRelayWebSocketGateway(deps);
       const resultPromise = gateway.openSession(buildSession());
@@ -153,7 +156,9 @@ describe('createRelayWebSocketGateway (IMPL-320, DD-105 / DD-411)', () => {
       const urlArg = deps.createdUrls[0] ?? '';
       expect(urlArg).toContain(RELAY_URL);
       expect(urlArg).toContain(`token=${STREAM_TOKEN}`);
-      expect(urlArg).toContain(`sessionId=${SESSION_ID}`);
+      // sessionId in URL must match token.sub (Relay-issued), not extension local id
+      expect(urlArg).toContain(`sessionId=${SERVER_SESSION_ID}`);
+      expect(urlArg).not.toContain(`sessionId=${SESSION_ID}`);
       expect(urlArg).toContain('protocolVersion=1.0');
     });
 
@@ -161,11 +166,11 @@ describe('createRelayWebSocketGateway (IMPL-320, DD-105 / DD-411)', () => {
       const customBuilder = vi.fn(
         (params: {
           relayUrl: string;
-          sessionIdentifier: string;
+          serverSessionId: string;
           streamToken: string;
           protocolVersion: string;
         }) =>
-          `${params.relayUrl}/custom?t=${params.streamToken}&s=${params.sessionIdentifier}&v=${params.protocolVersion}`,
+          `${params.relayUrl}/custom?t=${params.streamToken}&s=${params.serverSessionId}&v=${params.protocolVersion}`,
       );
       const deps = buildDependencies({ wsEndpointBuilder: customBuilder });
       const gateway = createRelayWebSocketGateway(deps);
@@ -175,12 +180,12 @@ describe('createRelayWebSocketGateway (IMPL-320, DD-105 / DD-411)', () => {
       await resultPromise;
       expect(customBuilder).toHaveBeenCalledWith({
         relayUrl: RELAY_URL,
-        sessionIdentifier: sessionIdentifier,
+        serverSessionId: SERVER_SESSION_ID,
         streamToken: STREAM_TOKEN,
         protocolVersion: '1.0',
       });
       expect(deps.createdUrls[0]).toBe(
-        `${RELAY_URL}/custom?t=${STREAM_TOKEN}&s=${SESSION_ID}&v=1.0`,
+        `${RELAY_URL}/custom?t=${STREAM_TOKEN}&s=${SERVER_SESSION_ID}&v=1.0`,
       );
     });
 

--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
@@ -17,16 +17,22 @@ import { type WebSocketFactory, type WebSocketLike } from './websocket-factory';
 
 /**
  * Stream token 発行器の結果。`POST /sessions` レスポンス (api-specification.md
- * §4.2) から `streamToken` と `relayUrl` の 2 値を抽出する。
+ * §4.2) から `streamToken` / `relayUrl` / `sessionId` の 3 値を抽出する。
  *
- * `relayUrl` は Relay API 側が環境ごとに提示する WS 接続先 (例:
- * `ws://localhost:3001/relay`)。extension 側で path を組み立てずに
- * そのまま使うことで SSOT (docs) と impl の path prefix drift (`/api/v1` 有無)
- * を吸収する。
+ * - `streamToken`: WS upgrade の Authorization 代替 token
+ * - `relayUrl`: Relay API が環境ごとに提示する WS 接続先 (例:
+ *   `ws://localhost:3001/relay`)。extension 側で path を組み立てずにそのまま
+ *   使うことで SSOT (docs) と impl の path prefix drift (`/api/v1` 有無) を吸収
+ * - `sessionId`: Relay が発行した session 識別子。WS URL の `?sessionId=` に
+ *   使う (token の `sub` claim と一致するため `validateSessionIdMatch` を通過
+ *   できる)。extension の local `SourceSession.sessionIdentifier` とは独立した
+ *   ULID。extension 側は local id を内部 routing key に使い続けるが、Relay と
+ *   の contract 用には本 field を使う
  */
 export type StreamTokenIssuerResult = Readonly<{
   streamToken: string;
   relayUrl: string;
+  sessionId: string;
 }>;
 
 /**
@@ -49,14 +55,14 @@ export type RelayWebSocketGatewayDependencies = Readonly<{
    */
   protocolVersion: string;
   /**
-   * Relay から返された `relayUrl` (ws:// or wss://) と streamToken / sessionId /
-   * protocolVersion から実 WebSocket URL を組み立てる。default は
-   * `${relayUrl}?token=<jwt>&sessionId=<ulid>&protocolVersion=<ver>` で、
+   * Relay から返された `relayUrl` / `serverSessionId` (token.sub 一致) /
+   * streamToken / protocolVersion から実 WebSocket URL を組み立てる。default は
+   * `${relayUrl}?token=<jwt>&sessionId=<serverSessionId>&protocolVersion=<ver>` で、
    * 相対 path や追加 query を本番で override したい場合のみ注入する。
    */
   wsEndpointBuilder?: (params: {
     relayUrl: string;
-    sessionIdentifier: SessionIdentifier;
+    serverSessionId: string;
     streamToken: string;
     protocolVersion: string;
   }) => string;
@@ -69,12 +75,12 @@ export type RelayWebSocketGatewayDependencies = Readonly<{
 
 const defaultWsEndpointBuilder = (params: {
   relayUrl: string;
-  sessionIdentifier: SessionIdentifier;
+  serverSessionId: string;
   streamToken: string;
   protocolVersion: string;
 }): string => {
   const separator = params.relayUrl.includes('?') ? '&' : '?';
-  return `${params.relayUrl}${separator}token=${encodeURIComponent(params.streamToken)}&sessionId=${encodeURIComponent(params.sessionIdentifier)}&protocolVersion=${encodeURIComponent(params.protocolVersion)}`;
+  return `${params.relayUrl}${separator}token=${encodeURIComponent(params.streamToken)}&sessionId=${encodeURIComponent(params.serverSessionId)}&protocolVersion=${encodeURIComponent(params.protocolVersion)}`;
 };
 
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 15000 as const;
@@ -168,12 +174,12 @@ export const createRelayWebSocketGateway = (
   return {
     openSession: (session) =>
       deps.tokenIssuer(session).andThen(
-        ({ streamToken, relayUrl }): ResultAsync<void, DomainError> =>
+        ({ streamToken, relayUrl, sessionId }): ResultAsync<void, DomainError> =>
           ResultAsync.fromPromise<void, DomainError>(
             new Promise<void>((resolve, reject) => {
               const url = wsEndpointBuilder({
                 relayUrl,
-                sessionIdentifier: session.sessionIdentifier,
+                serverSessionId: sessionId,
                 streamToken,
                 protocolVersion: deps.protocolVersion,
               });


### PR DESCRIPTION
## Summary

PR #88 merge 後も発生していた `HTTP Authentication failed` の最終原因を修正。

- WS URL `?sessionId=` が extension の local ULID (`SourceSession.sessionIdentifier`)
- JWT `sub` claim は Relay が `POST /sessions` で独自発行した ULID
- Relay `validateSessionIdMatch` で不一致 → `relay-session-id-mismatch` invariant → 401

## 根本原因

extension は `StartSourceSessionUseCase` で `sessionIdFactory()` により local ULID を生成しており、以降の内部 tracking key にもこれを使う。一方 Relay は `POST /sessions` 受付時に `sessionIdFactory()` を独自に呼び、`data.sessionId` として返却する。api-specification §4.2 も `data.sessionId` は Relay-issued と定義。

extension は `data.sessionId` を取りこぼし、local id をそのまま WS URL に載せていた。

## Fix

`StreamTokenIssuerResult` に `sessionId: string` を追加し、Relay response の `data.sessionId` を伝搬。gateway は WS URL 用に `serverSessionId` として利用する:

```ts
export type StreamTokenIssuerResult = Readonly<{
  streamToken: string;
  relayUrl: string;
  sessionId: string; // Relay-issued (token.sub と一致)
}>;
```

- `wsEndpointBuilder` param: `sessionIdentifier` → `serverSessionId` に rename (Relay-issued であることを明示)
- 内部 connection map のキーは引き続き extension local `sessionIdentifier` を使用 (routing 独立)
- `session.start` envelope の `sessionId` field も local id のまま (Relay は event 内 sessionId を検証しないため影響なし)

### 実機 curl 検証

```
curl -i --http1.1 \
  -H "Sec-WebSocket-Key: <valid>" \
  -H "Connection: Upgrade" -H "Upgrade: websocket" \
  -H "Sec-WebSocket-Version: 13" \
  "http://localhost:3001/relay?token=<jwt>&sessionId=<token.sub>&protocolVersion=1.0"

→ HTTP/1.1 101 Switching Protocols
→ session.ready event 受信
```

## 検証

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean (extension + relay-api)
- [x] `pnpm --filter @perapera/extension test --run` 120 files / 902 tests green
- [x] `pnpm --filter @perapera/extension build` 成功
- [x] 新規 regression test: URL に `sessionId=<local id>` が入らないことを negative assert

## Test plan

- [ ] reviewer: 本 PR merge 後、拡張再 build + Chrome reload → Popup 開始 → SW console で `HTTP Authentication failed` が消え `session.ready` 受信ログが出ることを確認

## 関連

初回ラン連鎖 bug fix の 8 本目:

| # | PR | エラー |
|---|---|---|
| 6 | #87 | `stream-token-fetch` (envelope + WS path) |
| 7 | #88 | `HTTP Authentication failed` (token query + protocolVersion) |
| 8 | 本 PR | `HTTP Authentication failed` 継続 (WS URL sessionId mismatch) |