### PR TITLE
fix(extension): align session.ready schema with SSOT (drop streamToken)

### DIFF
--- a/packages/extension/src/application/ports/relay-gateway.test.ts
+++ b/packages/extension/src/application/ports/relay-gateway.test.ts
@@ -96,14 +96,14 @@ describe('RelayGateway (DD-401)', () => {
       broadcast?.({
         type: 'session.ready',
         sessionIdentifier,
-        streamToken: 'token-xxx',
+        heartbeatIntervalSec: 15,
       });
       expect(listener).toHaveBeenCalledTimes(1);
       unsubscribe();
       broadcast?.({
         type: 'session.ready',
         sessionIdentifier,
-        streamToken: 'token-yyy',
+        heartbeatIntervalSec: 15,
       });
       // After unsubscribe, the mock clears broadcast so further events should not invoke listener.
       expect(listener).toHaveBeenCalledTimes(1);
@@ -113,7 +113,7 @@ describe('RelayGateway (DD-401)', () => {
   describe('RelayEvent discriminated union', () => {
     it('narrows payload via the type discriminator', () => {
       const events: RelayEvent[] = [
-        { type: 'session.ready', sessionIdentifier, streamToken: 'tkn' },
+        { type: 'session.ready', sessionIdentifier, heartbeatIntervalSec: 15 },
         {
           type: 'transcript.partial',
           sessionIdentifier,

--- a/packages/extension/src/application/ports/relay-gateway.ts
+++ b/packages/extension/src/application/ports/relay-gateway.ts
@@ -15,7 +15,7 @@ export type RelayEvent =
   | Readonly<{
       type: 'session.ready';
       sessionIdentifier: SessionIdentifier;
-      streamToken: string;
+      heartbeatIntervalSec: number;
     }>
   | Readonly<{
       type: 'transcript.partial';

--- a/packages/extension/src/application/services/session-command-service.test.ts
+++ b/packages/extension/src/application/services/session-command-service.test.ts
@@ -188,7 +188,7 @@ describe('createSessionCommandService (IMPL-340)', () => {
     const mocks = buildMocks();
     const service = createSessionCommandService({ ...mocks, clock });
     const events: RelayEvent[] = [
-      { type: 'session.ready', sessionIdentifier, streamToken: 'tok' },
+      { type: 'session.ready', sessionIdentifier, heartbeatIntervalSec: 15 },
       { type: 'session.state.changed', sessionIdentifier, state: 'capturing' },
       {
         type: 'session.error',

--- a/packages/extension/src/infrastructure/relay/relay-event-mapper.test.ts
+++ b/packages/extension/src/infrastructure/relay/relay-event-mapper.test.ts
@@ -18,18 +18,23 @@ const wrap = (eventType: string, payload: Record<string, unknown>): string =>
   });
 
 describe('parseRelayServerMessage (IMPL-321, DD-411)', () => {
-  it('parses session.ready', () => {
+  it('parses session.ready (per SSOT: state + heartbeatIntervalSec, no streamToken)', () => {
     const raw = wrap('session.ready', {
       state: 'capturing',
       heartbeatIntervalSec: 15,
-      streamToken: 'tkn_xxx',
+      acceptedAudio: {
+        transport: 'json-base64',
+        sampleRateHz: 16000,
+        channels: 1,
+        frameDurationMs: 100,
+      },
     });
     const result = parseRelayServerMessage(raw);
     expect(result.isOk()).toBe(true);
     if (result.isOk() && result.value !== null) {
       expect(result.value.type).toBe('session.ready');
       if (result.value.type === 'session.ready') {
-        expect(result.value.streamToken).toBe('tkn_xxx');
+        expect(result.value.heartbeatIntervalSec).toBe(15);
         expect(result.value.sessionIdentifier).toBe(sessionIdentifier);
       }
     }
@@ -141,7 +146,7 @@ describe('parseRelayServerMessage (IMPL-321, DD-411)', () => {
       sessionId: 'not-a-ulid',
       sequence: 0,
       timestamp: '2026-04-21T00:00:00.000Z',
-      payload: { state: 'capturing', heartbeatIntervalSec: 15, streamToken: 'x' },
+      payload: { state: 'capturing', heartbeatIntervalSec: 15 },
     });
     const result = parseRelayServerMessage(raw);
     expect(result.isErr()).toBe(true);

--- a/packages/extension/src/infrastructure/relay/relay-event-mapper.ts
+++ b/packages/extension/src/infrastructure/relay/relay-event-mapper.ts
@@ -25,10 +25,13 @@ const baseEnvelopeSchema = z.object({
   payload: z.record(z.unknown()).optional().default({}),
 });
 
+// api-specification.md §6.3 `session.ready`:
+// { state, heartbeatIntervalSec, acceptedAudio: {...} }
+// Relay 側 `buildSessionReady` (server-events.ts) と shape 一致が必須。
+// streamToken は POST /sessions レスポンス で既に取得済のためここでは送られない。
 const readyPayload = z.object({
   state: z.string(),
   heartbeatIntervalSec: z.number().positive(),
-  streamToken: z.string().min(1),
 });
 
 const transcriptPartialPayload = z.object({
@@ -110,7 +113,7 @@ export const parseRelayServerMessage = (raw: string): Result<RelayEvent | null, 
       return ok({
         type: 'session.ready',
         sessionIdentifier,
-        streamToken: payload.data.streamToken,
+        heartbeatIntervalSec: payload.data.heartbeatIntervalSec,
       });
     }
 


### PR DESCRIPTION
## Summary

WebSocket 接続成立後の `message-parse failed: Validation failed for RelayServerMessage: Required` を修正。

## 原因

extension `readyPayload` schema が `streamToken` を必須要求していたが、api-specification.md §6.3 の session.ready は `{ state, heartbeatIntervalSec, acceptedAudio: {...} }` のみ。streamToken は POST /sessions レスポンスで既に取得済で WS event には載せない設計。Relay の `buildSessionReady` も SSOT 準拠で streamToken を送らない → schema 不一致で全 event が捨てられていた。

## Fix

extension 側を SSOT 整合:

- `readyPayload` から `streamToken` を削除
- `RelayEvent['session.ready']` 型: `streamToken: string` → `heartbeatIntervalSec: number`
- mapper の session.ready branch 更新
- 関連 test 3 箇所更新 (`relay-event-mapper`, `relay-gateway`, `session-command-service`)

`session-command-service.handleRelayEvent` の `case 'session.ready'` は従来 no-op なので動作変更なし。

## 検証

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean (extension + relay-api)
- [x] `pnpm --filter @perapera/extension test --run` 120 files / 902 tests green
- [x] `pnpm --filter @perapera/extension build` 成功

## Test plan

- [ ] reviewer: 本 PR merge 後、extension reload → Popup 開始 → SW console で `message-parse failed` が消え、session.ready / 後続 transcript.* / translation.final event が正常に受信・dispatch されることを確認

## 関連 / 経緯

初回ラン連鎖 bug 修正の 9 本目:

| # | PR | エラー |
|---|---|---|
| 8 | #89 | WS URL sessionId mismatch (Relay-issued id 使用) |
| 9 | 本 PR | session.ready payload schema drift (streamToken 不要) |

残 issue: `chrome-runtime-message-bridge` warning (teardown race の cosmetic warn、blocker ではない) — 必要なら別 PR で対応。