### PR TITLE
fix(extension): silence closeAudioContext warn on teardown race

### DIFF
--- a/packages/extension/src/application/use-cases/stop-source-session-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/stop-source-session-use-case.test.ts
@@ -193,6 +193,82 @@ describe('createStopSourceSessionUseCase (IMPL-215, DD-306)', () => {
     expect(result.isOk()).toBe(true);
   });
 
+  it('suppresses closeAudioContext warn when offscreen receiver is already gone (teardown race)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* swallow */
+    });
+    try {
+      const deps = buildDependencies({
+        offscreenCommandSender: {
+          openAudioContext: vi.fn(() => okAsync<void, DomainError>(undefined)),
+          closeAudioContext: vi.fn(() =>
+            errAsync<void, DomainError>(
+              invariantViolationError({
+                invariant: 'chrome-runtime-message-bridge',
+                details: 'Could not establish connection. Receiving end does not exist.',
+              }),
+            ),
+          ),
+          ping: vi.fn(() => okAsync<void, DomainError>(undefined)),
+        },
+      });
+      const useCase = createStopSourceSessionUseCase(deps);
+      const result = await useCase({ sessionId: SESSION_ID });
+      // fire-and-forget の match は microtask で評価されるため、microtask を
+      // 1 周 flush してからログを検査する。
+      await new Promise<void>((resolve) => {
+        queueMicrotask(resolve);
+      });
+      expect(result.isOk()).toBe(true);
+      const closeAudioContextWarned = warnSpy.mock.calls.some((call) =>
+        call.some(
+          (arg) =>
+            typeof arg === 'string' && arg.includes('offscreenCommandSender.closeAudioContext'),
+        ),
+      );
+      expect(closeAudioContextWarned).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('still warns on closeAudioContext errors not matching the teardown pattern', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* swallow */
+    });
+    try {
+      const deps = buildDependencies({
+        offscreenCommandSender: {
+          openAudioContext: vi.fn(() => okAsync<void, DomainError>(undefined)),
+          closeAudioContext: vi.fn(() =>
+            errAsync<void, DomainError>(
+              invariantViolationError({
+                invariant: 'offscreen-audio-host',
+                details: 'AudioContext unexpectedly throws on close',
+              }),
+            ),
+          ),
+          ping: vi.fn(() => okAsync<void, DomainError>(undefined)),
+        },
+      });
+      const useCase = createStopSourceSessionUseCase(deps);
+      const result = await useCase({ sessionId: SESSION_ID });
+      await new Promise<void>((resolve) => {
+        queueMicrotask(resolve);
+      });
+      expect(result.isOk()).toBe(true);
+      const closeAudioContextWarned = warnSpy.mock.calls.some((call) =>
+        call.some(
+          (arg) =>
+            typeof arg === 'string' && arg.includes('offscreenCommandSender.closeAudioContext'),
+        ),
+      );
+      expect(closeAudioContextWarned).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('propagates save errors as conflict application errors', async () => {
     const deps = buildDependencies({
       sourceSessionRepository: {

--- a/packages/extension/src/application/use-cases/stop-source-session-use-case.ts
+++ b/packages/extension/src/application/use-cases/stop-source-session-use-case.ts
@@ -90,9 +90,24 @@ export const createStopSourceSessionUseCase = (
               void deps.overlayPresenter
                 .unmount(sessionIdentifier)
                 .match(() => undefined, logWarn('overlayPresenter.unmount'));
-              void deps.offscreenCommandSender
-                .closeAudioContext(sessionIdentifier)
-                .match(() => undefined, logWarn('offscreenCommandSender.closeAudioContext'));
+              void deps.offscreenCommandSender.closeAudioContext(sessionIdentifier).match(
+                () => undefined,
+                (error) => {
+                  // Offscreen が既に unload されているケース (SW 側で teardown
+                  // 中に開始前停止した場合など) は意味的に no-op (閉じる対象が
+                  // 存在しない) ので warn しない。Chrome runtime は receiver
+                  // 不在時に "Could not establish connection. Receiving end
+                  // does not exist." を throw する。
+                  if (
+                    error.kind === 'invariant-violation' &&
+                    error.invariant === 'chrome-runtime-message-bridge' &&
+                    /receiving end does not exist/i.test(error.details)
+                  ) {
+                    return;
+                  }
+                  logWarn('offscreenCommandSender.closeAudioContext')(error);
+                },
+              );
               return {
                 sessionId: stopped.sessionIdentifier,
                 state: stopped.state,


### PR DESCRIPTION
## Summary

SW console に毎回出ていた `offscreenCommandSender.closeAudioContext failed: Invariant violated: chrome-runtime-message-bridge (Could not establish connection. Receiving end does not exist.)` を意味的 no-op として silent 化。

## 原因

- stop-source-session の fire-and-forget 層で offscreen に `audio.close` command を送信
- offscreen document が未 load / 既に unload されているケースがある (SW teardown race, session 開始失敗後の stop 等)
- Chrome runtime は receiver 不在で `Could not establish connection. Receiving end does not exist.` を throw
- extension 側は全 `chrome-runtime-message-bridge` error を warn 出力していた

## Fix

close 対象が既に存在しないケースは **意味的に成功 (冪等)** なので warn しない:

```ts
void deps.offscreenCommandSender.closeAudioContext(sessionIdentifier).match(
  () => undefined,
  (error) => {
    if (
      error.kind === 'invariant-violation' &&
      error.invariant === 'chrome-runtime-message-bridge' &&
      /receiving end does not exist/i.test(error.details)
    ) {
      return;
    }
    logWarn('offscreenCommandSender.closeAudioContext')(error);
  },
);
```

AudioContext.close 実行時の実体 error (offscreen-audio-host 由来等) は従来通り warn。

## 検証

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm --filter @perapera/extension test --run` 120 files / 904 tests green (旧 902 → +2 新規 case)
- [x] `pnpm --filter @perapera/extension build` 成功

新規 test 2 件:
1. teardown pattern に一致する error → warn されない (regression guard)
2. pattern 外 error → 従来通り warn される (false-positive silence を防ぐ)

## 関連

初回ラン連鎖 bug 修正の仕上げ。stop session flow は従来から結果整合で成功扱いだが console noise が user に混乱を与えていたため cosmetic fix として対応。