### PR TITLE
fix(extension): ensure offscreen before send + verbose debug logs

### DIFF
--- a/packages/extension/src/application/services/offscreen-command-sender.ts
+++ b/packages/extension/src/application/services/offscreen-command-sender.ts
@@ -1,6 +1,6 @@
-import { type ResultAsync } from 'neverthrow';
+import { ResultAsync } from 'neverthrow';
 import { type SessionIdentifier } from '../../domain/session/session-identifier';
-import { type DomainError } from '../../domain/shared/errors';
+import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
 import { type OffscreenCommand } from '../../entrypoints/offscreen/offscreen-commands';
 
 /**
@@ -45,11 +45,49 @@ export type OffscreenCommandSender = Readonly<{
 
 export type OffscreenCommandSenderDependencies = Readonly<{
   bridge: RuntimeMessageBridge;
+  /**
+   * Offscreen document の存在を保証する idempotent な Promise factory。
+   * send 前に必ず await され、receiver 不在での `chrome.runtime.sendMessage`
+   * 失敗 (`Receiving end does not exist`) を防ぐ。未指定なら skip (test seam)。
+   * production では `offscreenLifecycle.ensure` を渡す。
+   */
+  ensureOffscreen?: () => Promise<void>;
+  /**
+   * 開発時のフロー追跡用。production の `console.log` が default。
+   */
+  logDebug?: (message: string) => void;
 }>;
+
+const defaultLogDebug = (message: string): void => {
+  console.log(message);
+};
 
 export const createOffscreenCommandSender = (
   deps: OffscreenCommandSenderDependencies,
 ): OffscreenCommandSender => {
+  const logDebug = deps.logDebug ?? defaultLogDebug;
+
+  const sendAfterEnsure = (
+    command: OffscreenCommand,
+    label: string,
+  ): ResultAsync<void, DomainError> => {
+    const ensurePromise =
+      deps.ensureOffscreen === undefined ? Promise.resolve() : deps.ensureOffscreen();
+    return ResultAsync.fromPromise(
+      ensurePromise,
+      (cause): DomainError =>
+        invariantViolationError({
+          invariant: 'offscreen-ensure',
+          details: `${label}: ${cause instanceof Error ? cause.message : String(cause)}`,
+        }),
+    ).andThen(() => {
+      logDebug(
+        `[perapera] offscreen-command-sender sending ${command.type} (${label}) after ensure()`,
+      );
+      return deps.bridge.sendMessage(command);
+    });
+  };
+
   return {
     openAudioContext: (sessionIdentifier, options) => {
       const base: {
@@ -60,10 +98,10 @@ export const createOffscreenCommandSender = (
       } = { type: 'offscreen.audio.open', sessionIdentifier };
       if (options?.sampleRateHz !== undefined) base.sampleRateHz = options.sampleRateHz;
       if (options?.tabStreamId !== undefined) base.tabStreamId = options.tabStreamId;
-      return deps.bridge.sendMessage(base satisfies OffscreenCommand);
+      return sendAfterEnsure(base satisfies OffscreenCommand, 'openAudioContext');
     },
     closeAudioContext: (sessionIdentifier) =>
-      deps.bridge.sendMessage({ type: 'offscreen.audio.close', sessionIdentifier }),
-    ping: () => deps.bridge.sendMessage({ type: 'offscreen.ping' }),
+      sendAfterEnsure({ type: 'offscreen.audio.close', sessionIdentifier }, 'closeAudioContext'),
+    ping: () => sendAfterEnsure({ type: 'offscreen.ping' }, 'ping'),
   };
 };

--- a/packages/extension/src/application/services/session-command-service.ts
+++ b/packages/extension/src/application/services/session-command-service.ts
@@ -122,10 +122,26 @@ const toTranslationFinalInput = (
 export const createSessionCommandService = (
   deps: SessionCommandServiceDependencies,
 ): SessionCommandService => ({
-  startSource: (input) => deps.startSourceSessionUseCase(input),
-  stopSource: (input) => deps.stopSourceSessionUseCase(input),
+  startSource: (input) => {
+    console.log('[session-command-service] startSource received:', {
+      sourceType: input.sourceType,
+      target: input.targetLanguage,
+    });
+    return deps.startSourceSessionUseCase(input).map((output) => {
+      console.log('[session-command-service] startSource ok:', {
+        sessionId: output.sessionId,
+        state: output.state,
+      });
+      return output;
+    });
+  },
+  stopSource: (input) => {
+    console.log('[session-command-service] stopSource received:', input);
+    return deps.stopSourceSessionUseCase(input);
+  },
   applySourceSettings: (input) => deps.updateSourceSettingsUseCase(input),
   handleRelayEvent: (event) => {
+    console.log('[session-command-service] relay event:', event.type);
     switch (event.type) {
       case 'transcript.partial': {
         const input = toPartialInput(event, deps.clock());

--- a/packages/extension/src/composition/extension-composition.ts
+++ b/packages/extension/src/composition/extension-composition.ts
@@ -138,6 +138,13 @@ export type ExtensionRuntimeConfig = Readonly<{
   databaseName?: string;
   /** AudioWorklet module URL (通常 `chrome.runtime.getURL('/audio-worklet.js')`) */
   workletModuleUrl: string;
+  /**
+   * Offscreen document の存在を保証する idempotent Promise factory。
+   * `offscreenCommandSender` から送信前に呼ばれる。未指定ならチェックなし
+   * (test の最小 wire / 単純 smoke 用)。production は `offscreenLifecycle.ensure`
+   * を渡す。
+   */
+  ensureOffscreen?: () => Promise<void>;
   /** SourceSession → displayName (default: sourceType 名) */
   resolveDisplayName?: (session: SourceSession) => string;
   /** SourceSession → overlayTarget (default: `{ kind: 'extension-monitor', pageId: 'monitor' }`) */
@@ -311,6 +318,7 @@ export const createExtensionApp = (
   );
   const offscreenCommandSender: OffscreenCommandSender = createOffscreenCommandSender({
     bridge: runtimeMessageBridge,
+    ...(config.ensureOffscreen !== undefined ? { ensureOffscreen: config.ensureOffscreen } : {}),
   });
   const tabStreamIdResolver = createChromeTabStreamIdResolver(ports.tabCaptureApi);
   const audioFrameForwardReceiver: AudioFrameForwardReceiver = createAudioFrameForwardReceiver({

--- a/packages/extension/src/entrypoints/background.ts
+++ b/packages/extension/src/entrypoints/background.ts
@@ -55,7 +55,14 @@ const WORKLET_MODULE_URL = (() => {
 })();
 
 export default defineBackground(() => {
-  console.log('[perapera] background service worker loaded');
+  console.log('[perapera] ---- background service worker loaded ----');
+  console.log('[perapera] runtime config:', {
+    relayApiBaseUrl: RELAY_API_BASE_URL,
+    hasAccessToken: RELAY_ACCESS_TOKEN.length > 0,
+    accessTokenLength: RELAY_ACCESS_TOKEN.length,
+    extensionVersion: EXTENSION_VERSION,
+    workletModuleUrl: WORKLET_MODULE_URL,
+  });
 
   if (RELAY_ACCESS_TOKEN.length === 0) {
     console.error(
@@ -70,8 +77,31 @@ export default defineBackground(() => {
     offscreenApi: defaultOffscreenApi,
     documentUrl: chrome.runtime.getURL('/offscreen.html'),
   });
-  void offscreen.ensure().catch((cause: unknown) => {
-    console.error('[perapera] offscreen ensure failed:', cause);
+
+  // ensure Promise を cache して開始フローと SW 初期化の両方で共有する。
+  // 単一 Promise を await することで idempotent かつ並行呼び出し安全。
+  let offscreenEnsurePromise: Promise<void> | null = null;
+  const ensureOffscreenReady = (): Promise<void> => {
+    if (offscreenEnsurePromise === null) {
+      console.log('[perapera] offscreen.ensure() start');
+      offscreenEnsurePromise = offscreen.ensure().then(
+        () => {
+          console.log('[perapera] offscreen.ensure() done');
+        },
+        (cause: unknown) => {
+          console.error('[perapera] offscreen.ensure() failed:', cause);
+          // 次回再試行できるよう cache を破棄
+          offscreenEnsurePromise = null;
+          throw cause instanceof Error ? cause : new Error(String(cause));
+        },
+      );
+    }
+    return offscreenEnsurePromise;
+  };
+
+  // SW 起動時に fire-and-forget で ensure を開始 (popup のクリック前に完了することを期待)
+  void ensureOffscreenReady().catch(() => {
+    // 失敗は console.error で記録済。session 開始時に再試行される
   });
 
   const config: ExtensionRuntimeConfig = {
@@ -80,9 +110,11 @@ export default defineBackground(() => {
     extensionVersion: EXTENSION_VERSION,
     protocolVersion: '1.0',
     workletModuleUrl: WORKLET_MODULE_URL,
+    ensureOffscreen: ensureOffscreenReady,
   };
   const ports = createProductionRuntimePorts();
   const app: ExtensionApp = createExtensionApp(config, ports);
+  console.log('[perapera] ExtensionApp composed');
 
   // SW 再起動時に IndexedDB に残存していた orphan active session を stopped 化
   // (IMPL-603, 設計論点 §10)。ensure() の完了を待たずに並列実行してよい

--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
@@ -172,10 +172,17 @@ export const createRelayWebSocketGateway = (
   };
 
   return {
-    openSession: (session) =>
-      deps.tokenIssuer(session).andThen(
-        ({ streamToken, relayUrl, sessionId }): ResultAsync<void, DomainError> =>
-          ResultAsync.fromPromise<void, DomainError>(
+    openSession: (session) => {
+      console.log(
+        `[relay-gateway] openSession start (local sessionId=${session.sessionIdentifier})`,
+      );
+      return deps
+        .tokenIssuer(session)
+        .andThen(({ streamToken, relayUrl, sessionId }): ResultAsync<void, DomainError> => {
+          console.log(
+            `[relay-gateway] token issued (relayUrl=${relayUrl}, serverSessionId=${sessionId})`,
+          );
+          return ResultAsync.fromPromise<void, DomainError>(
             new Promise<void>((resolve, reject) => {
               const url = wsEndpointBuilder({
                 relayUrl,
@@ -183,9 +190,13 @@ export const createRelayWebSocketGateway = (
                 streamToken,
                 protocolVersion: deps.protocolVersion,
               });
+              console.log(`[relay-gateway] connecting WebSocket to ${url}`);
               const socket = deps.webSocketFactory(url);
 
               const onOpen = (): void => {
+                console.log(
+                  `[relay-gateway] WebSocket open (session=${session.sessionIdentifier})`,
+                );
                 socket.removeEventListener('open', onOpen);
                 const sequence = 0;
                 socket.send(
@@ -217,8 +228,17 @@ export const createRelayWebSocketGateway = (
                 resolve();
               };
               socket.addEventListener('open', onOpen);
-              socket.addEventListener('error', () => {
+              socket.addEventListener('error', (event) => {
+                console.error('[relay-gateway] WebSocket error before open:', event);
                 reject(new Error('WebSocket error before open'));
+              });
+              socket.addEventListener('close', (event) => {
+                const code = event instanceof CloseEvent ? String(event.code) : 'unknown';
+                const reason =
+                  event instanceof CloseEvent && event.reason.length > 0 ? event.reason : '-';
+                console.log(
+                  `[relay-gateway] WebSocket close (session=${session.sessionIdentifier}, code=${code}, reason=${reason})`,
+                );
               });
             }),
             (cause) =>
@@ -226,8 +246,9 @@ export const createRelayWebSocketGateway = (
                 invariant: 'relay-handshake-failed',
                 details: cause instanceof Error ? cause.message : 'unknown error',
               }),
-          ),
-      ),
+          );
+        });
+    },
 
     sendAudioFrame: (frame: AudioFrameEnvelope) => {
       const connection = connections.get(frame.sessionIdentifier);


### PR DESCRIPTION
## Summary

`domain invariant violated: chrome-runtime-message-bridge (Could not establish connection. Receiving end does not exist.)` の根絶と、user 依頼のデバッグログ強化を同時に実装。

## 原因

SW 起動時に `offscreen.ensure()` を fire-and-forget で呼んでおり、offscreen document の load 完了前に user が popup で「開始」を押すと `openAudioContext` command が送られて receiver 不在エラー。

## Fix: offscreen ensure を send 前に await

`offscreenCommandSender` に `ensureOffscreen?: () => Promise<void>` を optional dep として追加。各 sendMessage 前に idempotent な ensure を await:

```ts
const sendAfterEnsure = (command, label) =>
  ResultAsync.fromPromise(
    deps.ensureOffscreen?.() ?? Promise.resolve(),
    (cause) => invariantViolationError({ invariant: 'offscreen-ensure', details: ... }),
  ).andThen(() => deps.bridge.sendMessage(command));
```

`background.ts` で offscreen.ensure() の Promise を cache (初回作成、2 回目以降は同じ Promise を返す) し、composition 経由で sender に注入。

## デバッグログ強化

user 依頼を受けて各 phase を追跡できる log を追加:

### `background.ts`
- SW 起動時 config dump (relayApiBaseUrl / hasAccessToken / extensionVersion / workletModuleUrl)
- `offscreen.ensure() start` / `done` / `failed`
- `ExtensionApp composed`

### `session-command-service.ts`
- `startSource received: { sourceType, target }`
- `startSource ok: { sessionId, state }`
- `stopSource received`
- `relay event: <type>`

### `offscreen-command-sender.ts`
- `sending <command.type> (<label>) after ensure()`

### `relay-websocket-gateway.ts`
- `openSession start (local sessionId=...)`
- `token issued (relayUrl=..., serverSessionId=...)`
- `connecting WebSocket to <url>`
- `WebSocket open (session=...)`
- `WebSocket close (session=..., code=..., reason=...)` (CloseEvent 判定で安全に抽出)
- `WebSocket error before open:`

## 検証

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm --filter @perapera/extension test --run` 120 files / 904 tests green
- [x] `pnpm --filter @perapera/extension build` 成功

## Test plan (manual)

1. 拡張 reload 時に SW console に以下の順で log が出る:
   ```
   [perapera] ---- background service worker loaded ----
   [perapera] runtime config: { ... }
   [perapera] offscreen.ensure() start
   [perapera] offscreen.ensure() done
   [perapera] ExtensionApp composed
   [perapera] default extension profile ready (identifier=...)
   ```
2. Popup「開始」で以下の chain:
   ```
   [session-command-service] startSource received
   [offscreen-command-sender] sending offscreen.audio.open (openAudioContext) after ensure()
   [relay-gateway] openSession start
   [relay-gateway] token issued
   [relay-gateway] connecting WebSocket to <url>
   [relay-gateway] WebSocket open
   [session-command-service] startSource ok
   ```
3. `chrome-runtime-message-bridge (Receiving end does not exist)` invariant が**出ない**

## 関連

初回ラン連鎖 bug 修正の 11 本目。stop side は PR #91 で対処済、本 PR で open side も閉じて両経路の receiver 不在 error を根絶。