### PR TITLE
chore(extension): audio pipeline debug logs (offscreen + forward receiver)

### DIFF
--- a/packages/extension/src/application/services/audio-frame-forward-receiver.ts
+++ b/packages/extension/src/application/services/audio-frame-forward-receiver.ts
@@ -94,18 +94,32 @@ export const createAudioFrameForwardReceiver = (
   deps: AudioFrameForwardReceiverDependencies,
 ): AudioFrameForwardReceiver => {
   const logWarn = deps.logWarn ?? defaultLogWarn;
+  const frameCountBySession = new Map<string, number>();
   return {
     receive: (rawMessage) => {
       const parsed = tryParseAudioFrameForwardMessage(rawMessage);
       if (parsed === null) {
         return okAsync<'forwarded' | 'ignored', DomainError>('ignored');
       }
+      const sessionId = parsed.envelope.sessionIdentifier;
+      const prev = frameCountBySession.get(sessionId) ?? 0;
+      const next = prev + 1;
+      frameCountBySession.set(sessionId, next);
+      if (next === 1) {
+        console.log(
+          `[audio-frame-forward-receiver] FIRST frame received for ${sessionId} — forwarding to relay`,
+        );
+      } else if (next % 50 === 0) {
+        console.log(
+          `[audio-frame-forward-receiver] frames forwarded for ${sessionId}: ${String(next)}`,
+        );
+      }
       return deps.relayGateway
         .sendAudioFrame(parsed.envelope)
         .map((): 'forwarded' | 'ignored' => 'forwarded')
         .orElse((error): ResultAsync<'forwarded' | 'ignored', DomainError> => {
           logWarn(
-            `[perapera] audio-frame-forward-receiver sendAudioFrame failed for ${parsed.envelope.sessionIdentifier}: ${
+            `[perapera] audio-frame-forward-receiver sendAudioFrame failed for ${sessionId}: ${
               'kind' in error ? error.kind : String(error)
             }`,
           );

--- a/packages/extension/src/entrypoints/offscreen/main.ts
+++ b/packages/extension/src/entrypoints/offscreen/main.ts
@@ -18,7 +18,7 @@ import { parseOffscreenCommand } from './offscreen-commands';
  * MVP スコープ: AudioContext 確保までの shell。PCM 転送 / AudioWorklet 配線は
  * Phase 6 integration で追加予定。
  */
-console.log('[perapera] offscreen document loaded');
+console.log('[perapera] ---- offscreen document loaded ----');
 
 const WORKLET_MODULE_URL = (() => {
   try {
@@ -27,15 +27,40 @@ const WORKLET_MODULE_URL = (() => {
     return '/perapera-audio-processor.js';
   }
 })();
+console.log('[perapera] offscreen worklet url:', WORKLET_MODULE_URL);
+
+const frameCountBySession = new Map<string, number>();
 
 const host = createOffscreenAudioHost({
   audioContextFactory: defaultAudioContextFactory,
   tabStreamApi: defaultTabStreamApi,
   workletModuleUrl: WORKLET_MODULE_URL,
   workletNodeFactory: defaultWorkletNodeFactory,
+  // console.debug は Chrome DevTools の 'verbose' level を有効化しないと
+  // 見えないため、トラブルシュート中は info level の console.log に昇格。
+  logger: {
+    debug: (message) => {
+      console.log(message);
+    },
+    warn: (message) => {
+      console.warn(message);
+    },
+  },
   // IMPL-617: worklet frame を SW へ転送。chrome.runtime.sendMessage で
   // broadcast し、SW の audio.frame.forward listener が audioFramePump に流す。
   onAudioFrame: (sessionIdentifier, data) => {
+    const prev = frameCountBySession.get(sessionIdentifier) ?? 0;
+    const next = prev + 1;
+    frameCountBySession.set(sessionIdentifier, next);
+    if (next === 1) {
+      console.log(
+        `[perapera] offscreen FIRST AUDIO FRAME for ${sessionIdentifier} — pipeline active`,
+      );
+    } else if (next % 50 === 0) {
+      console.log(
+        `[perapera] offscreen audio frames forwarded for ${sessionIdentifier}: ${String(next)}`,
+      );
+    }
     void chrome.runtime
       .sendMessage({
         type: 'audio.frame.forward',
@@ -58,6 +83,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     // ため silent ignore。return false で async 応答しないことを宣言。
     return false;
   }
+  console.log('[perapera] offscreen dispatch command:', parsed.value.type);
   host.dispatch(parsed.value);
   sendResponse({ ok: true });
   return false;


### PR DESCRIPTION
## Summary

Audio pipeline が実データを流しているか診断するためのログを追加。

## 追加内容

### offscreen `main.ts`
- boot: `---- offscreen document loaded ----` + `offscreen worklet url: ...`
- command 受信: `offscreen dispatch command: <type>` (audio.open / audio.close / ping)
- FIRST frame: `offscreen FIRST AUDIO FRAME for <session> — pipeline active`
- 50 件ごと: `offscreen audio frames forwarded for <session>: <count>`
- offscreen-audio-host logger の default `console.debug` (verbose level) を `console.log` (info level) に override

### SW `audio-frame-forward-receiver.ts`
- FIRST frame: `FIRST frame received for <session> — forwarding to relay`
- 50 件ごと: `frames forwarded for <session>: <count>`

per-frame は出さず first + 50 件おき snapshot で、10 fps の hot path に影響を抑制。

## 検証

- `pnpm lint` clean
- `pnpm typecheck` clean
- `pnpm --filter @perapera/extension test --run` 904 tests green
- `pnpm --filter @perapera/extension build` 成功

## Test plan

audio flow 診断に使う。user が tab 再生開始後に以下が順次出れば pipeline は活性:
```
[perapera] offscreen dispatch command: offscreen.audio.open
[perapera] offscreen-audio-host opened AudioContext for <sessionId>
[perapera] offscreen-audio-host attached MediaStream ...
[perapera] offscreen-audio-host connected MediaStreamAudioSourceNode → AudioWorkletNode
[perapera] offscreen FIRST AUDIO FRAME for <sessionId> — pipeline active
[audio-frame-forward-receiver] FIRST frame received for <sessionId>
```

出ない場合、どの段階で止まっているかが識別可能。