### PR TITLE
fix(extension): popup resolves active tabId for tab capture

### DIFF
--- a/packages/extension/src/presentation/organisms/start-session-form.test.tsx
+++ b/packages/extension/src/presentation/organisms/start-session-form.test.tsx
@@ -72,7 +72,13 @@ describe('StartSessionForm organism (IMPL-540)', () => {
     );
     const client = buildClient(startFn);
     const onStarted = vi.fn();
-    render(<StartSessionForm client={client} onStarted={onStarted} />);
+    render(
+      <StartSessionForm
+        client={client}
+        onStarted={onStarted}
+        resolveActiveTabId={() => Promise.resolve(42)}
+      />,
+    );
     await userEvent.type(screen.getByRole('textbox', { name: '表示名' }), 'YouTube Live');
     await userEvent.click(screen.getByRole('button', { name: '開始' }));
     await waitFor(() => expect(startFn).toHaveBeenCalledOnce());
@@ -83,10 +89,37 @@ describe('StartSessionForm organism (IMPL-540)', () => {
         sourceLanguage: 'en-US',
         targetLanguage: 'ja-JP',
         autoDetectLanguage: false,
-        overlayTarget: { kind: 'extension-monitor' },
+        overlayTarget: { kind: 'tab', tabId: 42 },
       }),
     );
     await waitFor(() => expect(onStarted).toHaveBeenCalledOnce());
+  });
+
+  it('falls back to extension-monitor when active tab id is unresolved for tab source', async () => {
+    const startFn = vi.fn(() =>
+      Promise.resolve<BackgroundResponse<StartSourceSessionResult>>({
+        ok: true,
+        value: { sessionId: 's-2', state: 'requesting_permission', startedAt: 'now' },
+      }),
+    );
+    const client = buildClient(startFn);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* swallow */
+    });
+    try {
+      render(<StartSessionForm client={client} resolveActiveTabId={() => Promise.resolve(null)} />);
+      await userEvent.type(screen.getByRole('textbox', { name: '表示名' }), 'Fallback');
+      await userEvent.click(screen.getByRole('button', { name: '開始' }));
+      await waitFor(() => expect(startFn).toHaveBeenCalledOnce());
+      expect(startFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceType: 'tab',
+          overlayTarget: { kind: 'extension-monitor', pageId: 'monitor' },
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('sends sourceLanguage=null when autoDetect is on', async () => {

--- a/packages/extension/src/presentation/organisms/start-session-form.tsx
+++ b/packages/extension/src/presentation/organisms/start-session-form.tsx
@@ -13,13 +13,36 @@ import {
 import { LanguagePairSelector } from '../molecules/language-pair-selector';
 import { SourceTypeSelector } from '../molecules/source-type-selector';
 
+/**
+ * Active tab resolver. Popup 側 (React context) は `chrome.tabs.query` を
+ * 呼ぶことで現在 active な tab の id を取得できる。tabCapture source では
+ * その id を `overlayTarget: { kind: 'tab', tabId }` として Background に渡し、
+ * Background 側 `chrome.tabCapture.getMediaStreamId({targetTabId})` で
+ * MediaStream を掴むチェーンに接続される。
+ *
+ * test では fake (vi.fn(() => Promise.resolve(42))) を注入可能。
+ */
+export type ActiveTabResolver = () => Promise<number | null>;
+
+const defaultActiveTabResolver: ActiveTabResolver = async () => {
+  try {
+    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+    const first = tabs[0];
+    return typeof first?.id === 'number' ? first.id : null;
+  } catch {
+    return null;
+  }
+};
+
 export type Props = Readonly<{
   client: BackgroundClient;
   onStarted?: (result: StartSourceSessionResult) => void;
+  resolveActiveTabId?: ActiveTabResolver;
 }>;
 
 const DEFAULT_SOURCE_LANGUAGE = 'en-US';
 const DEFAULT_TARGET_LANGUAGE = 'ja-JP';
+const DEFAULT_MONITOR_PAGE_ID = 'monitor';
 
 /**
  * IMPL-540 StartSessionForm organism。
@@ -45,21 +68,41 @@ export function StartSessionForm(props: Props) {
   const canSubmit =
     displayName.trim().length > 0 && !samePair && command.state.status !== 'pending';
 
+  const resolveActiveTabId = props.resolveActiveTabId ?? defaultActiveTabResolver;
+
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
-    const input: StartSourceSessionInput = {
+    const baseInput: Omit<StartSourceSessionInput, 'overlayTarget'> = {
       sourceType,
       displayName: displayName.trim(),
       autoDetectLanguage: autoDetect,
       sourceLanguage: autoDetect ? null : sourceLanguage,
       targetLanguage,
-      overlayTarget: { kind: 'extension-monitor' },
     };
-    void command.execute(input).then((response) => {
+    const buildOverlayTarget = async (): Promise<StartSourceSessionInput['overlayTarget']> => {
+      // tab source: 現在 active な tab を capture + overlay 先に使う。
+      // id 解決失敗時は monitor fallback (現状 tab capture は動かないが、
+      // 少なくとも UseCase の validation で `sourceType='tab'` 時に
+      // captureTabId 必須ロジックが入るまでの fail-soft)。
+      if (sourceType === 'tab') {
+        const tabId = await resolveActiveTabId();
+        if (typeof tabId === 'number') {
+          return { kind: 'tab', tabId };
+        }
+        console.warn(
+          '[start-session-form] active tab id unresolved; falling back to extension-monitor',
+        );
+      }
+      return { kind: 'extension-monitor', pageId: DEFAULT_MONITOR_PAGE_ID };
+    };
+    void (async () => {
+      const overlayTarget = await buildOverlayTarget();
+      const input: StartSourceSessionInput = { ...baseInput, overlayTarget };
+      const response = await command.execute(input);
       if (response.ok && props.onStarted !== undefined) {
         props.onStarted(response.value);
       }
-    });
+    })();
   };
 
   return (


### PR DESCRIPTION
## Summary

Popup が active tab の id を `chrome.tabs.query` 経由で解決し、`sourceType === 'tab'` のとき `overlayTarget: { kind: 'tab', tabId }` として送信。これにより tab capture → MediaStream → AudioWorklet → SW → Relay の frame pipeline が活性化。

## 原因 (user 報告ログから特定)

SW console で:
- `WebSocket open` ✓
- `openAudioContext` command 送信 ✓
- `transcript.partial` / `translation.final` event が**一切来ない** ✗

原因: Popup は `overlayTarget: { kind: 'extension-monitor' }` を hardcoded 送信 → `StartSourceSessionUseCase.targetTabId` が undefined → `tabStreamIdResolver.resolve` が skip → offscreen に `tabStreamId` が渡らず `attachMediaStream` 発動せず → MediaStream が取得されない → audio frame が 1 件も流れない。

## Fix

`StartSessionForm`:
- `ActiveTabResolver` 型 (`() => Promise<number | null>`) を追加、`props.resolveActiveTabId` で test seam 提供
- default は `chrome.tabs.query({active: true, currentWindow: true})`
- submit 時:
  - `sourceType === 'tab'` で tabId 解決成功 → `{ kind: 'tab', tabId }`
  - 解決失敗 → warn + `{ kind: 'extension-monitor', pageId: 'monitor' }` fallback
  - `microphone` / `desktop` → 従来の `extension-monitor` 固定
- Promise chain を `void (async () => {...})()` に書き直し (`promise/no-nesting` lint 対応)

## 副次的な効果

- tab capture + tab overlay が単一タブに集約され、user が monitor.html を別途開く必要なくなった
- `overlayTarget.tabId` は capture 対象 + overlay 描画先の両方を兼ねる (api-specification 準拠)

## 検証

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm --filter @perapera/extension test --run` 120 files / 905 tests green (旧 904 → +1 fallback regression)
- [x] `pnpm --filter @perapera/extension build` 成功

## Test plan (manual)

1. YouTube 等の音声ありタブで**音声を再生**
2. Popup → sourceType=tab → 開始
3. **Offscreen DevTools** で:
   - `attached MediaStream ... (tracks=1)` ← 今回の修正で出るようになる
   - `connected MediaStreamAudioSourceNode → AudioWorkletNode`
   - `FIRST AUDIO FRAME for <sessionId> — pipeline active`
4. **SW DevTools** で:
   - `[audio-frame-forward-receiver] FIRST frame received for <sessionId>`
   - `[session-command-service] relay event: transcript.partial`
   - `[session-command-service] relay event: translation.final`
5. Overlay が対象タブに Shadow DOM で表示される (content script 経由)