### PR TITLE
fix(extension): inline pure-JS base64 in AudioWorklet (btoa unavailable)

### DIFF
--- a/packages/extension/src/infrastructure/audio/pcm-utils.ts
+++ b/packages/extension/src/infrastructure/audio/pcm-utils.ts
@@ -31,18 +31,43 @@ export const floatToPcm16 = (float32: Float32Array): Int16Array => {
 
 /**
  * Int16 PCM を Base64 文字列に encode する。
- * AudioWorklet / browser / node (vitest) すべてで動作する最小実装として
- * Uint8Array → 8bit char → btoa を使う。
+ *
+ * AudioWorkletGlobalScope には `btoa` が**無い** (W3C 仕様上 Window/Worker のみ)
+ * ため、pure JS の RFC 4648 §4 準拠エンコーダを実装する。worklet 側
+ * (`packages/extension/src/public/perapera-audio-processor.js`) と同一ロジックで
+ * mirror すること (両方とも import 禁止コンテキストのため 1:1 複製)。
  */
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
 export const int16ToBase64 = (int16: Int16Array): string => {
   const bytes = new Uint8Array(int16.buffer, int16.byteOffset, int16.byteLength);
-  let binary = '';
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
+  let result = '';
+  let i = 0;
+  const len = bytes.length;
+  while (i < len - 2) {
+    const b0 = bytes[i] ?? 0;
+    const b1 = bytes[i + 1] ?? 0;
+    const b2 = bytes[i + 2] ?? 0;
+    result += BASE64_ALPHABET[b0 >> 2];
+    result += BASE64_ALPHABET[((b0 & 0x03) << 4) | (b1 >> 4)];
+    result += BASE64_ALPHABET[((b1 & 0x0f) << 2) | (b2 >> 6)];
+    result += BASE64_ALPHABET[b2 & 0x3f];
+    i += 3;
   }
-  if (typeof btoa === 'function') return btoa(binary);
-  // Node 20+ (vitest) には btoa グローバルがあるが、念のため fallback
-  return Buffer.from(binary, 'binary').toString('base64');
+  if (i < len) {
+    const b0 = bytes[i] ?? 0;
+    result += BASE64_ALPHABET[b0 >> 2];
+    if (i + 1 < len) {
+      const b1 = bytes[i + 1] ?? 0;
+      result += BASE64_ALPHABET[((b0 & 0x03) << 4) | (b1 >> 4)];
+      result += BASE64_ALPHABET[(b1 & 0x0f) << 2];
+      result += '=';
+    } else {
+      result += BASE64_ALPHABET[(b0 & 0x03) << 4];
+      result += '==';
+    }
+  }
+  return result;
 };
 
 /**

--- a/packages/extension/src/public/perapera-audio-processor.js
+++ b/packages/extension/src/public/perapera-audio-processor.js
@@ -48,14 +48,41 @@ const floatToPcm16 = (float32) => {
   return int16;
 };
 
+// AudioWorkletGlobalScope には `btoa` が存在しない (W3C 仕様上は
+// Window/Worker のみ)。Chrome 検証でも ReferenceError になるため、pure JS の
+// base64 エンコーダを inline 実装する。RFC 4648 §4 準拠、padding 付き。
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
 const int16ToBase64 = (int16) => {
   const bytes = new Uint8Array(int16.buffer, int16.byteOffset, int16.byteLength);
-  let binary = '';
-  for (let i = 0; i < bytes.length; i += 1) {
-    binary += String.fromCharCode(bytes[i]);
+  let result = '';
+  let i = 0;
+  const len = bytes.length;
+  while (i < len - 2) {
+    const b0 = bytes[i];
+    const b1 = bytes[i + 1];
+    const b2 = bytes[i + 2];
+    result += BASE64_ALPHABET[b0 >> 2];
+    result += BASE64_ALPHABET[((b0 & 0x03) << 4) | (b1 >> 4)];
+    result += BASE64_ALPHABET[((b1 & 0x0f) << 2) | (b2 >> 6)];
+    result += BASE64_ALPHABET[b2 & 0x3f];
+    i += 3;
   }
-  // AudioWorklet コンテキストには btoa が存在する (W3C 仕様)
-  return btoa(binary);
+  // 末尾 1〜2 byte の padding
+  if (i < len) {
+    const b0 = bytes[i];
+    result += BASE64_ALPHABET[b0 >> 2];
+    if (i + 1 < len) {
+      const b1 = bytes[i + 1];
+      result += BASE64_ALPHABET[((b0 & 0x03) << 4) | (b1 >> 4)];
+      result += BASE64_ALPHABET[(b1 & 0x0f) << 2];
+      result += '=';
+    } else {
+      result += BASE64_ALPHABET[(b0 & 0x03) << 4];
+      result += '==';
+    }
+  }
+  return result;
 };
 
 class PeraperaAudioProcessor extends AudioWorkletProcessor {


### PR DESCRIPTION
## Summary

`perapera-audio-processor.js` が `btoa is not defined` で 100ms ごとに失敗しており、audio frame pipeline の最終段で全 frame が捨てられていた。pure JS base64 エンコーダに置換。

## 原因

user 提供の offscreen console log:

```
perapera-audio-processor.js:117 [perapera-audio-processor] flush failed: ReferenceError: btoa is not defined
    at int16ToBase64 (perapera-audio-processor.js:58:3)
    at PeraperaAudioProcessor._flush (perapera-audio-processor.js:104:27)
    at PeraperaAudioProcessor.process (perapera-audio-processor.js:94:14)
```

- `AudioWorkletGlobalScope` には W3C 仕様で `btoa` が**存在しない** (Window/Worker のみ)
- worklet ファイル内 comment は「AudioWorklet コンテキストには btoa が存在する」と誤記されていたため気付きにくかった
- `_flush` は try/catch で握りつぶす設計 → workerlet は生きたまま動き続けるが 1 件も frame が flow しない

## Fix

### `packages/extension/src/public/perapera-audio-processor.js`

`int16ToBase64` を pure JS RFC 4648 §4 エンコーダに置換:
- 3 byte → 4 char の lookup 方式
- 末尾 1〜2 byte は `=` padding
- `BASE64_ALPHABET` 定数のみ、外部依存なし

### `packages/extension/src/infrastructure/audio/pcm-utils.ts`

worklet と 1:1 mirror するルールは既存 comment にあった。TS 側も同じ pure JS 実装に更新し、btoa 依存 + Buffer fallback を削除。誤った comment 「AudioWorklet / browser / node すべてで動作」を「AudioWorklet には btoa 無し、pure JS」に是正。

## 検証

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm --filter @perapera/extension test --run` 120 files / 905 tests green
  - 既存の `int16ToBase64 (IMPL-608)` 17 ケース (round-trip via atob + known values + empty 等) 全て pass
- [x] `pnpm --filter @perapera/extension build` 成功

## Test plan (manual)

PR merge → 拡張 rebuild + reload 後、 YouTube 等音声再生タブで「開始」:

offscreen console で:
```
[perapera-audio-processor] flush failed: ReferenceError ← 消える
```

そして:
```
[perapera] offscreen FIRST AUDIO FRAME for <sessionId> — pipeline active
[perapera] offscreen audio frames forwarded for <sessionId>: 50
```

SW console で:
```
[audio-frame-forward-receiver] FIRST frame received for <sessionId>
[session-command-service] relay event: transcript.partial
[session-command-service] relay event: transcript.final
[session-command-service] relay event: translation.final
```

overlay が対象タブに表示されることを確認。

## 関連

初回ラン連鎖 bug 修正の仕上げに近い 12 本目。この fix で audio capture → encode → offscreen → SW → relay のパイプラインが end-to-end で動くはず。