### PR TITLE
chore(extension): log session.error event with code/message/flags

### DIFF
--- a/packages/extension/src/application/services/session-command-service.ts
+++ b/packages/extension/src/application/services/session-command-service.ts
@@ -141,7 +141,16 @@ export const createSessionCommandService = (
   },
   applySourceSettings: (input) => deps.updateSourceSettingsUseCase(input),
   handleRelayEvent: (event) => {
-    console.log('[session-command-service] relay event:', event.type);
+    if (event.type === 'session.error') {
+      console.error('[session-command-service] relay session.error:', {
+        code: event.code,
+        message: event.message,
+        retryable: event.retryable,
+        fatal: event.fatal,
+      });
+    } else {
+      console.log('[session-command-service] relay event:', event.type);
+    }
     switch (event.type) {
       case 'transcript.partial': {
         const input = toPartialInput(event, deps.clock());


### PR DESCRIPTION
## Summary

Relay `session.error` event の内訳 (`code` / `message` / `retryable` / `fatal`) を SW console に console.error で出力。診断用。

## 背景

user 環境で PR #95 後、audio frame は流れるが Relay が `session.error` を連続返却。現状 handleRelayEvent の session.error branch は no-op で type しか log に出ず原因特定できない。

## Fix

`session-command-service.handleRelayEvent` の head に条件分岐を追加:
- `session.error` の場合 `console.error(...)` で 4 field 出力
- それ以外は従来の `console.log('relay event:', type)`

## 検証

- `pnpm lint` clean
- `pnpm typecheck` clean
- `pnpm --filter @perapera/extension test --run` 905 tests green

## Test plan

PR merge → rebuild + reload → 開始後、SW console で `[session-command-service] relay session.error:` エントリが出るはず。code が `STT_*` / `TRANSLATION_*` / `CAPTURE_*` / `SYSTEM_UNEXPECTED` のどれかで provider 特定できる。