### PR TITLE
fix(relay-api): buffer audio.frame during STT openStream async delay

### DIFF
--- a/packages/extension/src/application/services/session-command-service.ts
+++ b/packages/extension/src/application/services/session-command-service.ts
@@ -141,7 +141,16 @@ export const createSessionCommandService = (
   },
   applySourceSettings: (input) => deps.updateSourceSettingsUseCase(input),
   handleRelayEvent: (event) => {
-    console.log('[session-command-service] relay event:', event.type);
+    if (event.type === 'session.error') {
+      console.error('[session-command-service] relay session.error:', {
+        code: event.code,
+        message: event.message,
+        retryable: event.retryable,
+        fatal: event.fatal,
+      });
+    } else {
+      console.log('[session-command-service] relay event:', event.type);
+    }
     switch (event.type) {
       case 'transcript.partial': {
         const input = toPartialInput(event, deps.clock());

--- a/packages/relay-api/src/presentation/ws/relay-route.test.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.test.ts
@@ -1,11 +1,15 @@
 import fastifyWebsocket from '@fastify/websocket';
-import { errAsync, ok, okAsync } from 'neverthrow';
+import { errAsync, ok, ok as okResult, okAsync, ResultAsync, type Result } from 'neverthrow';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import WebSocket from 'ws';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { type AccessTokenVerifier } from '../../application/ports/access-token-verifier';
 import { type JwtVerifiedPayload, type JwtVerifier } from '../../application/ports/jwt-verifier';
-import { type SttPort, type TranscriptEvent } from '../../application/ports/stt-port';
+import {
+  type SttPort,
+  type SttStreamHandle,
+  type TranscriptEvent,
+} from '../../application/ports/stt-port';
 import { type TranslationPort } from '../../application/ports/translation-port';
 import { type IssueStreamTokenUseCase } from '../../application/use-cases/issue-stream-token-use-case';
 import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
@@ -532,6 +536,127 @@ describe('WebSocket /relay route', () => {
         eventType: 'session.error',
         payload: { code: 'SESSION_NOT_READY' },
       });
+      ws.close();
+    }, 10000);
+
+    it('buffers audio.frame sent during STT openStream delay and flushes after session.start resolves', async () => {
+      // STT の openStream を 200ms 遅延させる = session.start → audio.frame の
+      // race を再現。遅延中に送られた frame は pending queue に積まれ、
+      // openStream 解決後に handle.sendFrame へ flush される。
+      const sendFrameCalls: { audioBase64: string; chunkId: string }[] = [];
+      let resolveOpen: ((handle: SttStreamHandle) => void) | null = null;
+      const slowSttPort: SttPort = {
+        openStream: () => {
+          const handle: SttStreamHandle = {
+            sendFrame: (frame) => {
+              sendFrameCalls.push(frame);
+              return okResult(undefined);
+            },
+            close: () => okAsync<void, DomainError>(undefined),
+            events: {
+              [Symbol.asyncIterator]: () => ({
+                next: (): Promise<IteratorResult<TranscriptEvent>> =>
+                  new Promise<IteratorResult<TranscriptEvent>>(() => {
+                    // 無限保留 (このテストでは transcript を検証しない)
+                  }),
+              }),
+            },
+          };
+          return new ResultAsync<SttStreamHandle, DomainError>(
+            new Promise<Result<SttStreamHandle, DomainError>>((resolve) => {
+              resolveOpen = (h) => {
+                resolve(okResult(h));
+              };
+              setTimeout(() => {
+                if (resolveOpen !== null) {
+                  const capture = resolveOpen;
+                  resolveOpen = null;
+                  capture(handle);
+                }
+              }, 200);
+            }),
+          );
+        },
+      };
+      harness = await startApp(okVerifier, { sttPort: slowSttPort });
+      const ws = connectWithAuth(relayUrl(harness), 'valid.jwt');
+      const queue = createMessageQueue(ws);
+      await awaitOpen(ws);
+      await queue.next(); // session.ready
+
+      // session.start を先に送信 (STT は 200ms かけて開く)
+      ws.send(
+        JSON.stringify({
+          eventType: 'session.start',
+          sessionId: SESSION_ID,
+          sequence: 1,
+          timestamp: new Date().toISOString(),
+          payload: {
+            sourceLanguage: 'en-US',
+            autoDetectLanguage: false,
+            targetLanguage: 'ja-JP',
+            translationEnabled: true,
+          },
+        }),
+      );
+
+      // 直後に audio.frame を 2 件送る (STT 未準備で buffer されるはず)
+      ws.send(
+        JSON.stringify({
+          eventType: 'audio.frame',
+          sessionId: SESSION_ID,
+          sequence: 2,
+          timestamp: new Date().toISOString(),
+          payload: {
+            chunkId: 'chk_1',
+            audioBase64: 'AAAA=',
+            encoding: 'pcm_s16le',
+            sampleRateHz: 16000,
+            channels: 1,
+            frameDurationMs: 100,
+            capturedAt: new Date().toISOString(),
+          },
+        }),
+      );
+      ws.send(
+        JSON.stringify({
+          eventType: 'audio.frame',
+          sessionId: SESSION_ID,
+          sequence: 3,
+          timestamp: new Date().toISOString(),
+          payload: {
+            chunkId: 'chk_2',
+            audioBase64: 'BBBB=',
+            encoding: 'pcm_s16le',
+            sampleRateHz: 16000,
+            channels: 1,
+            frameDurationMs: 100,
+            capturedAt: new Date().toISOString(),
+          },
+        }),
+      );
+
+      // 500ms 待って STT open + flush 完了を期待
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 500);
+      });
+
+      // session.error は届かない想定: queue.next(100) で timeout 期待
+      let errorThrown = false;
+      try {
+        const maybeError = await queue.next(100);
+        expect(maybeError).not.toMatchObject({ eventType: 'session.error' });
+      } catch {
+        // timeout は期待通り (session.error が来なかった証拠)
+        errorThrown = true;
+      }
+      expect(errorThrown).toBe(true);
+
+      // sendFrame が 2 回呼ばれていること (flush された)
+      expect(sendFrameCalls).toHaveLength(2);
+      expect(sendFrameCalls[0]?.chunkId).toBe('chk_1');
+      expect(sendFrameCalls[1]?.chunkId).toBe('chk_2');
+
       ws.close();
     }, 10000);
   });

--- a/packages/relay-api/src/presentation/ws/relay-route.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.ts
@@ -290,9 +290,21 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
 
       // per-connection state
       let activeStream: ActiveStream | null = null;
+      /**
+       * `session.start` を受信してから `sttPort.openStream` が resolve するまで
+       * の一時状態。この間 `audio.frame` が届いても `SESSION_NOT_READY` を
+       * 返さず、`pendingFrames` に buffer する。client (browser extension) は
+       * WebSocket の onopen 直後に session.start → audio.frame を連続 post する
+       * ため、STT 接続の async レイテンシを server 側で吸収する必要がある
+       * (api-specification §6 のメッセージ順序契約に準拠)。
+       */
+      let sttOpening = false;
+      const MAX_PENDING_FRAMES = 50; // 100ms * 50 = 5s バッファ上限
+      let pendingFrames: { audioBase64: string; chunkId: string }[] = [];
       const audioFrameBucket = createRateBucket(audioFrameLimit, 1000);
 
       const closeActiveStream = (): void => {
+        pendingFrames = [];
         if (activeStream === null) return;
         const handle = activeStream.handle;
         activeStream = null;
@@ -358,7 +370,7 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
       const handleSessionStart = (
         event: Extract<ClientEvent, { eventType: 'session.start' }>,
       ): void => {
-        if (activeStream !== null) {
+        if (activeStream !== null || sttOpening) {
           sendSessionError(socket, context, nextSequence, deps.clock, {
             code: 'INVALID_STATE_TRANSITION',
             message: 'session.start received while stream is already active',
@@ -367,6 +379,7 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
           });
           return;
         }
+        sttOpening = true;
         // JWT claims / session.start payload どちらからも language を決定
         const sourceLanguage =
           event.payload.sourceLanguage ??
@@ -388,9 +401,29 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
                 sourceLanguage: autoDetectLanguage ? null : sourceLanguage,
               };
               activeStream = stream;
+              sttOpening = false;
+              // pending frame を flush (rate limit は既に consume 済、再度は不要)
+              if (pendingFrames.length > 0) {
+                request.log.debug(
+                  { count: pendingFrames.length, sessionId: context.sessionId },
+                  'flushing pending audio.frame buffer after session.start',
+                );
+                for (const frame of pendingFrames) {
+                  const flushResult = handle.sendFrame(frame);
+                  if (flushResult.isErr()) {
+                    request.log.warn(
+                      { err: flushResult.error },
+                      'stt sendFrame failed during pending flush',
+                    );
+                  }
+                }
+                pendingFrames = [];
+              }
               runTranscriptLoop(stream);
             },
             (err) => {
+              sttOpening = false;
+              pendingFrames = [];
               request.log.error({ err }, 'stt openStream failed');
               sendSessionError(socket, context, nextSequence, deps.clock, {
                 code: 'STT_ERROR',
@@ -405,7 +438,8 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
       const handleAudioFrame = (
         event: Extract<ClientEvent, { eventType: 'audio.frame' }>,
       ): void => {
-        if (activeStream === null) {
+        // session.start 未受信 / 既受信で STT open 待ち / ストリーム確立済 の 3 状態を分岐
+        if (activeStream === null && !sttOpening) {
           sendSessionError(socket, context, nextSequence, deps.clock, {
             code: 'SESSION_NOT_READY',
             message: 'audio.frame received before session.start',
@@ -421,6 +455,21 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
             retryable: true,
             fatal: false,
           });
+          return;
+        }
+        if (activeStream === null) {
+          // STT open 待ちの間は buffer。上限超過で drop (hot path を止めない)
+          if (pendingFrames.length < MAX_PENDING_FRAMES) {
+            pendingFrames.push({
+              audioBase64: event.payload.audioBase64,
+              chunkId: event.payload.chunkId,
+            });
+          } else {
+            request.log.warn(
+              { count: pendingFrames.length, chunkId: event.payload.chunkId },
+              'pending audio.frame buffer full — dropping frame during STT open',
+            );
+          }
           return;
         }
         const result = activeStream.handle.sendFrame({


### PR DESCRIPTION
## Summary

SW console で `session.error { code: 'SESSION_NOT_READY', message: 'audio.frame received before session.start' }` が連続発火していた race condition を Relay 側で修正。

## 原因

Relay `handleSessionStart` が `sttPort.openStream` を async で呼び、Promise が resolve するまで `activeStream = null`。その間に届く `audio.frame` は `SESSION_NOT_READY` で reject されていた。extension は session.start 送信直後 (~10ms 後) から 100ms ごとに frame を送るが、Deepgram WS 接続は数百 ms かかるため race が構造的に発生。

## Fix

per-connection state に:
- `sttOpening: boolean` (同期フラグ)
- `pendingFrames: Array<{audioBase64, chunkId}>` (上限 50 = 5 秒分)

を追加し、`handleAudioFrame` を 3 状態分岐:

| state | 挙動 |
|---|---|
| `!active && !opening` | 従来通り `SESSION_NOT_READY` reject |
| `opening` (STT 接続中) | rate bucket consume 後 `pendingFrames.push`、上限超過で drop + warn |
| `active` | rate bucket consume 後 `handle.sendFrame` |

`handleSessionStart` は同期で `sttOpening = true` を設定し、`openStream` resolve 時に:
1. `activeStream = stream`
2. `sttOpening = false`
3. `pendingFrames` を `sendFrame` へ flush
4. `runTranscriptLoop` 起動

失敗時は `pendingFrames = []` + `STT_ERROR`。`closeActiveStream` でも `pendingFrames` reset。

## 設計判断

- 上限 50 (5 秒分): CLAUDE.md ホットパス§ の「永続キュー禁止」と Deepgram 接続の実測レイテンシ (数百 ms) のバランス
- rate limit は buffer 段階でも consume: 過剰送信を防ぐ。flush 時は再 consume しない
- session.start 2 重受信は従来通り `INVALID_STATE_TRANSITION` (sttOpening 中もガード)

## 検証

- `pnpm lint` clean
- `pnpm typecheck` clean
- `pnpm --filter @perapera/relay-api test --run` 33 files / 189 tests green
  - 既存 `rejects audio.frame before session.start` test: 引き続き通る (session.start なしでの frame 送信は依然 SESSION_NOT_READY)
  - 新規 test: STT openStream に 200ms 遅延を仕込み、遅延中に送信した 2 frame が flush 後 `sendFrame` に投入されることを assert
- `pnpm --filter @perapera/extension test --run` 905 tests green

## Test plan (manual)

PR merge → relay-api 再起動 → extension reload + YouTube 再生タブで開始:

**Before**:
```
[session-command-service] relay session.error: { code: 'SESSION_NOT_READY', ... }
(繰り返し)
```

**After**:
```
[audio-frame-forward-receiver] FIRST frame received for <sid>
[session-command-service] relay event: transcript.partial
[session-command-service] relay event: transcript.final
[session-command-service] relay event: translation.final
```