### PR TITLE
fix(extension): include autoDetectLanguage in session.start envelope

### DIFF
--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.test.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.test.ts
@@ -200,12 +200,15 @@ describe('createRelayWebSocketGateway (IMPL-320, DD-105 / DD-411)', () => {
       expect(socket?.sentMessages.length).toBeGreaterThan(0);
       const first = socket?.sentMessages[0] ?? '';
       const parsed: unknown = JSON.parse(first);
+      // Relay client-events.ts sessionStartPayload が必須する 4 field を全て含むか
       expect(parsed).toMatchObject({
         eventType: 'session.start',
         sessionId: SESSION_ID,
         payload: {
           sourceLanguage: 'en-US',
+          autoDetectLanguage: false,
           targetLanguage: 'ja-JP',
+          translationEnabled: true,
         },
       });
     });

--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
@@ -199,19 +199,28 @@ export const createRelayWebSocketGateway = (
                 );
                 socket.removeEventListener('open', onOpen);
                 const sequence = 0;
-                socket.send(
-                  buildEnvelope(
-                    'session.start',
-                    session.sessionIdentifier,
-                    sequence,
-                    toIsoString(deps.clock),
-                    {
-                      sourceLanguage: session.languagePair.source,
-                      targetLanguage: session.languagePair.target,
-                      translationEnabled: true,
-                    },
-                  ),
+                const sessionStartEnvelope = buildEnvelope(
+                  'session.start',
+                  session.sessionIdentifier,
+                  sequence,
+                  toIsoString(deps.clock),
+                  {
+                    // Relay (client-events.ts `sessionStartPayload`) は
+                    // `sourceLanguage?: string | null`、`autoDetectLanguage: boolean`
+                    // (必須)、`targetLanguage: string`、`translationEnabled: boolean`
+                    // を期待。`autoDetectLanguage` を欠かすと Zod parse fail で
+                    // VALIDATION_ERROR になり、以降 audio.frame が
+                    // SESSION_NOT_READY 連続発火する。
+                    sourceLanguage: session.languagePair.source,
+                    autoDetectLanguage: false,
+                    targetLanguage: session.languagePair.target,
+                    translationEnabled: true,
+                  },
                 );
+                console.log(
+                  `[relay-gateway] sending session.start (${String(sessionStartEnvelope.length)} bytes)`,
+                );
+                socket.send(sessionStartEnvelope);
                 const connection: SessionConnection = {
                   socket,
                   sequence: sequence + 1,

--- a/packages/relay-api/src/presentation/ws/relay-route.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.ts
@@ -290,6 +290,7 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
 
       // per-connection state
       let activeStream: ActiveStream | null = null;
+      let audioFrameReceivedCount = 0;
       /**
        * `session.start` を受信してから `sttPort.openStream` が resolve するまで
        * の一時状態。この間 `audio.frame` が届いても `SESSION_NOT_READY` を
@@ -371,6 +372,14 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
         event: Extract<ClientEvent, { eventType: 'session.start' }>,
       ): void => {
         if (activeStream !== null || sttOpening) {
+          request.log.warn(
+            {
+              sessionId: context.sessionId,
+              activeStream: activeStream !== null,
+              sttOpening,
+            },
+            'session.start received while stream already active/opening — rejecting',
+          );
           sendSessionError(socket, context, nextSequence, deps.clock, {
             code: 'INVALID_STATE_TRANSITION',
             message: 'session.start received while stream is already active',
@@ -379,6 +388,15 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
           });
           return;
         }
+        request.log.info(
+          {
+            sessionId: context.sessionId,
+            sourceLanguage: event.payload.sourceLanguage,
+            targetLanguage: event.payload.targetLanguage,
+            autoDetect: event.payload.autoDetectLanguage,
+          },
+          'session.start accepted — opening STT stream',
+        );
         sttOpening = true;
         // JWT claims / session.start payload どちらからも language を決定
         const sourceLanguage =
@@ -404,7 +422,7 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
               sttOpening = false;
               // pending frame を flush (rate limit は既に consume 済、再度は不要)
               if (pendingFrames.length > 0) {
-                request.log.debug(
+                request.log.info(
                   { count: pendingFrames.length, sessionId: context.sessionId },
                   'flushing pending audio.frame buffer after session.start',
                 );
@@ -440,6 +458,14 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
       ): void => {
         // session.start 未受信 / 既受信で STT open 待ち / ストリーム確立済 の 3 状態を分岐
         if (activeStream === null && !sttOpening) {
+          request.log.warn(
+            {
+              sessionId: context.sessionId,
+              chunkId: event.payload.chunkId,
+              phase: 'handleAudioFrame: no session.start received yet',
+            },
+            'REJECTING audio.frame — activeStream=null, sttOpening=false',
+          );
           sendSessionError(socket, context, nextSequence, deps.clock, {
             code: 'SESSION_NOT_READY',
             message: 'audio.frame received before session.start',
@@ -486,6 +512,33 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
       };
 
       const dispatchClientEvent = (event: ClientEvent): void => {
+        // 診断: 全 client event を info level で出す (頻度の高い audio.frame は
+        // 1 件目と 10 件ごとに間引き)。
+        if (event.eventType === 'audio.frame') {
+          audioFrameReceivedCount += 1;
+          if (audioFrameReceivedCount === 1 || audioFrameReceivedCount % 10 === 0) {
+            request.log.info(
+              {
+                sessionId: context.sessionId,
+                activeStream: activeStream !== null,
+                sttOpening,
+                pendingCount: pendingFrames.length,
+                totalReceived: audioFrameReceivedCount,
+              },
+              'audio.frame received (sample)',
+            );
+          }
+        } else {
+          request.log.info(
+            {
+              sessionId: context.sessionId,
+              eventType: event.eventType,
+              activeStream: activeStream !== null,
+              sttOpening,
+            },
+            'client event received',
+          );
+        }
         switch (event.eventType) {
           case 'session.ping':
             socket.send(


### PR DESCRIPTION
## Summary

`session.start` envelope の payload から `autoDetectLanguage` field が欠落していたために Relay 側 Zod validation fail で VALIDATION_ERROR → extension は session.error を no-op 処理 → 以降 audio.frame が session.start 未受信状態で連続届き `SESSION_NOT_READY` 連発という race condition を修正。

## 原因判明のきっかけ

PR #98 診断 log で user 環境の Relay terminal に:
```
WARN: REJECTING audio.frame — activeStream=null, sttOpening=false
  chunkId: chk_000042   ← 42 件目から記録 (42 * 100ms = 4.2 秒)
```

`session.start accepted — opening STT stream` が**一度も出ていない** = Zod parse fail で VALIDATION_ERROR branch に入っていた。

## Fix

`relay-websocket-gateway.ts` の session.start 送信 payload に `autoDetectLanguage: false` を追加。副次的に送信時の byte count log を追加 (診断継続用)。

### api-spec §6.2 確認
`sessionStartPayload` は:
- `sourceLanguage?: string | null`
- **`autoDetectLanguage: boolean` (必須)**
- `targetLanguage: string`
- `translationEnabled: boolean`

Relay impl と一致。extension 側だけ drift していた。

### Test 強化
`sends session.start envelope on open` を拡張して 4 field 全て送信を assert (regression guard)。

## 検証

- `pnpm lint` / `pnpm typecheck` clean
- `pnpm --filter @perapera/extension test --run` 905 tests green
- `pnpm --filter @perapera/extension build` 成功

## Test plan

PR merge → 拡張 reload + rebuild は不要 (wxt dev が自動 pickup、SW だけ chrome://extensions で手動 reload):

Relay terminal:
```
INFO: client event received { eventType: 'session.start' }  ← 今回出るようになる
INFO: session.start accepted — opening STT stream           ← 次に出る
INFO: audio.frame received (sample) { sttOpening: true, pendingCount: 1 }
INFO: flushing pending audio.frame buffer after session.start { count: N }
```

## 関連

初回ラン連鎖 bug 修正の 14 本目。Relay contract drift の最終段。この修正で audio capture → encode → forward → Relay → STT → translation → overlay の end-to-end pipeline が実動作に入るはず。