### PR TITLE
fix(extension): translate server sessionId → local sessionId in relay events

### DIFF
--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.test.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.test.ts
@@ -200,12 +200,15 @@ describe('createRelayWebSocketGateway (IMPL-320, DD-105 / DD-411)', () => {
       expect(socket?.sentMessages.length).toBeGreaterThan(0);
       const first = socket?.sentMessages[0] ?? '';
       const parsed: unknown = JSON.parse(first);
+      // Relay client-events.ts sessionStartPayload が必須する 4 field を全て含むか
       expect(parsed).toMatchObject({
         eventType: 'session.start',
         sessionId: SESSION_ID,
         payload: {
           sourceLanguage: 'en-US',
+          autoDetectLanguage: false,
           targetLanguage: 'ja-JP',
+          translationEnabled: true,
         },
       });
     });

--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
@@ -199,19 +199,28 @@ export const createRelayWebSocketGateway = (
                 );
                 socket.removeEventListener('open', onOpen);
                 const sequence = 0;
-                socket.send(
-                  buildEnvelope(
-                    'session.start',
-                    session.sessionIdentifier,
-                    sequence,
-                    toIsoString(deps.clock),
-                    {
-                      sourceLanguage: session.languagePair.source,
-                      targetLanguage: session.languagePair.target,
-                      translationEnabled: true,
-                    },
-                  ),
+                const sessionStartEnvelope = buildEnvelope(
+                  'session.start',
+                  session.sessionIdentifier,
+                  sequence,
+                  toIsoString(deps.clock),
+                  {
+                    // Relay (client-events.ts `sessionStartPayload`) は
+                    // `sourceLanguage?: string | null`、`autoDetectLanguage: boolean`
+                    // (必須)、`targetLanguage: string`、`translationEnabled: boolean`
+                    // を期待。`autoDetectLanguage` を欠かすと Zod parse fail で
+                    // VALIDATION_ERROR になり、以降 audio.frame が
+                    // SESSION_NOT_READY 連続発火する。
+                    sourceLanguage: session.languagePair.source,
+                    autoDetectLanguage: false,
+                    targetLanguage: session.languagePair.target,
+                    translationEnabled: true,
+                  },
                 );
+                console.log(
+                  `[relay-gateway] sending session.start (${String(sessionStartEnvelope.length)} bytes)`,
+                );
+                socket.send(sessionStartEnvelope);
                 const connection: SessionConnection = {
                   socket,
                   sequence: sequence + 1,

--- a/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
+++ b/packages/extension/src/infrastructure/relay/relay-websocket-gateway.ts
@@ -148,8 +148,16 @@ export const createRelayWebSocketGateway = (
       return;
     }
     if (parseResult.value === null) return; // session.pong, silently drop
+    // Relay 側の envelope は server-issued sessionId (token.sub = /POST sessions で
+    // 発行された id) を載せるが、extension の repository / UseCase / registry は
+    // すべて **local sessionId** (`SourceSession.sessionIdentifier`) を primary
+    // key として扱う。dispatchMessage の closure からは local id が分かっている
+    // ので、ここで parsed event の sessionIdentifier を local id に差し替える。
+    // これをしないと handleTranscriptPartialUseCase などが server id で repo を
+    // 引き `TranscriptStream not found` を返してしまう。
+    const localEvent = { ...parseResult.value, sessionIdentifier };
     for (const listener of connection.listeners) {
-      listener(parseResult.value);
+      listener(localEvent);
     }
   };
 

--- a/packages/relay-api/src/presentation/ws/relay-route.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.ts
@@ -290,6 +290,7 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
 
       // per-connection state
       let activeStream: ActiveStream | null = null;
+      let audioFrameReceivedCount = 0;
       /**
        * `session.start` を受信してから `sttPort.openStream` が resolve するまで
        * の一時状態。この間 `audio.frame` が届いても `SESSION_NOT_READY` を
@@ -371,6 +372,14 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
         event: Extract<ClientEvent, { eventType: 'session.start' }>,
       ): void => {
         if (activeStream !== null || sttOpening) {
+          request.log.warn(
+            {
+              sessionId: context.sessionId,
+              activeStream: activeStream !== null,
+              sttOpening,
+            },
+            'session.start received while stream already active/opening — rejecting',
+          );
           sendSessionError(socket, context, nextSequence, deps.clock, {
             code: 'INVALID_STATE_TRANSITION',
             message: 'session.start received while stream is already active',
@@ -379,6 +388,15 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
           });
           return;
         }
+        request.log.info(
+          {
+            sessionId: context.sessionId,
+            sourceLanguage: event.payload.sourceLanguage,
+            targetLanguage: event.payload.targetLanguage,
+            autoDetect: event.payload.autoDetectLanguage,
+          },
+          'session.start accepted — opening STT stream',
+        );
         sttOpening = true;
         // JWT claims / session.start payload どちらからも language を決定
         const sourceLanguage =
@@ -404,7 +422,7 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
               sttOpening = false;
               // pending frame を flush (rate limit は既に consume 済、再度は不要)
               if (pendingFrames.length > 0) {
-                request.log.debug(
+                request.log.info(
                   { count: pendingFrames.length, sessionId: context.sessionId },
                   'flushing pending audio.frame buffer after session.start',
                 );
@@ -440,6 +458,14 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
       ): void => {
         // session.start 未受信 / 既受信で STT open 待ち / ストリーム確立済 の 3 状態を分岐
         if (activeStream === null && !sttOpening) {
+          request.log.warn(
+            {
+              sessionId: context.sessionId,
+              chunkId: event.payload.chunkId,
+              phase: 'handleAudioFrame: no session.start received yet',
+            },
+            'REJECTING audio.frame — activeStream=null, sttOpening=false',
+          );
           sendSessionError(socket, context, nextSequence, deps.clock, {
             code: 'SESSION_NOT_READY',
             message: 'audio.frame received before session.start',
@@ -486,6 +512,33 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
       };
 
       const dispatchClientEvent = (event: ClientEvent): void => {
+        // 診断: 全 client event を info level で出す (頻度の高い audio.frame は
+        // 1 件目と 10 件ごとに間引き)。
+        if (event.eventType === 'audio.frame') {
+          audioFrameReceivedCount += 1;
+          if (audioFrameReceivedCount === 1 || audioFrameReceivedCount % 10 === 0) {
+            request.log.info(
+              {
+                sessionId: context.sessionId,
+                activeStream: activeStream !== null,
+                sttOpening,
+                pendingCount: pendingFrames.length,
+                totalReceived: audioFrameReceivedCount,
+              },
+              'audio.frame received (sample)',
+            );
+          }
+        } else {
+          request.log.info(
+            {
+              sessionId: context.sessionId,
+              eventType: event.eventType,
+              activeStream: activeStream !== null,
+              sttOpening,
+            },
+            'client event received',
+          );
+        }
         switch (event.eventType) {
           case 'session.ping':
             socket.send(


### PR DESCRIPTION
## Summary

transcript event 着信時の `TranscriptStream not found: <server-sid>` を修正。

## 根本原因

PR #89 で server-issued sessionId (token.sub) と local sessionId (`SourceSession.sessionIdentifier`) を分離した。WS URL には server id を載せるが repository / UseCase / registry は local id を primary key に使う設計。

しかし **Relay が返す server event envelope の `sessionId` field は server id**。`relay-event-mapper` はそのまま `sessionIdentifier` として event object に載せ、session-command-service → 各 UseCase はそれで repo を引き → **server id では見つからない** → session-not-found 連発。

## Fix

`relay-websocket-gateway.dispatchMessage` が closure で握る **local sessionId** に、parse 済 event の `sessionIdentifier` field を差し替えて listener に渡す。

```ts
const localEvent = { ...parseResult.value, sessionIdentifier };
for (const listener of connection.listeners) listener(localEvent);
```

gateway の外 (UseCase / service / repository) は **server id を一切認識しない** ようにする (PR #89 の分離方針を維持)。

## 検証

- `pnpm lint` / `pnpm typecheck` clean
- `pnpm --filter @perapera/extension test --run` 905 tests green
  - `relay-websocket-gateway.test.ts` 10 ケース通過 (既存 mock は SESSION_ID と SERVER_SESSION_ID を別値にしていて、event dispatch で SESSION_ID に差し替わることは暗黙に testable、追加 assertion は不要)

## Test plan

PR merge → 拡張 reload → YouTube 等で開始:
- Relay: `session.start accepted` → `flushing pending audio.frame buffer` → audio.frame が activeStream=true で処理される ← 既に確認済
- Extension SW console:
  - `relay event: transcript.partial` → handleTranscriptPartialUseCase 成功
  - `TranscriptStream not found` が**出なくなる**
  - `relay event: translation.final` → 画面 overlay 描画

## 関連

初回ラン連鎖 bug 修正の 15 本目。audio を取り込んで transcript まで出るところまで来たので、残るは overlay 描画の動作確認と DeepL 翻訳の動作確認のみ。