### PR TITLE
fix(extension): accept empty text in handle-transcript-final (translation-only path)

### DIFF
--- a/packages/extension/src/application/dto/handle-transcript-final-dto.test.ts
+++ b/packages/extension/src/application/dto/handle-transcript-final-dto.test.ts
@@ -54,15 +54,23 @@ describe('HandleTranscriptFinalDTO (DD-305)', () => {
       expect(result.isOk()).toBe(true);
     });
 
-    it('rejects empty text (final segment must have content)', () => {
+    it('accepts empty text (translation-only path marker)', () => {
+      // session-command-service.toTranslationFinalInput が translation.final
+      // RelayEvent 受信時に text='' + translation 付き input を合成する経路
+      // (DD-305 §6.2 結果整合性)。Use case 側で text.length === 0 のとき
+      // finalizeSegment を skip する前提で、DTO は空 text を受け入れる必要がある。
       const result = parseHandleTranscriptFinalInput({
         sessionId: SESSION_ID,
         segmentId: SEGMENT_ID,
         text: '',
         timeRange: { startMs: 0, endMs: 1000 },
+        translation: { targetLanguage: 'ja-JP', text: 'こんにちは', status: 'completed' },
       });
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) expect(result.error.kind).toBe('validation');
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.text).toBe('');
+        expect(result.value.translation?.text).toBe('こんにちは');
+      }
     });
 
     it('rejects unknown translation.status', () => {

--- a/packages/extension/src/application/dto/handle-transcript-final-dto.ts
+++ b/packages/extension/src/application/dto/handle-transcript-final-dto.ts
@@ -47,10 +47,15 @@ export type HandleTranscriptFinalInput = {
     | undefined;
 };
 
+// NOTE: `text` は空文字列許容。`session-command-service` が
+// `translation.final` RelayEvent 受信時、`toTranslationFinalInput` 経由で
+// 空 text + translation 付き input を本 UseCase に渡す経路があるため。
+// use case 側で text.length === 0 時は finalizeSegment を skip し、
+// 既に final 化された segment に translation のみ attach する。
 const handleTranscriptFinalInputSchema = z.object({
   sessionId: z.string().min(1),
   segmentId: z.string().min(1),
-  text: z.string().min(1),
+  text: z.string(),
   timeRange: timeRangeSchema,
   translation: translationPayloadSchema.optional(),
 });

--- a/packages/extension/src/application/use-cases/handle-transcript-final-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/handle-transcript-final-use-case.test.ts
@@ -12,6 +12,7 @@ import { createTimestampRange } from '../../domain/transcript/timestamp-range';
 import {
   appendPartialTranscriptSegment,
   createTranscriptStream,
+  finalizeSegment,
   type TranscriptStream,
 } from '../../domain/transcript/transcript-stream';
 import { type OverlayPresenter } from '../ports/overlay-presenter';
@@ -32,6 +33,15 @@ const buildStreamWithPartial = (): TranscriptStream => {
     segmentIdentifier: SEGMENT_ID,
     revision: 1,
     text: 'hello',
+    timeRange: createTimestampRange({ startMs: 0, endMs: 1000 })._unsafeUnwrap(),
+  })._unsafeUnwrap();
+};
+
+const buildStreamWithFinal = (): TranscriptStream => {
+  const base = buildStreamWithPartial();
+  return finalizeSegment(base, {
+    segmentIdentifier: SEGMENT_ID,
+    text: 'hello world',
     timeRange: createTimestampRange({ startMs: 0, endMs: 1000 })._unsafeUnwrap(),
   })._unsafeUnwrap();
 };
@@ -158,17 +168,36 @@ describe('createHandleTranscriptFinalUseCase (IMPL-214, DD-305)', () => {
     expect(deps.transcriptStreamRepository.appendTranslation).not.toHaveBeenCalled();
   });
 
-  it('returns validation error when text is empty', async () => {
-    const deps = buildDependencies();
+  it('accepts empty text with translation (translation-only path)', async () => {
+    // text='' は session-command-service.toTranslationFinalInput が
+    // translation.final RelayEvent 受信時に合成する marker。Use case は
+    // finalizeSegment を skip し、既に別経路で final 化された segment に
+    // translation だけを attach する。stream は prior transcript.final で
+    // final 化された segment を持つ想定。
+    const deps = buildDependencies({
+      transcriptStreamRepository: {
+        findBySessionId: vi.fn(() => okAsync(buildStreamWithFinal())),
+        appendPartial: vi.fn(() => okAsync<void, DomainError>(undefined)),
+        appendFinal: vi.fn(() => okAsync<void, DomainError>(undefined)),
+        appendTranslation: vi.fn(() => okAsync<void, DomainError>(undefined)),
+      },
+    });
     const useCase = createHandleTranscriptFinalUseCase(deps);
     const result = await useCase({
       sessionId: SESSION_ID,
       segmentId: SEGMENT_ID,
       text: '',
       timeRange: { startMs: 0, endMs: 1000 },
+      translation: {
+        targetLanguage: 'ja-JP',
+        text: 'こんにちは',
+        status: 'completed',
+      },
     });
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) expect(result.error.type).toBe('validation');
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.translationStatus).toBe('completed');
+    }
   });
 
   it('still succeeds when overlay render fails (hot-path not rolled back)', async () => {

--- a/packages/extension/src/application/use-cases/handle-transcript-final-use-case.ts
+++ b/packages/extension/src/application/use-cases/handle-transcript-final-use-case.ts
@@ -107,13 +107,21 @@ export const createHandleTranscriptFinalUseCase = (
               endMs: parsed.timeRange.endMs,
             }).asyncAndThen((timeRange) =>
               findOrCreateTranscriptStream(deps.transcriptStreamRepository, sessionIdentifier)
-                .andThen((stream) =>
-                  finalizeSegment(stream, {
+                .andThen((stream): ResultAsync<TranscriptStream, DomainError> => {
+                  // `translation.final` 受信時は session-command-service 経由で
+                  // text='' + translation 付きの input が渡される。既に別経路で
+                  // 同 segment が final 化されている想定なので finalizeSegment を
+                  // skip して、後続 andThen の attachTranslationToSegment へ流す。
+                  if (parsed.text.length === 0) {
+                    return okAsync(stream);
+                  }
+                  const finalized = finalizeSegment(stream, {
                     segmentIdentifier,
                     text: parsed.text,
                     timeRange,
-                  }),
-                )
+                  });
+                  return finalized.isOk() ? okAsync(finalized.value) : errAsync(finalized.error);
+                })
                 .andThen((finalizedStream): ResultAsync<TranscriptStream, DomainError> => {
                   if (parsed.translation?.status === 'completed') {
                     return attachTranslationToSegment(finalizedStream, {


### PR DESCRIPTION
## Summary

`translation.final` event 受信時に overlay に翻訳が描画されない問題を修正。

## 原因

`session-command-service` が `translation.final` を受けた際に合成する input (`text: ''` + translation 付き) が `HandleTranscriptFinalInput` DTO schema の `text.min(1)` で弾かれていた。

## Fix

1. DTO schema: `text.min(1)` → `z.string()` (空許容、translation-only path の marker)
2. Use case: `text.length === 0` なら `finalizeSegment` を skip、`attachTranslationToSegment` に直進
3. 既存 test 2 件更新 + `buildStreamWithFinal` helper 追加

## 検証

- `pnpm lint` / `pnpm typecheck` clean
- 905 tests green
- build 成功

## Test plan

PR merge → 拡張 reload → YouTube 再生タブで開始:
- overlay に英語 transcript + 日本語 translation が併記
- `validation: String must contain at least 1 character(s)` が消える