### PR TITLE
fix(extension): restore tab audio to speaker during tab capture

### DIFF
--- a/packages/extension/src/composition/extension-composition.test.ts
+++ b/packages/extension/src/composition/extension-composition.test.ts
@@ -49,6 +49,7 @@ const createTestPorts = (overrides: Partial<ExtensionRuntimePorts> = {}): Extens
       sampleRate: 16000,
       audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
       close: vi.fn(() => Promise.resolve()),
+      destination: {},
       createMediaStreamSource: vi.fn(() => ({})),
     })),
     webSocketFactory: vi.fn(() => ({

--- a/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.test.ts
+++ b/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.test.ts
@@ -27,6 +27,7 @@ const buildFakeContext = (
     sampleRate,
     audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
     close: closeFn,
+    destination: {},
     createMediaStreamSource: vi.fn(() => ({})),
     closeFn,
   };
@@ -242,6 +243,7 @@ describe('createOffscreenAudioHost (IMPL-561)', () => {
       sampleRate: 16000,
       audioWorklet: { addModule },
       close: vi.fn(() => Promise.resolve()),
+      destination: {},
       createMediaStreamSource: vi.fn(() => ({})),
       closeFn: vi.fn(),
     };
@@ -266,6 +268,7 @@ describe('createOffscreenAudioHost (IMPL-561)', () => {
       sampleRate: 16000,
       audioWorklet: { addModule },
       close: vi.fn(() => Promise.resolve()),
+      destination: {},
       createMediaStreamSource: vi.fn(() => ({})),
       closeFn: vi.fn(),
     };
@@ -291,6 +294,7 @@ describe('createOffscreenAudioHost (IMPL-561)', () => {
       sampleRate: 16000,
       audioWorklet: { addModule },
       close: vi.fn(() => Promise.resolve()),
+      destination: {},
       createMediaStreamSource: vi.fn(() => ({
         connect: vi.fn(),
         disconnect: vi.fn(),
@@ -318,6 +322,7 @@ describe('createOffscreenAudioHost (IMPL-561)', () => {
       sampleRate: 16000,
       audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
       close: vi.fn(() => Promise.resolve()),
+      destination: {},
       createMediaStreamSource,
     };
     const factory = vi.fn<AudioContextFactory>(() => context);
@@ -346,7 +351,10 @@ describe('createOffscreenAudioHost (IMPL-561)', () => {
 
     expect(createMediaStreamSource).toHaveBeenCalledWith(mediaStream);
     expect(workletNodeFactory).toHaveBeenCalledWith(context, 'perapera-audio-processor');
+    // source は worklet と context.destination の両方に connect される
+    // (worklet: PCM 抽出で STT 送信、destination: tab 音声を speaker に戻す)
     expect(sourceNode.connect).toHaveBeenCalledWith(workletNode);
+    expect(sourceNode.connect).toHaveBeenCalledWith(context.destination);
     expect(host.hasWorkletConnected(identifierA)).toBe(true);
   });
 
@@ -361,6 +369,7 @@ describe('createOffscreenAudioHost (IMPL-561)', () => {
       sampleRate: 16000,
       audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
       close: vi.fn(() => Promise.resolve()),
+      destination: {},
       createMediaStreamSource: vi.fn(() => sourceNode),
     };
     const factory = vi.fn<AudioContextFactory>(() => context);
@@ -401,6 +410,7 @@ describe('createOffscreenAudioHost (IMPL-561)', () => {
       sampleRate: 16000,
       audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
       close: vi.fn(() => Promise.resolve()),
+      destination: {},
       createMediaStreamSource: vi.fn(() => sourceNode),
     };
     const factory = vi.fn<AudioContextFactory>(() => context);
@@ -456,6 +466,7 @@ describe('createOffscreenAudioHost (IMPL-561)', () => {
       sampleRate: 16000,
       audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
       close: vi.fn(() => Promise.resolve()),
+      destination: {},
       createMediaStreamSource: vi.fn(() => sourceNode),
     };
     const factory = vi.fn<AudioContextFactory>(() => context);

--- a/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.ts
+++ b/packages/extension/src/entrypoints/offscreen/offscreen-audio-host.ts
@@ -167,7 +167,29 @@ export const createOffscreenAudioHost = (
         entry.context,
         deps.workletProcessorName ?? DEFAULT_WORKLET_PROCESSOR_NAME,
       );
+      // fan-out: source を (1) worklet (PCM 抽出 → STT 送信) と
+      // (2) AudioContext.destination (speaker monitor) の両方に繋ぐ。
+      //
+      // Chrome の `chrome.tabCapture.getMediaStreamId` + `getUserMedia` で
+      // 取得した tab MediaStream は、取得時点でタブ元音声を通常の output
+      // から **切り離す** (= タブ音声が聞こえなくなる)。再生を復元するには
+      // 取得先の AudioContext `destination` に明示的に繋ぎ直す必要がある。
+      //
+      // worklet は PCM を `port.postMessage` で送るだけで output buffer を
+      // 書き込まないため `workletNode.connect(destination)` では音声は戻らない。
+      // したがって source を destination に**並列**接続する。
       sourceNode.connect(workletNode);
+      try {
+        sourceNode.connect(entry.context.destination);
+      } catch (cause) {
+        // destination への接続失敗は致命的ではない (音声が聞こえないだけで
+        // transcription は動く) ため warn のみ
+        logger.warn(
+          `[perapera] offscreen-audio-host destination monitor connect failed for ${sessionIdentifier}: ${
+            cause instanceof Error ? cause.message : String(cause)
+          }`,
+        );
+      }
       // IMPL-617: worklet processor から送られてくる frame を上位層 (SW) に
       // 転送する。onAudioFrame callback が注入されているときのみ listener を
       // 設定。callback 例外で listener が外れないよう try/catch で囲む。

--- a/packages/extension/src/infrastructure/audio/audio-preprocessor.test.ts
+++ b/packages/extension/src/infrastructure/audio/audio-preprocessor.test.ts
@@ -25,6 +25,7 @@ const createMockContext = (): MockContext => {
       addModule: vi.fn((_url: string) => Promise.resolve()),
     },
     close: vi.fn(() => Promise.resolve()),
+    destination: {},
     createMediaStreamSource: vi.fn((_stream: MediaStream) => ({
       connect: vi.fn(),
       disconnect: vi.fn(),

--- a/packages/extension/src/infrastructure/audio/audio-preprocessor.ts
+++ b/packages/extension/src/infrastructure/audio/audio-preprocessor.ts
@@ -15,6 +15,13 @@ export type AudioContextLike = {
   readonly audioWorklet: {
     addModule: (url: string) => Promise<void>;
   };
+  /**
+   * AudioContext の default output destination (speaker)。
+   * tab capture で得た MediaStream の音声を speaker に戻すため、source node を
+   * worklet と並列に destination にも connect する必要がある
+   * (offscreen-audio-host.ts `connectWorklet` 参照)。
+   */
+  readonly destination: unknown;
   close: () => Promise<void>;
   createMediaStreamSource: (stream: MediaStream) => unknown;
 };

--- a/packages/extension/src/infrastructure/audio/worklet-node-factory.test.ts
+++ b/packages/extension/src/infrastructure/audio/worklet-node-factory.test.ts
@@ -6,6 +6,7 @@ const buildFakeContext = (): AudioContextLike => ({
   sampleRate: 16000,
   audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
   close: vi.fn(() => Promise.resolve()),
+  destination: {},
   createMediaStreamSource: vi.fn(() => ({})),
 });
 


### PR DESCRIPTION
## Summary

YouTube 等でキャプチャ開始すると **タブ音声が聞こえなくなる** 既知の Chrome tab capture 仕様に対処。offscreen の audio graph で `sourceNode` を `AudioContext.destination` に並列接続し、speaker に音声を戻す。

## 原因

`chrome.tabCapture.getMediaStreamId` + `getUserMedia({chromeMediaSource:'tab'})` で MediaStream を取得すると、Chrome は対象タブの音声を通常 output から **切り離す**仕様。captured MediaStream を繋いだ AudioContext の `destination` に出力して初めて speaker に戻る。

現行実装は `sourceNode.connect(workletNode)` のみで `destination` への接続が無く、worklet は `outputs[0]` を書き込まないため完全 mute になっていた。

## Fix

```ts
sourceNode.connect(workletNode);                 // PCM 抽出 → STT 送信
sourceNode.connect(entry.context.destination);   // 追加: speaker monitor
```

Web Audio API の fan-out で 1 source を両方に流す。destination 接続失敗は致命的でないため `try/catch + warn` で handle。

`AudioContextLike` type に `readonly destination: unknown` を追加、既存 mock 5 箇所を更新。

## 字幕は出ていた理由

audio は worklet branch で抽出されて Deepgram に届いていたため transcript/translation は通常通り動作。「音声が聞こえない状態でも字幕は出る」というユーザー報告と整合。

## 検証

- `pnpm lint` / `pnpm typecheck` clean
- 905 tests green (新規 `sourceNode.connect(destination)` assertion 追加)
- build 成功

## Test plan (manual)

PR merge → 拡張 reload → YouTube 再生中タブで開始:
- ✅ タブ音声が**そのまま聞こえる** (speaker mute されない)
- ✅ 字幕 + 翻訳 overlay 通常通り
- ✅ 停止後 YouTube 通常再生に戻る