### PR TITLE
feat(extension): re-introduce export UI in main window (#106)

### DIFF
--- a/packages/extension/src/application/dto/export-session-result-dto.test.ts
+++ b/packages/extension/src/application/dto/export-session-result-dto.test.ts
@@ -77,8 +77,10 @@ describe('ExportSessionResultDTO (DD-307)', () => {
         exportId: EXPORT_ID,
         format: 'json',
         bytes: 1024,
+        content: '{"sample":true}',
       };
       expect(output.bytes).toBe(1024);
+      expect(output.content).toContain('sample');
     });
   });
 

--- a/packages/extension/src/application/dto/export-session-result-dto.ts
+++ b/packages/extension/src/application/dto/export-session-result-dto.ts
@@ -45,10 +45,12 @@ export const parseExportSessionResultInput = (
 /**
  * エクスポート実行出力 DTO (DTO-O-307)。
  * `ExportRecord` の `exportIdentifier` を `exportId` として primitive 化し、
- * 生成バイト数 `bytes` を追加。
+ * 生成バイト数 `bytes` と整形済み本文 `content` を追加する。`content` は
+ * presentation 層がそのまま `Blob` 化してダウンロードに用いる (Issue #106)。
  */
 export type ExportSessionResultOutput = Readonly<{
   exportId: string;
   format: ExportFormat;
   bytes: number;
+  content: string;
 }>;

--- a/packages/extension/src/application/services/export-service.test.ts
+++ b/packages/extension/src/application/services/export-service.test.ts
@@ -21,6 +21,7 @@ const buildOutput = (): ExportSessionResultOutput => ({
   exportId: '01HZX8Y1R8M7D3Q2P4T5V6W7B1',
   format: 'txt',
   bytes: 42,
+  content: 'hello world',
 });
 
 describe('createExportService (IMPL-344)', () => {

--- a/packages/extension/src/application/use-cases/export-session-result-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/export-session-result-use-case.test.ts
@@ -82,6 +82,7 @@ describe('createExportSessionResultUseCase (IMPL-216, DD-307)', () => {
       expect(result.value.exportId).toBe(EXPORT_ID);
       expect(result.value.format).toBe('txt');
       expect(result.value.bytes).toBeGreaterThan(0);
+      expect(result.value.content.length).toBeGreaterThan(0);
     }
     expect(deps.exportRecordRepository.save).toHaveBeenCalledTimes(1);
   });
@@ -158,6 +159,9 @@ describe('createExportSessionResultUseCase (IMPL-216, DD-307)', () => {
     if (result.isOk()) {
       expect(result.value.format).toBe('json');
       expect(result.value.bytes).toBeGreaterThan(10);
+      expect(() => {
+        JSON.parse(result.value.content);
+      }).not.toThrow();
     }
   });
 });

--- a/packages/extension/src/application/use-cases/export-session-result-use-case.ts
+++ b/packages/extension/src/application/use-cases/export-session-result-use-case.ts
@@ -59,7 +59,7 @@ export const createExportSessionResultUseCase = (
                   );
                 }
               })
-              .asyncAndThen(({ bytes }) => {
+              .asyncAndThen(({ bytes, content }) => {
                 const createdAt = deps.clock();
                 const exportId = deps.exportIdFactory();
                 return createExportRecord({
@@ -75,6 +75,7 @@ export const createExportSessionResultUseCase = (
                       exportId: record.exportIdentifier,
                       format: record.format,
                       bytes,
+                      content,
                     }),
                   ),
                 );

--- a/packages/extension/src/composition/runtime-dispatcher.test.ts
+++ b/packages/extension/src/composition/runtime-dispatcher.test.ts
@@ -21,7 +21,9 @@ const buildFakeDeps = () => {
     handleRelayEvent: vi.fn(() => okAsync<void, ApplicationError>(undefined)),
   };
   const exportService: ExportService = {
-    export: vi.fn(() => okAsync({ exportId: 'exp', format: 'txt' as const, bytes: 100 })),
+    export: vi.fn(() =>
+      okAsync({ exportId: 'exp', format: 'txt' as const, bytes: 100, content: 'x' }),
+    ),
   };
   const getSessionMonitorStateQuery: GetSessionMonitorStateQuery = vi.fn(() =>
     okAsync({ sessions: [], latestSegments: [] }),

--- a/packages/extension/src/presentation/infrastructure/background-client.ts
+++ b/packages/extension/src/presentation/infrastructure/background-client.ts
@@ -95,6 +95,8 @@ const exportSessionResultOutputSchema = z.object({
   exportId: z.string().min(1),
   format: z.enum(['txt', 'json']),
   bytes: z.number().int().nonnegative(),
+  // Issue #106: 整形済み本文。presentation 層が Blob 化して download する。
+  content: z.string(),
 });
 export type ExportSessionResultResult = z.infer<typeof exportSessionResultOutputSchema>;
 

--- a/packages/extension/src/presentation/molecules/export-controls.test.tsx
+++ b/packages/extension/src/presentation/molecules/export-controls.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type BackgroundClient,
+  type BackgroundResponse,
+  type ExportSessionResultResult,
+} from '../infrastructure/background-client';
+import { ExportControls } from './export-controls';
+
+const SESSION_ID = 'sess_01HZX8Y1R8M7D3Q2P4T5V6W7X8';
+
+const okResult = (
+  overrides: Partial<ExportSessionResultResult> = {},
+): BackgroundResponse<ExportSessionResultResult> => ({
+  ok: true,
+  value: {
+    exportId: 'exp_1',
+    format: 'txt',
+    bytes: 42,
+    content: 'hello world',
+    ...overrides,
+  },
+});
+
+const buildClient = (overrides: Partial<BackgroundClient> = {}): BackgroundClient => ({
+  startSourceSession: vi.fn(),
+  stopSourceSession: vi.fn(),
+  updateSourceSettings: vi.fn(),
+  exportSessionResult: vi.fn(() => Promise.resolve(okResult())),
+  getSessionMonitorState: vi.fn(),
+  getDefaultSettings: vi.fn(),
+  saveDefaultLanguagePair: vi.fn(),
+  saveDefaultOverlaySettings: vi.fn(),
+  saveDefaultEndpointingPolicy: vi.fn(),
+  saveDefaultTranslationContextWindow: vi.fn(),
+  saveRelayConnectionOverride: vi.fn(),
+  clearRelayConnectionOverride: vi.fn(),
+  ...overrides,
+});
+
+describe('ExportControls molecule (Issue #106)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders format select and include checkboxes with sane defaults', () => {
+    const client = buildClient();
+    render(<ExportControls client={client} sessionId={SESSION_ID} download={vi.fn()} />);
+    expect(screen.getByLabelText('エクスポート形式')).toHaveValue('txt');
+    expect(screen.getByLabelText('includeOriginal')).toBeChecked();
+    expect(screen.getByLabelText('includeTranslation')).toBeChecked();
+    expect(screen.getByRole('button', { name: 'エクスポート' })).toBeEnabled();
+  });
+
+  it('disables Export button when both include flags are off', () => {
+    const client = buildClient();
+    const download =
+      vi.fn<(params: { filename: string; content: string; mimeType: string }) => void>();
+    render(<ExportControls client={client} sessionId={SESSION_ID} download={download} />);
+    fireEvent.click(screen.getByLabelText('includeOriginal'));
+    fireEvent.click(screen.getByLabelText('includeTranslation'));
+    expect(screen.getByRole('button', { name: 'エクスポート' })).toBeDisabled();
+  });
+
+  it('invokes exportSessionResult and download with TXT defaults', async () => {
+    const client = buildClient();
+    const download =
+      vi.fn<(params: { filename: string; content: string; mimeType: string }) => void>();
+    render(<ExportControls client={client} sessionId={SESSION_ID} download={download} />);
+    fireEvent.click(screen.getByRole('button', { name: 'エクスポート' }));
+    await waitFor(() => {
+      expect(client.exportSessionResult).toHaveBeenCalledWith({
+        sessionId: SESSION_ID,
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: true,
+      });
+    });
+    await waitFor(() => {
+      expect(download).toHaveBeenCalledTimes(1);
+    });
+    const args = download.mock.calls[0]?.[0];
+    expect(args?.content).toBe('hello world');
+    expect(args?.mimeType).toBe('text/plain;charset=utf-8');
+    expect(args?.filename).toMatch(/perapera-.*\.txt$/);
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('保存しました (42 bytes)');
+    });
+  });
+
+  it('switches MIME type and extension when format=JSON', async () => {
+    const client = buildClient({
+      exportSessionResult: vi.fn(() =>
+        Promise.resolve(okResult({ format: 'json', content: '{"a":1}', bytes: 7 })),
+      ),
+    });
+    const download =
+      vi.fn<(params: { filename: string; content: string; mimeType: string }) => void>();
+    render(<ExportControls client={client} sessionId={SESSION_ID} download={download} />);
+    fireEvent.change(screen.getByLabelText('エクスポート形式'), {
+      target: { value: 'json' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'エクスポート' }));
+    await waitFor(() => {
+      expect(download).toHaveBeenCalledTimes(1);
+    });
+    const args = download.mock.calls[0]?.[0];
+    expect(args?.mimeType).toBe('application/json;charset=utf-8');
+    expect(args?.filename).toMatch(/perapera-.*\.json$/);
+  });
+
+  it('shows failure message when exportSessionResult fails', async () => {
+    const client = buildClient({
+      exportSessionResult: vi.fn(() =>
+        Promise.resolve<BackgroundResponse<ExportSessionResultResult>>({
+          ok: false,
+          error: { type: 'internal', code: 'INTERNAL_ERROR', message: 'boom' },
+        }),
+      ),
+    });
+    const download =
+      vi.fn<(params: { filename: string; content: string; mimeType: string }) => void>();
+    render(<ExportControls client={client} sessionId={SESSION_ID} download={download} />);
+    fireEvent.click(screen.getByRole('button', { name: 'エクスポート' }));
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('エクスポートに失敗しました: boom');
+    });
+    expect(download).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/src/presentation/molecules/export-controls.tsx
+++ b/packages/extension/src/presentation/molecules/export-controls.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useState } from 'react';
+import { Button } from '../atoms/button';
+import { Checkbox } from '../atoms/checkbox';
+import { Label } from '../atoms/label';
+import { Select } from '../atoms/select';
+import { useBackgroundCommand } from '../hooks/use-background-command';
+import {
+  type BackgroundClient,
+  type ExportSessionResultResult,
+} from '../infrastructure/background-client';
+
+export type ExportFormat = 'txt' | 'json';
+
+export type Props = Readonly<{
+  client: BackgroundClient;
+  sessionId: string;
+  /**
+   * file download を実行する関数。default は `downloadViaAnchor`
+   * (`URL.createObjectURL` + `a.download`)。テストで stub に差し替えられる。
+   */
+  download?: (params: { filename: string; content: string; mimeType: string }) => void;
+}>;
+
+const FORMAT_OPTIONS = [
+  { value: 'txt' as const, label: 'TXT' },
+  { value: 'json' as const, label: 'JSON' },
+];
+
+const MIME_TYPE: Readonly<Record<ExportFormat, string>> = {
+  txt: 'text/plain;charset=utf-8',
+  json: 'application/json;charset=utf-8',
+};
+
+const downloadViaAnchor = (params: {
+  filename: string;
+  content: string;
+  mimeType: string;
+}): void => {
+  const blob = new Blob([params.content], { type: params.mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = params.filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  // a.click() 直後に revoke すると Firefox 等で download が cancel される
+  // ことがあるため、tick 跨ぎで revoke する。
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 0);
+};
+
+const buildFilename = (sessionId: string, format: ExportFormat): string => {
+  const safe = sessionId.replace(/[^A-Za-z0-9_-]/g, '');
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  return `perapera-${safe || 'session'}-${stamp}.${format}`;
+};
+
+/**
+ * IMPL-533 (再導入) ExportControls molecule (Issue #106)。
+ *
+ * セッション停止後 (capturing 中も可) に、保存済 transcript / translation を
+ * TXT / JSON 形式でローカルダウンロードする。`BackgroundClient.exportSessionResult`
+ * の応答に含まれる整形済 `content` を `Blob` 化し、`a.download` でファイルを
+ * 取得する。
+ *
+ * 不変条件: `includeOriginal === false && includeTranslation === false` は
+ * UseCase 側で reject されるため、UI でも Export ボタンを disabled にする。
+ */
+export function ExportControls(props: Props) {
+  const exportCommand = useBackgroundCommand(props.client.exportSessionResult);
+  const [format, setFormat] = useState<ExportFormat>('txt');
+  const [includeOriginal, setIncludeOriginal] = useState<boolean>(true);
+  const [includeTranslation, setIncludeTranslation] = useState<boolean>(true);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const isPending = exportCommand.state.status === 'pending';
+  const nothingSelected = !includeOriginal && !includeTranslation;
+  const download = props.download ?? downloadViaAnchor;
+
+  const handleExport = useCallback(async (): Promise<void> => {
+    setMessage(null);
+    if (nothingSelected) {
+      setMessage('原文または翻訳の少なくとも 1 つを選んでください。');
+      return;
+    }
+    const response = await exportCommand.execute({
+      sessionId: props.sessionId,
+      format,
+      includeOriginal,
+      includeTranslation,
+    });
+    if (!response.ok) {
+      setMessage(`エクスポートに失敗しました: ${response.error.message}`);
+      return;
+    }
+    const value: ExportSessionResultResult = response.value;
+    download({
+      filename: buildFilename(props.sessionId, value.format),
+      content: value.content,
+      mimeType: MIME_TYPE[value.format],
+    });
+    setMessage(`保存しました (${value.bytes} bytes)`);
+  }, [
+    download,
+    exportCommand,
+    format,
+    includeOriginal,
+    includeTranslation,
+    nothingSelected,
+    props.sessionId,
+  ]);
+
+  return (
+    <div className="container" data-testid="export-controls">
+      <div className="field">
+        <Label htmlFor="export-format">形式</Label>
+        <Select
+          id="export-format"
+          value={format}
+          ariaLabel="エクスポート形式"
+          options={FORMAT_OPTIONS}
+          onChange={(next) => {
+            if (next === 'txt' || next === 'json') setFormat(next);
+          }}
+          disabled={isPending}
+        />
+      </div>
+      <div className="field">
+        <Label htmlFor="export-include-original">原文を含める</Label>
+        <Checkbox
+          id="export-include-original"
+          ariaLabel="includeOriginal"
+          checked={includeOriginal}
+          onChange={setIncludeOriginal}
+          disabled={isPending}
+        />
+      </div>
+      <div className="field">
+        <Label htmlFor="export-include-translation">翻訳を含める</Label>
+        <Checkbox
+          id="export-include-translation"
+          ariaLabel="includeTranslation"
+          checked={includeTranslation}
+          onChange={setIncludeTranslation}
+          disabled={isPending}
+        />
+      </div>
+      <Button
+        variant="secondary"
+        ariaLabel="エクスポート"
+        disabled={isPending || nothingSelected}
+        onClick={() => {
+          void handleExport();
+        }}
+      >
+        {isPending ? 'エクスポート中…' : 'エクスポート'}
+      </Button>
+      {message !== null ? (
+        <p className="message" role="status">
+          {message}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/extension/src/presentation/organisms/session-toolbar.test.tsx
+++ b/packages/extension/src/presentation/organisms/session-toolbar.test.tsx
@@ -79,6 +79,15 @@ describe('SessionToolbar organism', () => {
     expect(onStopped).not.toHaveBeenCalled();
   });
 
+  it('toggles the export panel via the dedicated button (Issue #106)', () => {
+    render(<SessionToolbar client={buildClient()} session={session} onStopped={() => undefined} />);
+    expect(screen.queryByTestId('export-panel')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'エクスポートを開く' }));
+    expect(screen.getByTestId('export-panel')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'エクスポートを開く' }));
+    expect(screen.queryByTestId('export-panel')).toBeNull();
+  });
+
   it('shows pending label while in-flight', async () => {
     let resolveStop: (value: BackgroundResponse<StopSourceSessionResult>) => void = () => undefined;
     const stopPromise = new Promise<BackgroundResponse<StopSourceSessionResult>>((resolve) => {
@@ -90,7 +99,7 @@ describe('SessionToolbar organism', () => {
     render(<SessionToolbar client={client} session={session} onStopped={() => undefined} />);
     fireEvent.click(screen.getByRole('button', { name: 'セッションを停止' }));
     await waitFor(() => {
-      expect(screen.getByRole('button')).toHaveTextContent('停止中…');
+      expect(screen.getByRole('button', { name: 'セッションを停止' })).toHaveTextContent('停止中…');
     });
     await act(async () => {
       resolveStop({

--- a/packages/extension/src/presentation/organisms/session-toolbar.tsx
+++ b/packages/extension/src/presentation/organisms/session-toolbar.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { Button } from '../atoms/button';
 import { StatusBadge } from '../atoms/status-badge';
 import { useBackgroundCommand } from '../hooks/use-background-command';
 import { type BackgroundClient } from '../infrastructure/background-client';
+import { ExportControls } from '../molecules/export-controls';
 
 export type ActiveSession = Readonly<{
   sessionId: string;
@@ -28,6 +30,7 @@ export type Props = Readonly<{
 export function SessionToolbar(props: Props) {
   const stopCommand = useBackgroundCommand(props.client.stopSourceSession);
   const isPending = stopCommand.state.status === 'pending';
+  const [exportOpen, setExportOpen] = useState<boolean>(false);
 
   const handleStop = async (): Promise<void> => {
     const response = await stopCommand.execute({ sessionId: props.session.sessionId });
@@ -55,6 +58,17 @@ export function SessionToolbar(props: Props) {
             ⚙
           </button>
         ) : null}
+        <button
+          type="button"
+          className="iconButton"
+          aria-label="エクスポートを開く"
+          aria-expanded={exportOpen}
+          onClick={() => {
+            setExportOpen((prev) => !prev);
+          }}
+        >
+          {exportOpen ? '▾' : '↧'}
+        </button>
         <Button
           variant="danger"
           disabled={isPending}
@@ -66,6 +80,11 @@ export function SessionToolbar(props: Props) {
           {isPending ? '停止中…' : '停止'}
         </Button>
       </div>
+      {exportOpen ? (
+        <div className="panel" data-testid="export-panel">
+          <ExportControls client={props.client} sessionId={props.session.sessionId} />
+        </div>
+      ) : null}
     </header>
   );
 }

--- a/packages/extension/src/presentation/organisms/start-session-form.test.tsx
+++ b/packages/extension/src/presentation/organisms/start-session-form.test.tsx
@@ -26,7 +26,7 @@ const DUMMY_UPDATE: BackgroundResponse<UpdateSourceSettingsResult> = {
 };
 const DUMMY_EXPORT: BackgroundResponse<ExportSessionResultResult> = {
   ok: true,
-  value: { exportId: 'e', format: 'txt', bytes: 0 },
+  value: { exportId: 'e', format: 'txt', bytes: 0, content: '' },
 };
 
 const buildClient = (start: BackgroundClient['startSourceSession']): BackgroundClient => ({


### PR DESCRIPTION
Closes #106

## Summary

UI 刷新で削除された Export 導線を main window に再接続する。

- `ExportSessionResultOutput` / background-client output schema に整形済 `content` フィールドを追加し、UseCase が既に生成していた本文を presentation 層へ届ける (DD-307 / IMPL-216 互換)
- 新 molecule `ExportControls` を再導入: TXT/JSON 切り替え、原文/翻訳の包含チェック、`a.download` ベースの blob ダウンロード、失敗時のメッセージ表示
- `SessionToolbar` に折り畳み式の「↧」ボタンを追加し、押下で ExportControls を expand する。停止前後どちらでも保存済み transcript/translation を取得可能

## 受入基準

- [x] main window に TXT/JSON Export ボタン (toolbar 内 ↧ で展開)
- [x] click で `BackgroundClient.exportSessionResult` → `ExportSessionResultUseCase` 起動
- [x] 成功時 `a.download` でファイル保存 (`URL.createObjectURL` + revoke)
- [x] 失敗時に `role="status"` で error message 表示
- [x] TXT/JSON フォーマットは既存 `ExportFormatSpecification` (DD-273) 準拠 (UseCase は変更なし)
- [x] molecules / organisms にテスト追加 (5 + 5 件)

## Test plan

- [x] `pnpm typecheck` clean (extension)
- [x] `pnpm test` 935/935 green
- [x] `pnpm lint` 0 errors (既存の IDB cursor 警告のみ残存)
- [ ] 手動: dev ビルドで session 開始 → 停止 → ↧ → エクスポート押下で TXT/JSON が download できる