### PR TITLE
feat(extension): broadcast session.state.changed to main window (#108)

### DIFF
--- a/packages/extension/src/application/ports/session-state-broadcaster.ts
+++ b/packages/extension/src/application/ports/session-state-broadcaster.ts
@@ -1,0 +1,23 @@
+import { type ResultAsync } from 'neverthrow';
+import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type SessionState } from '../../domain/session/session-state';
+import { type DomainError } from '../../domain/shared/errors';
+
+/**
+ * Issue #108: Relay からの `session.state.changed` を main window (popup /
+ * sidepanel / floating window) へ push するためのポート。
+ *
+ * - 配信先は `chrome.runtime.sendMessage` ベースの broadcast を想定
+ * - ホットパス上 (translate / overlay 経路) には影響を与えず、状態遷移時の
+ *   1 ショットイベントとして扱う
+ * - 失敗 (受信者ゼロを含む) は呼び出し側で握り潰す前提 (warn ログのみ)
+ */
+export type SessionStateChangedEvent = Readonly<{
+  sessionIdentifier: SessionIdentifier;
+  state: SessionState;
+  reason: string | null;
+}>;
+
+export type SessionStateBroadcaster = Readonly<{
+  broadcast: (event: SessionStateChangedEvent) => ResultAsync<void, DomainError>;
+}>;

--- a/packages/extension/src/application/services/session-command-service.test.ts
+++ b/packages/extension/src/application/services/session-command-service.test.ts
@@ -17,6 +17,7 @@ import {
 } from '../dto/update-source-settings-dto';
 import { internalAppError, sessionNotFoundAppError } from '../errors/application-errors';
 import { type RelayEvent } from '../ports/relay-gateway';
+import { type SessionStateBroadcaster } from '../ports/session-state-broadcaster';
 import { type HandleTranscriptFinalUseCase } from '../use-cases/handle-transcript-final-use-case';
 import { type HandleTranscriptPartialUseCase } from '../use-cases/handle-transcript-partial-use-case';
 import { type StartSourceSessionUseCase } from '../use-cases/start-source-session-use-case';
@@ -47,6 +48,9 @@ type Mocks = {
   updateSourceSettingsUseCase: ReturnType<typeof vi.fn<UpdateSourceSettingsUseCase>>;
   handleTranscriptPartialUseCase: ReturnType<typeof vi.fn<HandleTranscriptPartialUseCase>>;
   handleTranscriptFinalUseCase: ReturnType<typeof vi.fn<HandleTranscriptFinalUseCase>>;
+  sessionStateBroadcaster: SessionStateBroadcaster & {
+    broadcast: ReturnType<typeof vi.fn<SessionStateBroadcaster['broadcast']>>;
+  };
 };
 
 const buildMocks = (): Mocks => ({
@@ -92,6 +96,9 @@ const buildMocks = (): Mocks => ({
       },
     }),
   ),
+  sessionStateBroadcaster: {
+    broadcast: vi.fn<SessionStateBroadcaster['broadcast']>(() => okAsync<void, never>(undefined)),
+  },
 });
 
 describe('createSessionCommandService (IMPL-340)', () => {
@@ -205,6 +212,23 @@ describe('createSessionCommandService (IMPL-340)', () => {
     }
     expect(mocks.handleTranscriptPartialUseCase).not.toHaveBeenCalled();
     expect(mocks.handleTranscriptFinalUseCase).not.toHaveBeenCalled();
+  });
+
+  it('handleRelayEvent broadcasts session.state.changed via SessionStateBroadcaster (Issue #108)', async () => {
+    const mocks = buildMocks();
+    const service = createSessionCommandService({ ...mocks, clock });
+    const event: RelayEvent = {
+      type: 'session.state.changed',
+      sessionIdentifier,
+      state: 'degraded',
+    };
+    const result = await service.handleRelayEvent(event);
+    expect(result.isOk()).toBe(true);
+    expect(mocks.sessionStateBroadcaster.broadcast).toHaveBeenCalledWith({
+      sessionIdentifier,
+      state: 'degraded',
+      reason: null,
+    });
   });
 
   it('handleRelayEvent surfaces UseCase failures', async () => {

--- a/packages/extension/src/application/services/session-command-service.ts
+++ b/packages/extension/src/application/services/session-command-service.ts
@@ -21,6 +21,7 @@ import {
 } from '../dto/update-source-settings-dto';
 import { type ApplicationError } from '../errors/application-errors';
 import { type RelayEvent } from '../ports/relay-gateway';
+import { type SessionStateBroadcaster } from '../ports/session-state-broadcaster';
 import { type HandleTranscriptFinalUseCase } from '../use-cases/handle-transcript-final-use-case';
 import { type HandleTranscriptPartialUseCase } from '../use-cases/handle-transcript-partial-use-case';
 import { type StartSourceSessionUseCase } from '../use-cases/start-source-session-use-case';
@@ -69,6 +70,8 @@ export type SessionCommandServiceDependencies = Readonly<{
   updateSourceSettingsUseCase: UpdateSourceSettingsUseCase;
   handleTranscriptPartialUseCase: HandleTranscriptPartialUseCase;
   handleTranscriptFinalUseCase: HandleTranscriptFinalUseCase;
+  /** Issue #108: 必須 DI。session.state.changed を main window へ broadcast する */
+  sessionStateBroadcaster: SessionStateBroadcaster;
   clock: () => number;
 }>;
 
@@ -170,8 +173,22 @@ export const createSessionCommandService = (
           .handleTranscriptFinalUseCase(input)
           .map((_output: HandleTranscriptFinalOutput): void => undefined);
       }
+      case 'session.state.changed': {
+        // Issue #108: main window 側 SessionToolbar / banner の更新材料を push。
+        // broadcast 失敗 (受信者ゼロを含む) はホットパスを止めず warn だけにする。
+        return deps.sessionStateBroadcaster
+          .broadcast({
+            sessionIdentifier: event.sessionIdentifier,
+            state: event.state,
+            reason: null,
+          })
+          .map((): void => undefined)
+          .orElse((domainError) => {
+            console.warn('[session-command-service] session.state broadcast failed:', domainError);
+            return okAsync<void, ApplicationError>(undefined);
+          });
+      }
       case 'session.ready':
-      case 'session.state.changed':
       case 'session.error':
         return okAsync<void, ApplicationError>(undefined);
     }

--- a/packages/extension/src/composition/extension-composition.ts
+++ b/packages/extension/src/composition/extension-composition.ts
@@ -76,6 +76,7 @@ import {
 import { createChromeTabStreamIdResolver } from '../infrastructure/capture/chrome-tab-stream-id-resolver';
 import {
   createChromeMessagingOverlayPresenter,
+  createChromeMessagingSessionStateBroadcaster,
   defaultOverlayMessagingBridge,
   type OverlayMessagingBridge,
 } from '../infrastructure/overlay/chrome-messaging-overlay-presenter';
@@ -294,6 +295,11 @@ export const createExtensionApp = (
   const overlayPresenter = createChromeMessagingOverlayPresenter({
     bridge: ports.overlayMessagingBridge,
   });
+  // Issue #108: SessionStateBroadcaster は overlay と同じ bridge を共有する
+  // (main window 側 useOverlayMessages が一括購読する設計のため)。
+  const sessionStateBroadcaster = createChromeMessagingSessionStateBroadcaster({
+    bridge: ports.overlayMessagingBridge,
+  });
 
   // --------------- Application services (先に構築: circular dep 回避) ---------------
   // MV3 SW では MediaStream / AudioContext が動作しないため、CaptureOrchestrator は
@@ -401,6 +407,7 @@ export const createExtensionApp = (
     updateSourceSettingsUseCase,
     handleTranscriptPartialUseCase,
     handleTranscriptFinalUseCase,
+    sessionStateBroadcaster,
     clock: ports.clockMs,
   });
   // 構築完了後に late-bind 用 ref に保存。以降 relaySessionSubscriber の

--- a/packages/extension/src/entrypoints/main/App.tsx
+++ b/packages/extension/src/entrypoints/main/App.tsx
@@ -59,6 +59,25 @@ export function App() {
     }
   }, [overlay.sessionIdentifier]);
 
+  // Issue #108: Relay からの session.state.changed で active.state を最新化。
+  // `stopped` を受信したら自動で idle 画面に戻す (form 表示)。
+  useEffect(() => {
+    const nextState = overlay.sessionState;
+    if (nextState === null) return;
+    if (nextState === 'stopped') {
+      setActive(null);
+      return;
+    }
+    setActive((current) => {
+      if (current === null) return current;
+      if (overlay.sessionIdentifier !== null && current.sessionId !== overlay.sessionIdentifier) {
+        return current;
+      }
+      if (current.state === nextState) return current;
+      return { ...current, state: nextState };
+    });
+  }, [overlay.sessionState, overlay.sessionIdentifier]);
+
   if (showSettings) {
     return (
       <SettingsView
@@ -90,6 +109,7 @@ export function App() {
       <SessionToolbar
         client={client}
         session={active}
+        stateReason={overlay.sessionStateReason}
         onStopped={handleStopped}
         onOpenSettings={openSettings}
       />

--- a/packages/extension/src/entrypoints/main/use-overlay-messages.ts
+++ b/packages/extension/src/entrypoints/main/use-overlay-messages.ts
@@ -1,16 +1,23 @@
 import { useEffect, useState } from 'react';
 import { type OverlayLine } from '../../application/ports/overlay-presenter';
 import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type SessionState } from '../../domain/session/session-state';
 import { parseOverlayCommand } from '../../infrastructure/overlay/overlay-commands';
 
 export type OverlayMessagesState = Readonly<{
   sessionIdentifier: SessionIdentifier | null;
   lines: readonly OverlayLine[];
+  /** Issue #108: 直近受信した session state ('connecting' / 'capturing' 等) */
+  sessionState: SessionState | null;
+  /** Issue #108: degraded / error 等で Relay が付与した補足理由 */
+  sessionStateReason: string | null;
 }>;
 
 const initialState: OverlayMessagesState = {
   sessionIdentifier: null,
   lines: [],
+  sessionState: null,
+  sessionStateReason: null,
 };
 
 /**
@@ -47,7 +54,12 @@ export const useOverlayMessages = (): OverlayMessagesState => {
       setState((prev): OverlayMessagesState => {
         switch (command.type) {
           case 'overlay.mount':
-            return { sessionIdentifier: command.sessionIdentifier, lines: [] };
+            return {
+              sessionIdentifier: command.sessionIdentifier,
+              lines: [],
+              sessionState: prev.sessionState,
+              sessionStateReason: prev.sessionStateReason,
+            };
           case 'overlay.render':
             // prior mount が無くても先行 render を adopt する。現状
             // start-source-session-use-case は overlayPresenter.mount を
@@ -70,12 +82,30 @@ export const useOverlayMessages = (): OverlayMessagesState => {
             return {
               sessionIdentifier: command.model.sessionIdentifier,
               lines: command.model.lines,
+              sessionState: prev.sessionState,
+              sessionStateReason: prev.sessionStateReason,
             };
           case 'overlay.unmount':
             if (prev.sessionIdentifier !== command.sessionIdentifier) return prev;
             return initialState;
           case 'overlay.update-settings':
             return prev;
+          case 'session.state':
+            // Issue #108: 別 session の state は無視 (active session のみ追従)。
+            // active が null の場合は最初の state イベント自体で session を
+            // 採用する (start レスポンスより先に届く可能性に備える)。
+            if (
+              prev.sessionIdentifier !== null &&
+              prev.sessionIdentifier !== command.sessionIdentifier
+            ) {
+              return prev;
+            }
+            return {
+              sessionIdentifier: command.sessionIdentifier,
+              lines: prev.lines,
+              sessionState: command.state,
+              sessionStateReason: command.reason,
+            };
         }
       });
       sendResponse(undefined);

--- a/packages/extension/src/infrastructure/overlay/chrome-messaging-overlay-presenter.ts
+++ b/packages/extension/src/infrastructure/overlay/chrome-messaging-overlay-presenter.ts
@@ -1,11 +1,13 @@
 import { ResultAsync } from 'neverthrow';
 import { type OverlaySettings } from '../../domain/profile/overlay-settings';
 import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import { type SessionState } from '../../domain/session/session-state';
 import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
 import {
   type OverlayPresenter,
   type OverlayRenderModel,
 } from '../../application/ports/overlay-presenter';
+import { type SessionStateBroadcaster } from '../../application/ports/session-state-broadcaster';
 
 /**
  * Overlay への chrome.* messaging 操作を隠蔽する adapter contract。
@@ -43,6 +45,12 @@ export type OverlayCommand =
   | Readonly<{
       type: 'overlay.unmount';
       sessionIdentifier: SessionIdentifier;
+    }>
+  | Readonly<{
+      type: 'session.state';
+      sessionIdentifier: SessionIdentifier;
+      state: SessionState;
+      reason: string | null;
     }>;
 
 /**
@@ -131,5 +139,26 @@ export const createChromeMessagingOverlayPresenter = (
     ResultAsync.fromPromise<void, DomainError>(
       deps.bridge.send({ type: 'overlay.unmount', sessionIdentifier }),
       toInvariant('unmount'),
+    ),
+});
+
+/**
+ * Issue #108: SessionStateBroadcaster の `OverlayMessagingBridge` 実装。
+ * `session.state` command を `chrome.runtime.sendMessage` でブロードキャスト
+ * する。bridge は overlay 用と同じ default (`defaultOverlayMessagingBridge`)
+ * を共有し、main window 側の `useOverlayMessages` がまとめて購読する。
+ */
+export const createChromeMessagingSessionStateBroadcaster = (
+  deps: ChromeMessagingOverlayPresenterDependencies,
+): SessionStateBroadcaster => ({
+  broadcast: (event) =>
+    ResultAsync.fromPromise<void, DomainError>(
+      deps.bridge.send({
+        type: 'session.state',
+        sessionIdentifier: event.sessionIdentifier,
+        state: event.state,
+        reason: event.reason,
+      }),
+      toInvariant('session.state.broadcast'),
     ),
 });

--- a/packages/extension/src/infrastructure/overlay/overlay-commands.ts
+++ b/packages/extension/src/infrastructure/overlay/overlay-commands.ts
@@ -13,6 +13,11 @@ import {
   parseSessionIdentifier,
   type SessionIdentifier,
 } from '../../domain/session/session-identifier';
+import {
+  parseSessionState,
+  SESSION_STATES,
+  type SessionState,
+} from '../../domain/session/session-state';
 import { validationError, type DomainError } from '../../domain/shared/errors';
 
 /**
@@ -76,11 +81,24 @@ const unmountCommandSchema = z.object({
   sessionIdentifier: z.string().min(1),
 });
 
+/**
+ * Issue #108: session.state.changed を main window へ push する command。
+ * Relay からの WebSocket イベントを `SessionCommandService` 経由で受けて
+ * `chrome.runtime.sendMessage` で broadcast する。
+ */
+const sessionStateCommandSchema = z.object({
+  type: z.literal('session.state'),
+  sessionIdentifier: z.string().min(1),
+  state: z.enum(SESSION_STATES),
+  reason: z.string().nullable(),
+});
+
 const overlayCommandRawSchema = z.discriminatedUnion('type', [
   mountCommandSchema,
   renderCommandSchema,
   updateSettingsCommandSchema,
   unmountCommandSchema,
+  sessionStateCommandSchema,
 ]);
 
 /**
@@ -97,7 +115,13 @@ export type OverlayCommand =
       sessionIdentifier: SessionIdentifier;
       settings: OverlaySettings;
     }>
-  | Readonly<{ type: 'overlay.unmount'; sessionIdentifier: SessionIdentifier }>;
+  | Readonly<{ type: 'overlay.unmount'; sessionIdentifier: SessionIdentifier }>
+  | Readonly<{
+      type: 'session.state';
+      sessionIdentifier: SessionIdentifier;
+      state: SessionState;
+      reason: string | null;
+    }>;
 
 const toOverlayLine = (
   raw: z.infer<typeof overlayLineRawSchema>,
@@ -184,6 +208,17 @@ export const parseOverlayCommand = (raw: unknown): Result<OverlayCommand, Domain
           type: 'overlay.unmount',
           sessionIdentifier,
         }),
+      );
+    case 'session.state':
+      return parseSessionIdentifier(data.sessionIdentifier).andThen((sessionIdentifier) =>
+        parseSessionState(data.state).map(
+          (state): OverlayCommand => ({
+            type: 'session.state',
+            sessionIdentifier,
+            state,
+            reason: data.reason,
+          }),
+        ),
       );
   }
 };

--- a/packages/extension/src/presentation/organisms/session-toolbar.test.tsx
+++ b/packages/extension/src/presentation/organisms/session-toolbar.test.tsx
@@ -79,6 +79,30 @@ describe('SessionToolbar organism', () => {
     expect(onStopped).not.toHaveBeenCalled();
   });
 
+  it('shows a state banner when active state is degraded (Issue #108)', () => {
+    const degraded: ActiveSession = {
+      sessionId: 's-1',
+      displayName: 'YouTube',
+      state: 'degraded',
+    };
+    render(
+      <SessionToolbar
+        client={buildClient()}
+        session={degraded}
+        stateReason="translation timeout"
+        onStopped={() => undefined}
+      />,
+    );
+    const banner = screen.getByTestId('session-state-banner');
+    expect(banner).toHaveTextContent('翻訳が一時停止');
+    expect(banner).toHaveTextContent('translation timeout');
+  });
+
+  it('hides the state banner for normal states (Issue #108)', () => {
+    render(<SessionToolbar client={buildClient()} session={session} onStopped={() => undefined} />);
+    expect(screen.queryByTestId('session-state-banner')).toBeNull();
+  });
+
   it('toggles the export panel via the dedicated button (Issue #106)', () => {
     render(<SessionToolbar client={buildClient()} session={session} onStopped={() => undefined} />);
     expect(screen.queryByTestId('export-panel')).toBeNull();

--- a/packages/extension/src/presentation/organisms/session-toolbar.tsx
+++ b/packages/extension/src/presentation/organisms/session-toolbar.tsx
@@ -14,10 +14,27 @@ export type ActiveSession = Readonly<{
 export type Props = Readonly<{
   client: BackgroundClient;
   session: ActiveSession;
+  /** Issue #108: Relay が `session.state.changed` に付与した補足理由 (degraded / error 時の banner で表示) */
+  stateReason?: string | null;
   onStopped: () => void;
   /** `⚙` ボタン押下で設定画面を開く。未指定時は非表示 */
   onOpenSettings?: () => void;
 }>;
+
+const ABNORMAL_STATES = new Set<string>(['degraded', 'error', 'reconnecting']);
+
+const stateBannerMessage = (state: string, reason: string | null | undefined): string | null => {
+  if (!ABNORMAL_STATES.has(state)) return null;
+  const base =
+    state === 'degraded'
+      ? '翻訳が一時停止しました。文字起こしのみ継続中です。'
+      : state === 'reconnecting'
+        ? 'Relay と再接続中です…'
+        : 'セッションエラー: 復旧不能なエラーが発生しました。';
+  return reason !== null && reason !== undefined && reason.length > 0
+    ? `${base} (${reason})`
+    : base;
+};
 
 /**
  * SessionToolbar organism。
@@ -31,6 +48,7 @@ export function SessionToolbar(props: Props) {
   const stopCommand = useBackgroundCommand(props.client.stopSourceSession);
   const isPending = stopCommand.state.status === 'pending';
   const [exportOpen, setExportOpen] = useState<boolean>(false);
+  const banner = stateBannerMessage(props.session.state, props.stateReason);
 
   const handleStop = async (): Promise<void> => {
     const response = await stopCommand.execute({ sessionId: props.session.sessionId });
@@ -83,6 +101,16 @@ export function SessionToolbar(props: Props) {
       {exportOpen ? (
         <div className="panel" data-testid="export-panel">
           <ExportControls client={props.client} sessionId={props.session.sessionId} />
+        </div>
+      ) : null}
+      {banner !== null ? (
+        <div
+          className="banner"
+          role="alert"
+          data-testid="session-state-banner"
+          data-state={props.session.state}
+        >
+          {banner}
         </div>
       ) : null}
     </header>


### PR DESCRIPTION
Closes #108

## Summary

`SessionToolbar` の state badge は session 開始応答 (`state: 'connecting'`) で固定されており、その後の `capturing` / `transcribing` / `degraded` / `error` / `reconnecting` / `stopped` 遷移が UI に反映されない問題を解消する。

- 新 application port `SessionStateBroadcaster` を追加し、Relay の `session.state.changed` を main window へ push
- 既存の overlay broadcast 経路 (`chrome.runtime.sendMessage`) を再利用 (`OverlayCommand` union に `session.state` 種別を追加)
- `SessionCommandService.handleRelayEvent` の `session.state.changed` 分岐を no-op から broadcaster.broadcast() に切替
- `useOverlayMessages` hook が `sessionState` / `sessionStateReason` を返却
- `App.tsx` で hook の `sessionState` を `active.state` に反映、`stopped` 受信で自動 idle 復帰
- `SessionToolbar` に `degraded` / `error` / `reconnecting` 用 `role="alert"` banner を追加

## 受入基準

- [x] 活性 session の state を取得する経路 → (B) push 採用、polling 不要
- [x] `SessionToolbar` の `StatusBadge` が最新 state を反映
- [x] `degraded` / `error` / `reconnecting` 遷移時に banner で通知 (Toast atom 新設は回避)
- [ ] `error` 遷移時の「再試行」ボタンは option のためスコープ外
- [x] `stopped` を受信したら自動で idle 画面に戻す
- [x] unit test: state ごとの banner 発火 / broadcaster 呼び出し

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 938/938 green
- [x] `pnpm lint` 0 errors (既存 IDB cursor 警告のみ残存)
- [ ] 手動: dev ビルドで擬似 `session.state.changed` 受信時の badge / banner 反映