### PR TITLE
feat(extension): session history viewer (#109)

### DIFF
--- a/packages/extension/src/application/dto/get-session-history-dto.ts
+++ b/packages/extension/src/application/dto/get-session-history-dto.ts
@@ -1,0 +1,83 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../../domain/shared/errors';
+import { type OverlayLine } from '../ports/overlay-presenter';
+
+/**
+ * Issue #109: 履歴一覧入力。MVP では filter / pagination は無し (全件取得)。
+ * 将来の拡張のために空 input を許容しつつ schema 定義を持つ。
+ */
+export type GetSessionHistoryInput = Readonly<Record<string, never>>;
+
+const getSessionHistoryInputSchema = z.object({}).optional();
+
+export const parseGetSessionHistoryInput = (
+  raw: unknown,
+): Result<GetSessionHistoryInput, DomainError> => {
+  const parsed = getSessionHistoryInputSchema.safeParse(raw);
+  if (!parsed.success) {
+    return err(
+      validationError({
+        field: 'GetSessionHistoryInput',
+        message: parsed.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok({});
+};
+
+/**
+ * 履歴一覧の 1 件分。stopped 含む全 session を表現する。
+ * - `durationMs`: stoppedAt - startedAt (停止前は `null`)
+ */
+export type SessionHistorySummary = Readonly<{
+  sessionId: string;
+  displayName: string;
+  sourceType: string;
+  state: string;
+  sourceLanguage: string;
+  targetLanguage: string;
+  startedAt: string;
+  stoppedAt: string | null;
+  durationMs: number | null;
+}>;
+
+export type SessionHistorySummaryListOutput = Readonly<{
+  sessions: readonly SessionHistorySummary[];
+}>;
+
+/**
+ * 履歴詳細入力。`sessionId` を必須に取る。
+ */
+export type GetSessionHistoryDetailInput = Readonly<{
+  sessionId: string;
+}>;
+
+const getSessionHistoryDetailInputSchema = z.object({
+  sessionId: z.string().min(1),
+});
+
+export const parseGetSessionHistoryDetailInput = (
+  raw: unknown,
+): Result<GetSessionHistoryDetailInput, DomainError> => {
+  const parsed = getSessionHistoryDetailInputSchema.safeParse(raw);
+  if (!parsed.success) {
+    return err(
+      validationError({
+        field: 'GetSessionHistoryDetailInput',
+        message: parsed.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(parsed.data);
+};
+
+/**
+ * 履歴詳細出力。`summary` に加え read-only `lines` を含める。
+ * `lines` は `projectOverlayRenderModel` で投影済の `OverlayLine[]` で、
+ * UI 側は `TranscriptPairStream` にそのまま渡せる。
+ */
+export type SessionHistoryDetailOutput = Readonly<{
+  summary: SessionHistorySummary;
+  lines: readonly OverlayLine[];
+}>;

--- a/packages/extension/src/application/services/orphan-session-cleanup-service.test.ts
+++ b/packages/extension/src/application/services/orphan-session-cleanup-service.test.ts
@@ -45,6 +45,7 @@ const buildRepository = (
     ),
   ),
   findActiveSessions: vi.fn(() => okAsync(sessions)),
+  findAllSessions: vi.fn(() => okAsync(sessions)),
   save: vi.fn(() => okAsync(undefined)),
   ...overrides,
 });

--- a/packages/extension/src/application/use-cases/get-session-history-detail-query.ts
+++ b/packages/extension/src/application/use-cases/get-session-history-detail-query.ts
@@ -1,0 +1,101 @@
+import { okAsync, type ResultAsync } from 'neverthrow';
+import { createOverlaySettings, type OverlaySettings } from '../../domain/profile/overlay-settings';
+import { parseSessionIdentifier } from '../../domain/session/session-identifier';
+import { type SourceSession } from '../../domain/session/source-session';
+import { type DomainError } from '../../domain/shared/errors';
+import {
+  type GetSessionHistoryDetailInput,
+  parseGetSessionHistoryDetailInput,
+  type SessionHistoryDetailOutput,
+  type SessionHistorySummary,
+} from '../dto/get-session-history-dto';
+import { toApplicationError, type ApplicationError } from '../errors/application-errors';
+import { type SessionStore } from '../ports/session-store';
+import { type SettingsStore } from '../ports/settings-store';
+import { projectOverlayRenderModel } from './overlay-render-projector';
+
+export type GetSessionHistoryDetailDependencies = Readonly<{
+  sessionStore: SessionStore;
+  settingsStore: SettingsStore;
+}>;
+
+export type GetSessionHistoryDetailQuery = (
+  input: GetSessionHistoryDetailInput,
+) => ResultAsync<SessionHistoryDetailOutput, ApplicationError>;
+
+const summarize = (session: SourceSession): SessionHistorySummary => {
+  const startedAtMs = new Date(session.startedAt).getTime();
+  const stoppedAtMs = session.stoppedAt === null ? null : new Date(session.stoppedAt).getTime();
+  const durationMs =
+    stoppedAtMs !== null && Number.isFinite(stoppedAtMs - startedAtMs)
+      ? Math.max(0, stoppedAtMs - startedAtMs)
+      : null;
+  return {
+    sessionId: session.sessionIdentifier,
+    displayName: session.sessionIdentifier,
+    sourceType: session.sourceType,
+    state: session.state,
+    sourceLanguage: session.languagePair.source,
+    targetLanguage: session.languagePair.target,
+    startedAt: session.startedAt,
+    stoppedAt: session.stoppedAt,
+    durationMs,
+  };
+};
+
+const HISTORY_FALLBACK_SETTINGS: OverlaySettings = createOverlaySettings({
+  positionPreset: 'bottom',
+  opacity: 0.8,
+  maxLines: 200,
+  fontScale: 1,
+  showOriginalText: true,
+  showTranslatedText: true,
+})._unsafeUnwrap();
+
+const resolveSettings = (settingsStore: SettingsStore): ResultAsync<OverlaySettings, DomainError> =>
+  settingsStore.getDefaultOverlaySettings().orElse(() => okAsync(HISTORY_FALLBACK_SETTINGS));
+
+/**
+ * Issue #109 GetSessionHistoryDetailQuery (新規)。
+ *
+ * `SessionStore.loadExportBundle` で session + transcript stream を取得し、
+ * `projectOverlayRenderModel` で `OverlayLine[]` に投影する。`maxLines` は
+ * 履歴用の大きな値 (最低 200) で読み込み、UI 側で全文確認できるようにする。
+ *
+ * settings 取得失敗 (未初期化) は内部既定値 `HISTORY_FALLBACK_SETTINGS` で
+ * fallback する。
+ */
+export const createGetSessionHistoryDetailQuery = (
+  deps: GetSessionHistoryDetailDependencies,
+): GetSessionHistoryDetailQuery => {
+  return (input) =>
+    parseGetSessionHistoryDetailInput(input)
+      .asyncAndThen((parsed) =>
+        parseSessionIdentifier(parsed.sessionId).asyncAndThen((sessionIdentifier) =>
+          deps.sessionStore.loadExportBundle(sessionIdentifier).andThen((bundle) =>
+            resolveSettings(deps.settingsStore).map((settings): SessionHistoryDetailOutput => {
+              const cappedSettings = createOverlaySettings({
+                positionPreset: settings.positionPreset,
+                opacity: settings.opacity,
+                maxLines: Math.max(settings.maxLines, 200),
+                fontScale: settings.fontScale,
+                showOriginalText: settings.showOriginalText,
+                showTranslatedText: settings.showTranslatedText,
+              });
+              const finalSettings = cappedSettings.isOk()
+                ? cappedSettings.value
+                : HISTORY_FALLBACK_SETTINGS;
+              const renderModel = projectOverlayRenderModel({
+                stream: bundle.stream,
+                settings: finalSettings,
+              });
+              return {
+                summary: summarize(bundle.session),
+                lines: renderModel.lines,
+              };
+            }),
+          ),
+        ),
+      )
+      .mapErr(toApplicationError);
+};

--- a/packages/extension/src/application/use-cases/get-session-history-query.ts
+++ b/packages/extension/src/application/use-cases/get-session-history-query.ts
@@ -1,0 +1,64 @@
+import { type ResultAsync } from 'neverthrow';
+import { type SourceSessionRepository } from '../../domain/repositories/source-session-repository';
+import { type SourceSession } from '../../domain/session/source-session';
+import {
+  parseGetSessionHistoryInput,
+  type GetSessionHistoryInput,
+  type SessionHistorySummary,
+  type SessionHistorySummaryListOutput,
+} from '../dto/get-session-history-dto';
+import { toApplicationError, type ApplicationError } from '../errors/application-errors';
+
+export type GetSessionHistoryDependencies = Readonly<{
+  sourceSessionRepository: SourceSessionRepository;
+}>;
+
+export type GetSessionHistoryQuery = (
+  input?: GetSessionHistoryInput,
+) => ResultAsync<SessionHistorySummaryListOutput, ApplicationError>;
+
+const toSummary = (session: SourceSession): SessionHistorySummary => {
+  const startedAtMs = new Date(session.startedAt).getTime();
+  const stoppedAtMs = session.stoppedAt === null ? null : new Date(session.stoppedAt).getTime();
+  const durationMs =
+    stoppedAtMs !== null && Number.isFinite(stoppedAtMs - startedAtMs)
+      ? Math.max(0, stoppedAtMs - startedAtMs)
+      : null;
+  return {
+    sessionId: session.sessionIdentifier,
+    displayName: session.sessionIdentifier,
+    sourceType: session.sourceType,
+    state: session.state,
+    sourceLanguage: session.languagePair.source,
+    targetLanguage: session.languagePair.target,
+    startedAt: session.startedAt,
+    stoppedAt: session.stoppedAt,
+    durationMs,
+  };
+};
+
+/**
+ * Issue #109 GetSessionHistoryQuery (新規)。
+ *
+ * `SourceSessionRepository.findAllSessions` で stopped 含む全 session を取り、
+ * `startedAt` 降順で並べた `SessionHistorySummary[]` を返す。MVP では
+ * pagination / filter は持たない (件数は MVP の同時 3 セッション + α 想定)。
+ *
+ * displayName は SourceSession に保持されないため (旧仕様で UI 側が独自に
+ * `input.displayName` を握っていた) 、暫定で `sessionId` を表示名として返す。
+ * displayName 永続化は後続 Issue で対応。
+ */
+export const createGetSessionHistoryQuery = (
+  deps: GetSessionHistoryDependencies,
+): GetSessionHistoryQuery => {
+  return (rawInput) =>
+    parseGetSessionHistoryInput(rawInput ?? {})
+      .asyncAndThen(() => deps.sourceSessionRepository.findAllSessions())
+      .map((sessions): SessionHistorySummaryListOutput => {
+        const summaries = sessions
+          .map(toSummary)
+          .sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+        return { sessions: summaries };
+      })
+      .mapErr(toApplicationError);
+};

--- a/packages/extension/src/application/use-cases/get-session-monitor-state-query.test.ts
+++ b/packages/extension/src/application/use-cases/get-session-monitor-state-query.test.ts
@@ -73,6 +73,9 @@ const buildDependencies = (
     findActiveSessions: vi.fn(() =>
       okAsync([buildSession(SESSION_ID_1, SOURCE_ID_1), buildSession(SESSION_ID_2, SOURCE_ID_2)]),
     ),
+    findAllSessions: vi.fn(() =>
+      okAsync([buildSession(SESSION_ID_1, SOURCE_ID_1), buildSession(SESSION_ID_2, SOURCE_ID_2)]),
+    ),
     save: vi.fn(() => okAsync(undefined)),
   };
   const defaultFindBySessionId: TranscriptStreamRepository['findBySessionId'] = (id) =>
@@ -149,6 +152,7 @@ describe('createGetSessionMonitorStateQuery (IMPL-211, DD-302)', () => {
       sourceSessionRepository: {
         findById: vi.fn(() => okAsync(buildSession(SESSION_ID_1, SOURCE_ID_1))),
         findActiveSessions: vi.fn(() => okAsync([])),
+        findAllSessions: vi.fn(() => okAsync([])),
         save: vi.fn(() => okAsync(undefined)),
       },
     });

--- a/packages/extension/src/application/use-cases/start-source-session-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/start-source-session-use-case.test.ts
@@ -54,6 +54,7 @@ const buildDependencies = (
   const sourceSessionRepository: SourceSessionRepository = {
     findById: vi.fn(() => okAsync(buildSessionIdle())),
     findActiveSessions: vi.fn(() => okAsync([])),
+    findAllSessions: vi.fn(() => okAsync([])),
     save: vi.fn(() => okAsync(undefined)),
   };
   const extensionProfileRepository: ExtensionProfileRepository = {
@@ -229,6 +230,7 @@ describe('createStartSourceSessionUseCase (IMPL-210, DD-301)', () => {
       sourceSessionRepository: {
         findById: vi.fn(() => okAsync(buildSessionIdle())),
         findActiveSessions: vi.fn(() => okAsync(existing)),
+        findAllSessions: vi.fn(() => okAsync(existing)),
         save: vi.fn(() => okAsync(undefined)),
       },
     });

--- a/packages/extension/src/application/use-cases/stop-source-session-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/stop-source-session-use-case.test.ts
@@ -41,6 +41,7 @@ const buildDependencies = (
   const sourceSessionRepository: SourceSessionRepository = {
     findById: vi.fn(() => okAsync(buildActiveSession())),
     findActiveSessions: vi.fn(() => okAsync([])),
+    findAllSessions: vi.fn(() => okAsync([])),
     save: vi.fn(() => okAsync(undefined)),
   };
   const relayGateway: RelayGateway = {
@@ -148,6 +149,7 @@ describe('createStopSourceSessionUseCase (IMPL-215, DD-306)', () => {
           ),
         ),
         findActiveSessions: vi.fn(() => okAsync([])),
+        findAllSessions: vi.fn(() => okAsync([])),
         save: vi.fn(() => okAsync(undefined)),
       },
     });
@@ -164,6 +166,7 @@ describe('createStopSourceSessionUseCase (IMPL-215, DD-306)', () => {
       sourceSessionRepository: {
         findById: vi.fn(() => okAsync(stopped)),
         findActiveSessions: vi.fn(() => okAsync([])),
+        findAllSessions: vi.fn(() => okAsync([])),
         save: vi.fn(() => okAsync(undefined)),
       },
     });
@@ -274,6 +277,7 @@ describe('createStopSourceSessionUseCase (IMPL-215, DD-306)', () => {
       sourceSessionRepository: {
         findById: vi.fn(() => okAsync(buildActiveSession())),
         findActiveSessions: vi.fn(() => okAsync([])),
+        findAllSessions: vi.fn(() => okAsync([])),
         save: vi.fn(() =>
           errAsync<void, DomainError>(
             invariantViolationError({ invariant: 'storage-write-failed', details: 'quota' }),

--- a/packages/extension/src/application/use-cases/update-source-settings-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/update-source-settings-use-case.test.ts
@@ -33,6 +33,7 @@ const buildDependencies = (
   const sourceSessionRepository: SourceSessionRepository = {
     findById: vi.fn(() => okAsync(buildSession())),
     findActiveSessions: vi.fn(() => okAsync([])),
+    findAllSessions: vi.fn(() => okAsync([])),
     save: vi.fn(() => okAsync(undefined)),
   };
   const overlayPresenter: OverlayPresenter = {
@@ -127,6 +128,7 @@ describe('createUpdateSourceSettingsUseCase (IMPL-212, DD-303)', () => {
           ),
         ),
         findActiveSessions: vi.fn(() => okAsync([])),
+        findAllSessions: vi.fn(() => okAsync([])),
         save: vi.fn(() => okAsync(undefined)),
       },
     });

--- a/packages/extension/src/composition/extension-composition.ts
+++ b/packages/extension/src/composition/extension-composition.ts
@@ -1,6 +1,14 @@
 import { okAsync } from 'neverthrow';
 import { ulid } from 'ulidx';
 import { createExportSessionResultUseCase } from '../application/use-cases/export-session-result-use-case';
+import {
+  createGetSessionHistoryDetailQuery,
+  type GetSessionHistoryDetailQuery,
+} from '../application/use-cases/get-session-history-detail-query';
+import {
+  createGetSessionHistoryQuery,
+  type GetSessionHistoryQuery,
+} from '../application/use-cases/get-session-history-query';
 import { createGetSessionMonitorStateQuery } from '../application/use-cases/get-session-monitor-state-query';
 import { createHandleTranscriptFinalUseCase } from '../application/use-cases/handle-transcript-final-use-case';
 import { createHandleTranscriptPartialUseCase } from '../application/use-cases/handle-transcript-partial-use-case';
@@ -215,6 +223,8 @@ export type ExtensionApp = Readonly<{
   sessionCommandService: SessionCommandService;
   exportService: ExportService;
   getSessionMonitorStateQuery: GetSessionMonitorStateQuery;
+  getSessionHistoryQuery: GetSessionHistoryQuery;
+  getSessionHistoryDetailQuery: GetSessionHistoryDetailQuery;
   sessionRegistry: SessionRegistry;
   captureOrchestrator: CaptureOrchestrator;
   audioFramePump: AudioFramePump;
@@ -399,6 +409,13 @@ export const createExtensionApp = (
     transcriptStreamRepository,
     settingsStore,
   });
+  const getSessionHistoryQuery = createGetSessionHistoryQuery({
+    sourceSessionRepository,
+  });
+  const getSessionHistoryDetailQuery = createGetSessionHistoryDetailQuery({
+    sessionStore,
+    settingsStore,
+  });
 
   // --------------- Application services (Phase 3 facades) ---------------
   const sessionCommandService = createSessionCommandService({
@@ -422,6 +439,8 @@ export const createExtensionApp = (
     sessionCommandService,
     exportService,
     getSessionMonitorStateQuery,
+    getSessionHistoryQuery,
+    getSessionHistoryDetailQuery,
     sessionRegistry,
     captureOrchestrator,
     audioFramePump,

--- a/packages/extension/src/composition/runtime-dispatcher.test.ts
+++ b/packages/extension/src/composition/runtime-dispatcher.test.ts
@@ -49,10 +49,29 @@ const buildFakeDeps = () => {
     saveRelayConnectionOverride: vi.fn(() => okAsync<void, DomainError>(undefined)),
     clearRelayConnectionOverride: vi.fn(() => okAsync<void, DomainError>(undefined)),
   };
+  const getSessionHistoryQuery = vi.fn(() => okAsync({ sessions: [] }));
+  const getSessionHistoryDetailQuery = vi.fn(() =>
+    okAsync({
+      summary: {
+        sessionId: 's',
+        displayName: 's',
+        sourceType: 'tab',
+        state: 'stopped',
+        sourceLanguage: 'en-US',
+        targetLanguage: 'ja-JP',
+        startedAt: '2026-04-21T00:00:00.000Z',
+        stoppedAt: '2026-04-21T00:01:00.000Z',
+        durationMs: 60_000,
+      },
+      lines: [],
+    }),
+  );
   return {
     sessionCommandService,
     exportService,
     getSessionMonitorStateQuery,
+    getSessionHistoryQuery,
+    getSessionHistoryDetailQuery,
     settingsStore,
   };
 };

--- a/packages/extension/src/composition/runtime-dispatcher.ts
+++ b/packages/extension/src/composition/runtime-dispatcher.ts
@@ -6,6 +6,8 @@ import {
 import { type SettingsStore } from '../application/ports/settings-store';
 import { type ExportService } from '../application/services/export-service';
 import { type SessionCommandService } from '../application/services/session-command-service';
+import { type GetSessionHistoryDetailQuery } from '../application/use-cases/get-session-history-detail-query';
+import { type GetSessionHistoryQuery } from '../application/use-cases/get-session-history-query';
 import { type GetSessionMonitorStateQuery } from '../application/use-cases/get-session-monitor-state-query';
 import { createOverlaySettings, type OverlaySettings } from '../domain/profile/overlay-settings';
 import {
@@ -37,6 +39,8 @@ export type RuntimeDispatcherDependencies = Readonly<{
   sessionCommandService: SessionCommandService;
   exportService: ExportService;
   getSessionMonitorStateQuery: GetSessionMonitorStateQuery;
+  getSessionHistoryQuery: GetSessionHistoryQuery;
+  getSessionHistoryDetailQuery: GetSessionHistoryDetailQuery;
   settingsStore: SettingsStore;
 }>;
 
@@ -256,6 +260,10 @@ export const createRuntimeDispatcher = (deps: RuntimeDispatcherDependencies): Ru
             .mapErr(toApplicationError)
             .map(() => ({ saved: true })),
         );
+      case 'query.get-session-history':
+        return run(deps.getSessionHistoryQuery({}));
+      case 'query.get-session-history-detail':
+        return run(deps.getSessionHistoryDetailQuery(request.input));
     }
   };
 };

--- a/packages/extension/src/composition/runtime-messages.ts
+++ b/packages/extension/src/composition/runtime-messages.ts
@@ -92,6 +92,18 @@ const getDefaultSettingsRequestSchema = z.object({
   input: z.object({}).optional(),
 });
 
+const getSessionHistoryRequestSchema = z.object({
+  type: z.literal('query.get-session-history'),
+  input: z.object({}).optional(),
+});
+
+const getSessionHistoryDetailRequestSchema = z.object({
+  type: z.literal('query.get-session-history-detail'),
+  input: z.object({
+    sessionId: z.string().min(1),
+  }),
+});
+
 const defaultLanguagePairPayloadSchema = z.object({
   source: bcp47Schema,
   target: bcp47Schema,
@@ -156,6 +168,8 @@ export const backgroundRequestSchema = z.discriminatedUnion('type', [
   saveDefaultTranslationContextWindowRequestSchema,
   saveRelayConnectionOverrideRequestSchema,
   clearRelayConnectionOverrideRequestSchema,
+  getSessionHistoryRequestSchema,
+  getSessionHistoryDetailRequestSchema,
 ]);
 
 export type BackgroundRequest = z.infer<typeof backgroundRequestSchema>;

--- a/packages/extension/src/domain/repositories/source-session-repository.test.ts
+++ b/packages/extension/src/domain/repositories/source-session-repository.test.ts
@@ -29,6 +29,7 @@ describe('SourceSessionRepository (DD-260)', () => {
       const mock: SourceSessionRepository = {
         findById: () => okAsync(buildSession(SESSION_ID, SOURCE_ID)),
         findActiveSessions: () => okAsync([]),
+        findAllSessions: () => okAsync([]),
         save: () => okAsync(undefined),
       };
       expect(typeof mock.findById).toBe('function');
@@ -43,6 +44,7 @@ describe('SourceSessionRepository (DD-260)', () => {
       const mock: SourceSessionRepository = {
         findById: () => okAsync(session),
         findActiveSessions: () => okAsync([]),
+        findAllSessions: () => okAsync([]),
         save: () => okAsync(undefined),
       };
       const result = await mock.findById(sessionIdentifier);
@@ -57,6 +59,7 @@ describe('SourceSessionRepository (DD-260)', () => {
             notFoundError({ resourceType: 'SourceSession', identifier: id }),
           ),
         findActiveSessions: () => okAsync([]),
+        findAllSessions: () => okAsync([]),
         save: () => okAsync(undefined),
       };
       const result = await mock.findById(sessionIdentifier);
@@ -76,6 +79,7 @@ describe('SourceSessionRepository (DD-260)', () => {
       const mock: SourceSessionRepository = {
         findById: () => okAsync(buildSession(SESSION_ID, SOURCE_ID)),
         findActiveSessions: () => okAsync([]),
+        findAllSessions: () => okAsync([]),
         save: () => okAsync(undefined),
       };
       const result = await mock.findActiveSessions();
@@ -91,6 +95,7 @@ describe('SourceSessionRepository (DD-260)', () => {
       const mock: SourceSessionRepository = {
         findById: () => okAsync(sessions[0]!),
         findActiveSessions: () => okAsync(sessions),
+        findAllSessions: () => okAsync(sessions),
         save: () => okAsync(undefined),
       };
       const result = await mock.findActiveSessions();
@@ -108,6 +113,7 @@ describe('SourceSessionRepository (DD-260)', () => {
       const mock: SourceSessionRepository = {
         findById: () => okAsync(buildSession(SESSION_ID, SOURCE_ID)),
         findActiveSessions: () => okAsync([]),
+        findAllSessions: () => okAsync([]),
         save: () => okAsync(undefined),
       };
       const result = await mock.save(buildSession(SESSION_ID, SOURCE_ID));

--- a/packages/extension/src/domain/repositories/source-session-repository.ts
+++ b/packages/extension/src/domain/repositories/source-session-repository.ts
@@ -26,5 +26,12 @@ import { type DomainError } from '../shared/errors';
 export type SourceSessionRepository = Readonly<{
   findById: (sessionIdentifier: SessionIdentifier) => ResultAsync<SourceSession, DomainError>;
   findActiveSessions: () => ResultAsync<readonly SourceSession[], DomainError>;
+  /**
+   * Issue #109: 履歴画面用に **stopped 含む全件** を取得する。
+   * `findActiveSessions` がアクティブのみフィルタするのに対し、本メソッドは
+   * フィルタせず IndexedDB の全レコードを返す。
+   * 0 件は `ok([])`、整合失敗は `invariantViolationError` を返す。
+   */
+  findAllSessions: () => ResultAsync<readonly SourceSession[], DomainError>;
   save: (session: SourceSession) => ResultAsync<void, DomainError>;
 }>;

--- a/packages/extension/src/entrypoints/background.ts
+++ b/packages/extension/src/entrypoints/background.ts
@@ -182,6 +182,8 @@ export default defineBackground(() => {
     sessionCommandService: app.sessionCommandService,
     exportService: app.exportService,
     getSessionMonitorStateQuery: app.getSessionMonitorStateQuery,
+    getSessionHistoryQuery: app.getSessionHistoryQuery,
+    getSessionHistoryDetailQuery: app.getSessionHistoryDetailQuery,
     settingsStore: app.settingsStore,
   });
 

--- a/packages/extension/src/entrypoints/main/App.tsx
+++ b/packages/extension/src/entrypoints/main/App.tsx
@@ -5,6 +5,7 @@ import {
   createBackgroundClient,
   type StartSourceSessionResult,
 } from '../../presentation/infrastructure/background-client';
+import { SessionHistoryView } from '../../presentation/organisms/session-history-view';
 import { SessionToolbar, type ActiveSession } from '../../presentation/organisms/session-toolbar';
 import { SettingsView } from '../../presentation/organisms/settings-view';
 import { StartSessionForm } from '../../presentation/organisms/start-session-form';
@@ -30,6 +31,7 @@ export function App() {
   });
   const [active, setActive] = useState<ActiveSession | null>(null);
   const [showSettings, setShowSettings] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
 
   const handleStarted = useCallback(
     (result: StartSourceSessionResult, input: StartSourceSessionInput) => {
@@ -51,6 +53,12 @@ export function App() {
   }, []);
   const closeSettings = useCallback(() => {
     setShowSettings(false);
+  }, []);
+  const openHistory = useCallback(() => {
+    setShowHistory(true);
+  }, []);
+  const closeHistory = useCallback(() => {
+    setShowHistory(false);
   }, []);
 
   useEffect(() => {
@@ -90,19 +98,33 @@ export function App() {
     );
   }
 
+  if (showHistory) {
+    return <SessionHistoryView client={client} onClose={closeHistory} />;
+  }
+
   const defaultLanguagePair = defaultSettingsQuery.state.data?.languagePair ?? null;
   const formKey =
     defaultLanguagePair !== null
       ? `${defaultLanguagePair.source}:${defaultLanguagePair.target}`
       : 'loading';
   const formSlot = (
-    <StartSessionForm
-      key={formKey}
-      client={client}
-      onStarted={handleStarted}
-      initialSourceLanguage={defaultLanguagePair?.source}
-      initialTargetLanguage={defaultLanguagePair?.target}
-    />
+    <>
+      <StartSessionForm
+        key={formKey}
+        client={client}
+        onStarted={handleStarted}
+        initialSourceLanguage={defaultLanguagePair?.source}
+        initialTargetLanguage={defaultLanguagePair?.target}
+      />
+      <button
+        type="button"
+        className="historyButton"
+        aria-label="セッション履歴を開く"
+        onClick={openHistory}
+      >
+        過去のセッションを見る
+      </button>
+    </>
   );
   const toolbarSlot =
     active !== null ? (

--- a/packages/extension/src/infrastructure/storage/indexed-db-source-session-repository.ts
+++ b/packages/extension/src/infrastructure/storage/indexed-db-source-session-repository.ts
@@ -91,6 +91,25 @@ export const createIndexedDbSourceSessionRepository = (
         return okAsync<readonly SourceSession[], DomainError>(sessions);
       }),
 
+    findAllSessions: () =>
+      ResultAsync.fromPromise(
+        (async () => {
+          const connection = await handle.get();
+          return connection.getAll(SESSIONS_STORE);
+        })(),
+        toPersistenceError('findAllSessions'),
+      ).andThen((rows): ResultAsync<readonly SourceSession[], DomainError> => {
+        const sessions: SourceSession[] = [];
+        for (const row of rows) {
+          const parsed = sessionFromRecord(row);
+          if (parsed.isErr()) {
+            return errAsync<readonly SourceSession[], DomainError>(parsed.error);
+          }
+          sessions.push(parsed.value);
+        }
+        return okAsync<readonly SourceSession[], DomainError>(sessions);
+      }),
+
     save: (session) =>
       ResultAsync.fromPromise(
         (async () => {

--- a/packages/extension/src/presentation/infrastructure/background-client.ts
+++ b/packages/extension/src/presentation/infrastructure/background-client.ts
@@ -134,6 +134,39 @@ export type DefaultSettingsResult = z.infer<typeof defaultSettingsOutputSchema>;
 const savedAckSchema = z.object({ saved: z.literal(true) });
 export type SavedAckResult = z.infer<typeof savedAckSchema>;
 
+const sessionHistorySummarySchema = z.object({
+  sessionId: z.string().min(1),
+  displayName: z.string(),
+  sourceType: z.string().min(1),
+  state: z.string().min(1),
+  sourceLanguage: z.string(),
+  targetLanguage: z.string(),
+  startedAt: z.string().min(1),
+  stoppedAt: z.string().min(1).nullable(),
+  durationMs: z.number().nonnegative().nullable(),
+});
+
+const sessionHistoryListOutputSchema = z.object({
+  sessions: z.array(sessionHistorySummarySchema),
+});
+export type SessionHistoryListResult = z.infer<typeof sessionHistoryListOutputSchema>;
+
+const overlayLineOutputSchema = z.object({
+  segmentIdentifier: z.string().min(1),
+  originalText: z.string().nullable(),
+  translatedText: z.string().nullable(),
+  targetLanguage: z.string().nullable(),
+  isFinal: z.boolean(),
+  precedingSegmentIdentifier: z.string().min(1).nullable(),
+  hasTranslationContext: z.boolean(),
+});
+
+const sessionHistoryDetailOutputSchema = z.object({
+  summary: sessionHistorySummarySchema,
+  lines: z.array(overlayLineOutputSchema),
+});
+export type SessionHistoryDetailResult = z.infer<typeof sessionHistoryDetailOutputSchema>;
+
 const sessionMonitorStateOutputSchema = z.object({
   sessions: z.array(
     z.object({
@@ -256,6 +289,10 @@ export type BackgroundClient = Readonly<{
     input: RelayConnectionOverrideInput,
   ) => Promise<BackgroundResponse<SavedAckResult>>;
   clearRelayConnectionOverride: () => Promise<BackgroundResponse<SavedAckResult>>;
+  getSessionHistory: () => Promise<BackgroundResponse<SessionHistoryListResult>>;
+  getSessionHistoryDetail: (input: {
+    sessionId: string;
+  }) => Promise<BackgroundResponse<SessionHistoryDetailResult>>;
 }>;
 
 /**
@@ -314,4 +351,12 @@ export const createBackgroundClient = (
     sendTyped(sender, { type: 'command.save-relay-connection-override', input }, savedAckSchema),
   clearRelayConnectionOverride: () =>
     sendTyped(sender, { type: 'command.clear-relay-connection-override' }, savedAckSchema),
+  getSessionHistory: () =>
+    sendTyped(sender, { type: 'query.get-session-history' }, sessionHistoryListOutputSchema),
+  getSessionHistoryDetail: (input) =>
+    sendTyped(
+      sender,
+      { type: 'query.get-session-history-detail', input },
+      sessionHistoryDetailOutputSchema,
+    ),
 });

--- a/packages/extension/src/presentation/molecules/export-controls.test.tsx
+++ b/packages/extension/src/presentation/molecules/export-controls.test.tsx
@@ -35,6 +35,8 @@ const buildClient = (overrides: Partial<BackgroundClient> = {}): BackgroundClien
   saveDefaultTranslationContextWindow: vi.fn(),
   saveRelayConnectionOverride: vi.fn(),
   clearRelayConnectionOverride: vi.fn(),
+  getSessionHistory: vi.fn(),
+  getSessionHistoryDetail: vi.fn(),
   ...overrides,
 });
 

--- a/packages/extension/src/presentation/organisms/session-history-view.test.tsx
+++ b/packages/extension/src/presentation/organisms/session-history-view.test.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type BackgroundClient,
+  type BackgroundResponse,
+  type SessionHistoryDetailResult,
+  type SessionHistoryListResult,
+} from '../infrastructure/background-client';
+import { SessionHistoryView } from './session-history-view';
+
+const SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SECOND_SESSION_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+
+const buildList = (
+  overrides: Partial<SessionHistoryListResult> = {},
+): BackgroundResponse<SessionHistoryListResult> => ({
+  ok: true,
+  value: {
+    sessions: [
+      {
+        sessionId: SESSION_ID,
+        displayName: SESSION_ID,
+        sourceType: 'tab',
+        state: 'stopped',
+        sourceLanguage: 'en-US',
+        targetLanguage: 'ja-JP',
+        startedAt: '2026-04-21T00:00:00.000Z',
+        stoppedAt: '2026-04-21T00:01:00.000Z',
+        durationMs: 60_000,
+      },
+      {
+        sessionId: SECOND_SESSION_ID,
+        displayName: SECOND_SESSION_ID,
+        sourceType: 'microphone',
+        state: 'stopped',
+        sourceLanguage: 'ja-JP',
+        targetLanguage: 'en-US',
+        startedAt: '2026-04-22T00:00:00.000Z',
+        stoppedAt: '2026-04-22T00:00:30.000Z',
+        durationMs: 30_000,
+      },
+    ],
+    ...overrides,
+  },
+});
+
+const buildDetail = (): BackgroundResponse<SessionHistoryDetailResult> => ({
+  ok: true,
+  value: {
+    summary: {
+      sessionId: SESSION_ID,
+      displayName: SESSION_ID,
+      sourceType: 'tab',
+      state: 'stopped',
+      sourceLanguage: 'en-US',
+      targetLanguage: 'ja-JP',
+      startedAt: '2026-04-21T00:00:00.000Z',
+      stoppedAt: '2026-04-21T00:01:00.000Z',
+      durationMs: 60_000,
+    },
+    lines: [
+      {
+        segmentIdentifier: '01HZX8Y2R8M7D3Q2P4T5V6W7B1',
+        originalText: 'hello world',
+        translatedText: 'こんにちは',
+        targetLanguage: 'ja-JP',
+        isFinal: true,
+        precedingSegmentIdentifier: null,
+        hasTranslationContext: false,
+      },
+    ],
+  },
+});
+
+const buildClient = (overrides: Partial<BackgroundClient> = {}): BackgroundClient => ({
+  startSourceSession: vi.fn(),
+  stopSourceSession: vi.fn(),
+  updateSourceSettings: vi.fn(),
+  exportSessionResult: vi.fn(),
+  getSessionMonitorState: vi.fn(),
+  getDefaultSettings: vi.fn(),
+  saveDefaultLanguagePair: vi.fn(),
+  saveDefaultOverlaySettings: vi.fn(),
+  saveDefaultEndpointingPolicy: vi.fn(),
+  saveDefaultTranslationContextWindow: vi.fn(),
+  saveRelayConnectionOverride: vi.fn(),
+  clearRelayConnectionOverride: vi.fn(),
+  getSessionHistory: vi.fn(() => Promise.resolve(buildList())),
+  getSessionHistoryDetail: vi.fn(() => Promise.resolve(buildDetail())),
+  ...overrides,
+});
+
+describe('SessionHistoryView organism (Issue #109)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the list of past sessions', async () => {
+    const client = buildClient();
+    render(<SessionHistoryView client={client} onClose={() => undefined} />);
+    await waitFor(() => {
+      expect(client.getSessionHistory).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(screen.getAllByRole('listitem').length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('fetches detail and renders lines when an entry is clicked', async () => {
+    const client = buildClient();
+    render(<SessionHistoryView client={client} onClose={() => undefined} />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: `セッション ${SESSION_ID} を開く` }),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: `セッション ${SESSION_ID} を開く` }));
+    await waitFor(() => {
+      expect(client.getSessionHistoryDetail).toHaveBeenCalledWith({ sessionId: SESSION_ID });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('history-detail')).toBeInTheDocument();
+    });
+    expect(screen.getByText('hello world')).toBeInTheDocument();
+    expect(screen.getByText('こんにちは')).toBeInTheDocument();
+  });
+
+  it('shows error message when detail fetch fails', async () => {
+    const client = buildClient({
+      getSessionHistoryDetail: vi.fn(() =>
+        Promise.resolve<BackgroundResponse<SessionHistoryDetailResult>>({
+          ok: false,
+          error: { type: 'internal', code: 'INTERNAL_ERROR', message: 'boom' },
+        }),
+      ),
+    });
+    render(<SessionHistoryView client={client} onClose={() => undefined} />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: `セッション ${SESSION_ID} を開く` }),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: `セッション ${SESSION_ID} を開く` }));
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole('alert').some((el) => el.textContent?.includes('詳細取得に失敗')),
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/extension/src/presentation/organisms/session-history-view.tsx
+++ b/packages/extension/src/presentation/organisms/session-history-view.tsx
@@ -1,0 +1,153 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Button } from '../atoms/button';
+import { useBackgroundCommand } from '../hooks/use-background-command';
+import { useBackgroundQuery } from '../hooks/use-background-query';
+import {
+  type BackgroundClient,
+  type SessionHistoryDetailResult,
+} from '../infrastructure/background-client';
+import { TranscriptPairItem } from '../molecules/transcript-pair-item';
+
+export type Props = Readonly<{
+  client: BackgroundClient;
+  onClose: () => void;
+}>;
+
+const formatDuration = (ms: number | null): string => {
+  if (ms === null) return '—';
+  const totalSec = Math.round(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min.toString()}:${sec.toString().padStart(2, '0')}`;
+};
+
+const formatStartedAt = (iso: string): string => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+};
+
+/**
+ * IMPL-545 SessionHistoryView organism (Issue #109)。
+ *
+ * 過去セッション一覧 + 選択 detail。`SettingsView` と同じ「全画面差し替え」
+ * パターンで idle 画面から呼び出される。削除 / 自動破棄は次 PR で対応する。
+ */
+export function SessionHistoryView(props: Props) {
+  const listQuery = useBackgroundQuery(() => props.client.getSessionHistory(), {
+    input: undefined,
+  });
+  const detailCommand = useBackgroundCommand(props.client.getSessionHistoryDetail);
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<SessionHistoryDetailResult | null>(null);
+  const [detailError, setDetailError] = useState<string | null>(null);
+
+  const sessions = useMemo(() => listQuery.state.data?.sessions ?? [], [listQuery.state.data]);
+
+  const handleSelect = useCallback(
+    async (sessionId: string): Promise<void> => {
+      setSelectedSessionId(sessionId);
+      setDetailError(null);
+      setDetail(null);
+      const response = await detailCommand.execute({ sessionId });
+      if (response.ok) {
+        setDetail(response.value);
+      } else {
+        setDetailError(`詳細取得に失敗しました: ${response.error.message}`);
+      }
+    },
+    [detailCommand],
+  );
+
+  return (
+    <div className="container" role="dialog" aria-label="セッション履歴">
+      <header className="header">
+        <h2 className="title">セッション履歴</h2>
+        <Button variant="secondary" onClick={props.onClose}>
+          閉じる
+        </Button>
+      </header>
+      <div className="body" data-variant="history">
+        <aside className="list" aria-label="履歴一覧">
+          {listQuery.state.status === 'pending' || listQuery.state.status === 'idle' ? (
+            <p className="message">読み込み中…</p>
+          ) : null}
+          {listQuery.state.status === 'error' ? (
+            <p className="message" role="alert">
+              一覧の取得に失敗しました: {listQuery.state.error?.message ?? 'unknown error'}
+            </p>
+          ) : null}
+          {listQuery.state.status === 'success' && sessions.length === 0 ? (
+            <p className="message">過去のセッションはまだありません。</p>
+          ) : null}
+          <ul className="items" role="list">
+            {sessions.map((summary) => (
+              <li
+                key={summary.sessionId}
+                className="item"
+                role="listitem"
+                data-selected={selectedSessionId === summary.sessionId ? 'true' : 'false'}
+              >
+                <button
+                  type="button"
+                  className="row"
+                  aria-label={`セッション ${summary.sessionId} を開く`}
+                  onClick={() => {
+                    void handleSelect(summary.sessionId);
+                  }}
+                >
+                  <span className="name" title={summary.displayName}>
+                    {summary.displayName}
+                  </span>
+                  <span className="meta">
+                    {formatStartedAt(summary.startedAt)} ・ {summary.sourceLanguage} →{' '}
+                    {summary.targetLanguage} ・ {summary.state}
+                    {summary.durationMs !== null ? ` ・ ${formatDuration(summary.durationMs)}` : ''}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </aside>
+        <section className="detail" aria-label="履歴詳細">
+          {selectedSessionId === null ? (
+            <p className="message">左の一覧からセッションを選択してください。</p>
+          ) : null}
+          {detailError !== null ? (
+            <p className="message" role="alert">
+              {detailError}
+            </p>
+          ) : null}
+          {detailCommand.state.status === 'pending' ? <p className="message">読み込み中…</p> : null}
+          {detail !== null ? (
+            <div className="content" data-testid="history-detail">
+              <header className="metaHeader">
+                <h3 className="subtitle">{detail.summary.displayName}</h3>
+                <p className="meta">
+                  {formatStartedAt(detail.summary.startedAt)} ・ {detail.summary.sourceLanguage} →{' '}
+                  {detail.summary.targetLanguage} ・ {detail.summary.state}
+                </p>
+              </header>
+              <div className="list" role="list" aria-label="字幕履歴">
+                {detail.lines.length === 0 ? (
+                  <p className="message">字幕は記録されていません。</p>
+                ) : (
+                  detail.lines.map((line) => (
+                    <TranscriptPairItem
+                      key={line.segmentIdentifier}
+                      originalText={line.originalText}
+                      translatedText={line.translatedText}
+                      isFinal={line.isFinal}
+                      connectedToPrevious={line.precedingSegmentIdentifier !== null}
+                      hasTranslationContext={line.hasTranslationContext}
+                    />
+                  ))
+                )}
+              </div>
+            </div>
+          ) : null}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/packages/extension/src/presentation/organisms/session-toolbar.test.tsx
+++ b/packages/extension/src/presentation/organisms/session-toolbar.test.tsx
@@ -27,6 +27,8 @@ const buildClient = (overrides: Partial<BackgroundClient> = {}): BackgroundClien
   saveDefaultTranslationContextWindow: vi.fn(),
   saveRelayConnectionOverride: vi.fn(),
   clearRelayConnectionOverride: vi.fn(),
+  getSessionHistory: vi.fn(),
+  getSessionHistoryDetail: vi.fn(),
   ...overrides,
 });
 

--- a/packages/extension/src/presentation/organisms/settings-view.test.tsx
+++ b/packages/extension/src/presentation/organisms/settings-view.test.tsx
@@ -51,6 +51,8 @@ const buildClient = (overrides: Partial<BackgroundClient> = {}): BackgroundClien
   saveDefaultTranslationContextWindow: vi.fn(() => Promise.resolve(SAVED_ACK)),
   saveRelayConnectionOverride: vi.fn(() => Promise.resolve(SAVED_ACK)),
   clearRelayConnectionOverride: vi.fn(() => Promise.resolve(SAVED_ACK)),
+  getSessionHistory: vi.fn(),
+  getSessionHistoryDetail: vi.fn(),
   ...overrides,
 });
 

--- a/packages/extension/src/presentation/organisms/start-session-form.test.tsx
+++ b/packages/extension/src/presentation/organisms/start-session-form.test.tsx
@@ -42,6 +42,8 @@ const buildClient = (start: BackgroundClient['startSourceSession']): BackgroundC
   saveDefaultTranslationContextWindow: vi.fn(),
   saveRelayConnectionOverride: vi.fn(),
   clearRelayConnectionOverride: vi.fn(),
+  getSessionHistory: vi.fn(),
+  getSessionHistoryDetail: vi.fn(),
 });
 
 describe('StartSessionForm organism (IMPL-540)', () => {


### PR DESCRIPTION
Closes #109 (一覧 + read-only 詳細部分)

## Summary

停止済セッションの transcript / translation を main window から閲覧する画面を追加する。受入基準のうち「一覧 + read-only 詳細」を実装、削除と自動破棄は Issue 本文で許容されている通り別 PR に分離する。

- `SourceSessionRepository` に `findAllSessions` (stopped 含む全件) を追加
- 新 UseCase 2 つ: `GetSessionHistoryQuery` (一覧) と `GetSessionHistoryDetailQuery` (`SessionStore.loadExportBundle` + `projectOverlayRenderModel` で `OverlayLine[]` 投影)
- runtime-messages / runtime-dispatcher / background-client に `query.get-session-history` / `query.get-session-history-detail` を追加
- 新 organism `SessionHistoryView`: list (左) + detail (右) の `SettingsView` と同じ全画面差し替えパターン。`TranscriptPairItem` を再利用し read-only 表示
- `App.tsx` に `showHistory` state と「過去のセッションを見る」ボタンを idle 画面に追加

## 受入基準

- [x] main window の idle 画面に「履歴」ボタンを追加
- [x] 過去セッション一覧 (displayName / 開始日時 / 継続時間 / 言語ペア / 状態)
- [x] 項目クリックで該当 session の `TranscriptPairStream` 風の read-only 再生表示
- [ ] 削除ボタン (別 PR で対応予定)
- [ ] 保持件数 / 自動破棄 (別 PR で対応予定)
- [x] unit test: 一覧取得 / read-only 表示 / エラー表示

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 941/941 green (新規 view test 3 件含む)
- [x] `pnpm lint` 0 errors (既存 IDB cursor 警告のみ残存)
- [ ] 手動: dev ビルドで session 開始 → 停止後、「過去のセッションを見る」から一覧 → 選択で詳細表示