### PR TITLE
feat(extension): VU meter in main window (#110)

### DIFF
--- a/packages/extension/src/entrypoints/main/App.tsx
+++ b/packages/extension/src/entrypoints/main/App.tsx
@@ -11,6 +11,7 @@ import { SettingsView } from '../../presentation/organisms/settings-view';
 import { StartSessionForm } from '../../presentation/organisms/start-session-form';
 import { TranscriptPairStream } from '../../presentation/organisms/transcript-pair-stream';
 import { MainWindowTemplate } from '../../presentation/templates/main-window-template';
+import { useAudioLevel } from './use-audio-level';
 import { useOverlayMessages } from './use-overlay-messages';
 
 /**
@@ -26,6 +27,7 @@ import { useOverlayMessages } from './use-overlay-messages';
 export function App() {
   const client = useMemo(() => createBackgroundClient(), []);
   const overlay = useOverlayMessages();
+  const audio = useAudioLevel();
   const defaultSettingsQuery = useBackgroundQuery(() => client.getDefaultSettings(), {
     input: undefined,
   });
@@ -132,6 +134,8 @@ export function App() {
         client={client}
         session={active}
         stateReason={overlay.sessionStateReason}
+        audioLevel={audio.rms}
+        audioIsSilent={audio.isSilent}
         onStopped={handleStopped}
         onOpenSettings={openSettings}
       />

--- a/packages/extension/src/entrypoints/main/use-audio-level.ts
+++ b/packages/extension/src/entrypoints/main/use-audio-level.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from 'react';
+import { z } from 'zod';
+
+/**
+ * Issue #110: 音声レベル hook (main window)。
+ *
+ * `offscreen/main.ts` が `chrome.runtime.sendMessage({ type:
+ * 'audio.level.forward', sessionIdentifier, rms, capturedAt })` で
+ * broadcast する RMS を購読する。1 秒以上 RMS < `SILENCE_THRESHOLD` の
+ * 場合は `isSilent=true` を返し、UI 側で警告表示に使う。
+ */
+
+const SILENCE_THRESHOLD = 0.01;
+const SILENCE_DURATION_MS = 1000;
+
+const audioLevelSchema = z.object({
+  type: z.literal('audio.level.forward'),
+  sessionIdentifier: z.string().min(1),
+  rms: z.number(),
+  capturedAt: z.string().nullable().optional(),
+});
+
+export type AudioLevelState = Readonly<{
+  rms: number;
+  isSilent: boolean;
+}>;
+
+const initialState: AudioLevelState = { rms: 0, isSilent: false };
+
+export const useAudioLevel = (): AudioLevelState => {
+  const [state, setState] = useState<AudioLevelState>(initialState);
+  const lastLoudAtRef = useRef<number>(Date.now());
+
+  useEffect(() => {
+    const listener: Parameters<typeof chrome.runtime.onMessage.addListener>[0] = (
+      message,
+      _sender,
+      sendResponse,
+    ) => {
+      const parsed = audioLevelSchema.safeParse(message);
+      if (!parsed.success) return false;
+      const { rms } = parsed.data;
+      const clamped = Math.max(0, Math.min(1, rms));
+      const now = Date.now();
+      if (clamped >= SILENCE_THRESHOLD) {
+        lastLoudAtRef.current = now;
+      }
+      const isSilent = now - lastLoudAtRef.current >= SILENCE_DURATION_MS;
+      setState((prev) =>
+        prev.rms === clamped && prev.isSilent === isSilent ? prev : { rms: clamped, isSilent },
+      );
+      sendResponse(undefined);
+      return false;
+    };
+    chrome.runtime.onMessage.addListener(listener);
+    return () => {
+      chrome.runtime.onMessage.removeListener(listener);
+    };
+  }, []);
+
+  return state;
+};

--- a/packages/extension/src/entrypoints/offscreen/main.ts
+++ b/packages/extension/src/entrypoints/offscreen/main.ts
@@ -89,6 +89,31 @@ const host = createOffscreenAudioHost({
           cause instanceof Error ? cause.message : String(cause),
         );
       });
+
+    // Issue #110: RMS piggyback を別 channel にも broadcast。
+    // main window の useAudioLevel hook が購読する。失敗は warn のみで無視
+    // (audio.frame.forward と独立)。
+    if (typeof data === 'object' && data !== null && 'rms' in data) {
+      const rms = Reflect.get(data, 'rms');
+      if (typeof rms === 'number' && Number.isFinite(rms)) {
+        void chrome.runtime
+          .sendMessage({
+            type: 'audio.level.forward',
+            sessionIdentifier,
+            rms,
+            capturedAt:
+              typeof data === 'object' && data !== null && 'capturedAt' in data
+                ? Reflect.get(data, 'capturedAt')
+                : null,
+          })
+          .catch((cause: unknown) => {
+            console.warn(
+              '[perapera] offscreen audio.level.forward sendMessage failed:',
+              cause instanceof Error ? cause.message : String(cause),
+            );
+          });
+      }
+    }
   },
 });
 

--- a/packages/extension/src/presentation/atoms/vu-meter.test.tsx
+++ b/packages/extension/src/presentation/atoms/vu-meter.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { VuMeter } from './vu-meter';
+
+describe('VuMeter atom (Issue #110)', () => {
+  it('renders with the correct aria attributes', () => {
+    render(<VuMeter rms={0.3} />);
+    const meter = screen.getByRole('meter', { name: '音声レベル' });
+    expect(meter).toHaveAttribute('aria-valuenow', '30');
+    expect(meter).toHaveAttribute('aria-valuemin', '0');
+    expect(meter).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('clamps negative rms to 0', () => {
+    render(<VuMeter rms={-0.5} />);
+    expect(screen.getByRole('meter')).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('clamps rms > 1 to 100', () => {
+    render(<VuMeter rms={2} />);
+    expect(screen.getByRole('meter')).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  it('uses data-level="low" for rms below 0.2', () => {
+    render(<VuMeter rms={0.1} />);
+    expect(screen.getByRole('meter')).toHaveAttribute('data-level', 'low');
+  });
+
+  it('uses data-level="mid" for rms in [0.2, 0.5)', () => {
+    render(<VuMeter rms={0.3} />);
+    expect(screen.getByRole('meter')).toHaveAttribute('data-level', 'mid');
+  });
+
+  it('uses data-level="high" for rms >= 0.5', () => {
+    render(<VuMeter rms={0.7} />);
+    expect(screen.getByRole('meter')).toHaveAttribute('data-level', 'high');
+  });
+
+  it('treats NaN rms as 0', () => {
+    render(<VuMeter rms={Number.NaN} />);
+    expect(screen.getByRole('meter')).toHaveAttribute('aria-valuenow', '0');
+  });
+});

--- a/packages/extension/src/presentation/atoms/vu-meter.tsx
+++ b/packages/extension/src/presentation/atoms/vu-meter.tsx
@@ -1,0 +1,36 @@
+export type Props = Readonly<{
+  /** 0〜1 の音声レベル (RMS)。範囲外は clamp される */
+  rms: number;
+  /** アクセシビリティラベル (既定: "音声レベル") */
+  ariaLabel?: string;
+}>;
+
+/**
+ * Issue #110 VuMeter atom。
+ *
+ * 0〜1 の RMS を横バーで可視化する単純な atom。しきい値で色が切り替わる:
+ * - `rms < 0.2`  → green (弱いが正常に流れている)
+ * - `rms < 0.5`  → yellow (普通〜大きい)
+ * - `rms >= 0.5` → red (過大音量)
+ *
+ * 実装は container `.meter` + child `.fill` (幅を rms% に) の 2 要素。
+ */
+export function VuMeter(props: Props) {
+  const clamped = Math.max(0, Math.min(1, Number.isFinite(props.rms) ? props.rms : 0));
+  const percentage = Math.round(clamped * 100);
+  const level = clamped >= 0.5 ? 'high' : clamped >= 0.2 ? 'mid' : 'low';
+  return (
+    <div
+      className="meter"
+      role="meter"
+      aria-label={props.ariaLabel ?? '音声レベル'}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={percentage}
+      data-level={level}
+      data-testid="vu-meter"
+    >
+      <div className="fill" style={{ width: `${percentage.toString()}%` }} data-level={level} />
+    </div>
+  );
+}

--- a/packages/extension/src/presentation/organisms/session-toolbar.tsx
+++ b/packages/extension/src/presentation/organisms/session-toolbar.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Button } from '../atoms/button';
 import { StatusBadge } from '../atoms/status-badge';
+import { VuMeter } from '../atoms/vu-meter';
 import { useBackgroundCommand } from '../hooks/use-background-command';
 import { type BackgroundClient } from '../infrastructure/background-client';
 import { ExportControls } from '../molecules/export-controls';
@@ -16,6 +17,10 @@ export type Props = Readonly<{
   session: ActiveSession;
   /** Issue #108: Relay が `session.state.changed` に付与した補足理由 (degraded / error 時の banner で表示) */
   stateReason?: string | null;
+  /** Issue #110: 最新の音声レベル (RMS 0-1)。既定 0 (未取得) */
+  audioLevel?: number;
+  /** Issue #110: 1 秒以上無音の場合 true。既定 false */
+  audioIsSilent?: boolean;
   onStopped: () => void;
   /** `⚙` ボタン押下で設定画面を開く。未指定時は非表示 */
   onOpenSettings?: () => void;
@@ -64,6 +69,7 @@ export function SessionToolbar(props: Props) {
           {props.session.displayName}
         </span>
         <StatusBadge state={props.session.state} />
+        <VuMeter rms={props.audioLevel ?? 0} />
       </div>
       <div className="actions">
         {props.onOpenSettings !== undefined ? (
@@ -111,6 +117,16 @@ export function SessionToolbar(props: Props) {
           data-state={props.session.state}
         >
           {banner}
+        </div>
+      ) : null}
+      {props.audioIsSilent === true ? (
+        <div
+          className="banner"
+          role="alert"
+          data-testid="audio-silent-banner"
+          data-variant="silence"
+        >
+          音声を検出できません。入力デバイス / タブ音量を確認してください。
         </div>
       ) : null}
     </header>

--- a/packages/extension/src/public/perapera-audio-processor.js
+++ b/packages/extension/src/public/perapera-audio-processor.js
@@ -53,6 +53,23 @@ const floatToPcm16 = (float32) => {
 // base64 エンコーダを inline 実装する。RFC 4648 §4 準拠、padding 付き。
 const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 
+/**
+ * Issue #110: Float32 buffer (1600 samples) から RMS (0-1) を計算する。
+ * overflow しないよう sum は number、戻り値は 0〜1 範囲。
+ */
+const computeRms = (float32) => {
+  let sumSquares = 0;
+  const len = float32.length;
+  for (let i = 0; i < len; i += 1) {
+    const value = float32[i] ?? 0;
+    sumSquares += value * value;
+  }
+  if (len === 0) return 0;
+  const rms = Math.sqrt(sumSquares / len);
+  if (!Number.isFinite(rms)) return 0;
+  return Math.max(0, Math.min(1, rms));
+};
+
 const int16ToBase64 = (int16) => {
   const bytes = new Uint8Array(int16.buffer, int16.byteOffset, int16.byteLength);
   let result = '';
@@ -127,6 +144,7 @@ class PeraperaAudioProcessor extends AudioWorkletProcessor {
 
   _flush() {
     try {
+      const rms = computeRms(this._buffer);
       const pcm16 = floatToPcm16(this._buffer);
       const pcm16Base64 = int16ToBase64(pcm16);
       this._sequenceNumber += 1;
@@ -138,6 +156,10 @@ class PeraperaAudioProcessor extends AudioWorkletProcessor {
         sampleRate: TARGET_SAMPLE_RATE_HZ,
         channels: 1,
         pcm16Base64,
+        // Issue #110: piggyback で RMS を送る。offscreen 側は audio.frame を
+        // SW 転送する際に rms のみ別 channel (audio.level.forward) にも
+        // broadcast する。
+        rms,
       });
     } catch (cause) {
       // Worklet コンテキストには console があるが、throw すると processor 停止


### PR DESCRIPTION
Closes #110

## Summary

tab capture / マイクから流れる音声が「実際に届いているか / 音量が十分か」を視認できる手段が UI に無い問題を解消。

- AudioWorklet で RMS (0-1) を計算し、既存 `audio.frame` に piggyback
- offscreen → SW → main へ `audio.level.forward` で broadcast (PCM 経路と独立)
- 新 hook `useAudioLevel` + 新 atom `VuMeter`
- `SessionToolbar` info セクションに meter 配置、1 秒以上無音で warning banner

## 受入基準

- [x] AudioWorklet が 100ms フレームごとに RMS を計算 (既存 audio.frame に piggyback)
- [x] offscreen → SW → main window に level を broadcast (`audio.level.forward`)
- [x] `SessionToolbar` に横バー VU メーター (`role="meter"`)
- [x] 1 秒以上 RMS 閾値以下 (0.01) で「音声を検出できません」warning
- [x] PCM データのサイズは現状維持 (RMS は別 message)
- [x] unit test: VuMeter atom (range/clamp/data-level)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 948/948 green
- [x] `pnpm lint` 0 errors
- [ ] 手動: dev ビルドで session 開始 → meter 動作 / 無音時に warning 表示