### PR TITLE
feat(extension): persist main window bounds (#111)

### DIFF
--- a/packages/extension/src/composition/main-window-lifecycle.test.ts
+++ b/packages/extension/src/composition/main-window-lifecycle.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createMainWindowLifecycle,
+  type MainWindowBounds,
+  type MainWindowBoundsStore,
   type MainWindowLifecycle,
   type WindowsApi,
 } from './main-window-lifecycle';
@@ -148,6 +150,162 @@ describe('createMainWindowLifecycle', () => {
       type: 'popup',
       width: 600,
       height: 800,
+    });
+  });
+
+  describe('bounds persistence (Issue #111)', () => {
+    const buildStore = (overrides: Partial<MainWindowBoundsStore> = {}): MainWindowBoundsStore => ({
+      loadBounds: vi.fn(() => Promise.resolve<MainWindowBounds | null>(null)),
+      saveBounds: vi.fn(() => Promise.resolve()),
+      ...overrides,
+    });
+
+    it('restores saved bounds in create options when available', async () => {
+      const api = buildApi();
+      const boundsStore = buildStore({
+        loadBounds: vi.fn(() =>
+          Promise.resolve<MainWindowBounds | null>({
+            top: 100,
+            left: 200,
+            width: 500,
+            height: 700,
+          }),
+        ),
+      });
+      const lifecycle = createMainWindowLifecycle({
+        windowsApi: api,
+        mainWindowUrl: MAIN_URL,
+        boundsStore,
+        logWarn: () => undefined,
+      });
+      await lifecycle.openOrFocus();
+      expect(api.create).toHaveBeenCalledWith({
+        url: MAIN_URL,
+        type: 'popup',
+        top: 100,
+        left: 200,
+        width: 500,
+        height: 700,
+      });
+    });
+
+    it('falls back to default size when loadBounds returns null', async () => {
+      const api = buildApi();
+      const boundsStore = buildStore();
+      const lifecycle = createMainWindowLifecycle({
+        windowsApi: api,
+        mainWindowUrl: MAIN_URL,
+        boundsStore,
+        logWarn: () => undefined,
+      });
+      await lifecycle.openOrFocus();
+      expect(api.create).toHaveBeenCalledWith({
+        url: MAIN_URL,
+        type: 'popup',
+        width: 480,
+        height: 720,
+      });
+    });
+
+    it('persists bounds when onBoundsChanged fires for the tracked window', async () => {
+      let registered: (window: chrome.windows.Window) => void = () => undefined;
+      let captured = false;
+      const api = buildApi({
+        onBoundsChanged: {
+          addListener: (listener) => {
+            registered = listener;
+            captured = true;
+          },
+        },
+        create: vi.fn(() =>
+          Promise.resolve(buildWindow({ id: 42, tabs: [buildTab(MAIN_URL, 7)] })),
+        ),
+      });
+      const boundsStore = buildStore();
+      const lifecycle = createMainWindowLifecycle({
+        windowsApi: api,
+        mainWindowUrl: MAIN_URL,
+        boundsStore,
+        logWarn: () => undefined,
+      });
+      lifecycle.registerBoundsListener();
+      await lifecycle.openOrFocus();
+      expect(registered).not.toBeNull();
+      expect(captured).toBe(true);
+      registered(buildWindow({ id: 42, top: 50, left: 60, width: 700, height: 900 }));
+      expect(boundsStore.saveBounds).toHaveBeenCalledWith({
+        top: 50,
+        left: 60,
+        width: 700,
+        height: 900,
+      });
+    });
+
+    it('ignores bounds events for other windows', async () => {
+      let registered: (window: chrome.windows.Window) => void = () => undefined;
+      let captured = false;
+      const api = buildApi({
+        onBoundsChanged: {
+          addListener: (listener) => {
+            registered = listener;
+            captured = true;
+          },
+        },
+        create: vi.fn(() => Promise.resolve(buildWindow({ id: 1, tabs: [buildTab(MAIN_URL, 7)] }))),
+      });
+      const boundsStore = buildStore();
+      const lifecycle = createMainWindowLifecycle({
+        windowsApi: api,
+        mainWindowUrl: MAIN_URL,
+        boundsStore,
+        logWarn: () => undefined,
+      });
+      lifecycle.registerBoundsListener();
+      await lifecycle.openOrFocus();
+      expect(captured).toBe(true);
+      registered(buildWindow({ id: 999, top: 0, left: 0, width: 300, height: 400 }));
+      expect(boundsStore.saveBounds).not.toHaveBeenCalled();
+    });
+
+    it('ignores events with invalid bounds (missing / below min size)', async () => {
+      let registered: (window: chrome.windows.Window) => void = () => undefined;
+      let captured = false;
+      const api = buildApi({
+        onBoundsChanged: {
+          addListener: (listener) => {
+            registered = listener;
+            captured = true;
+          },
+        },
+        create: vi.fn(() => Promise.resolve(buildWindow({ id: 1, tabs: [buildTab(MAIN_URL, 7)] }))),
+      });
+      const boundsStore = buildStore();
+      const lifecycle = createMainWindowLifecycle({
+        windowsApi: api,
+        mainWindowUrl: MAIN_URL,
+        boundsStore,
+        logWarn: () => undefined,
+      });
+      lifecycle.registerBoundsListener();
+      await lifecycle.openOrFocus();
+      expect(captured).toBe(true);
+      registered(buildWindow({ id: 1, top: 0, left: 0, width: 50, height: 50 }));
+      expect(boundsStore.saveBounds).not.toHaveBeenCalled();
+    });
+
+    it('registerBoundsListener without boundsStore is a noop', () => {
+      const api = buildApi({
+        onBoundsChanged: {
+          addListener: vi.fn(),
+        },
+      });
+      const lifecycle = createMainWindowLifecycle({
+        windowsApi: api,
+        mainWindowUrl: MAIN_URL,
+        logWarn: () => undefined,
+      });
+      lifecycle.registerBoundsListener();
+      expect(api.onBoundsChanged?.addListener).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/extension/src/composition/main-window-lifecycle.ts
+++ b/packages/extension/src/composition/main-window-lifecycle.ts
@@ -3,13 +3,17 @@
  *
  * `chrome.action.onClicked` でアイコンが押されたときに、独立 floating window
  * (type: 'popup', 480×720) を開く / 既存なら focus する idempotent な責務を
- * 分離する。
+ * 分離する。Issue #111 で bounds (top/left/width/height) の永続化を追加
+ * しており、ユーザーが移動した位置を次回以降も保持する。
  *
  * **本番実装で mock を使わない設計**:
- * - `windowsApi` は必須 DI。production では `defaultWindowsApi`
- *   (`chrome.windows` を直接 wrap) を明示注入
+ * - `windowsApi` / `boundsStore` は必須 DI。production では `defaultWindowsApi`
+ *   (`chrome.windows` を直接 wrap) と `createChromeLocalMainWindowBoundsStore`
+ *   (`chrome.storage.local` を直接 wrap) を明示注入
  * - test では fake を注入する
  */
+
+import { z } from 'zod';
 
 export type WindowsApi = Readonly<{
   getAll: (options: { populate: boolean }) => Promise<chrome.windows.Window[]>;
@@ -18,17 +22,106 @@ export type WindowsApi = Readonly<{
     windowId: number,
     updateInfo: chrome.windows.UpdateInfo,
   ) => Promise<chrome.windows.Window>;
+  /**
+   * Issue #111: onBoundsChanged を subscribe するための addListener。
+   * chrome.windows.onBoundsChanged.addListener と同 signature。optional にして
+   * 既存 test の WindowsApi mock との互換を保つ。
+   */
+  onBoundsChanged?:
+    | {
+        addListener: (listener: (window: chrome.windows.Window) => void) => void;
+        removeListener?: (listener: (window: chrome.windows.Window) => void) => void;
+      }
+    | undefined;
 }>;
+
+const buildDefaultOnBoundsChanged = (): WindowsApi['onBoundsChanged'] => {
+  if (typeof chrome === 'undefined' || chrome.windows?.onBoundsChanged === undefined) {
+    return undefined;
+  }
+  return {
+    addListener: (listener) => {
+      chrome.windows.onBoundsChanged.addListener(listener);
+    },
+    removeListener: (listener) => {
+      chrome.windows.onBoundsChanged.removeListener(listener);
+    },
+  };
+};
 
 export const defaultWindowsApi: WindowsApi = {
   getAll: (options) => chrome.windows.getAll(options),
   create: (options) => chrome.windows.create(options),
   update: (windowId, updateInfo) => chrome.windows.update(windowId, updateInfo),
+  onBoundsChanged: buildDefaultOnBoundsChanged(),
 };
 
+export type MainWindowBounds = Readonly<{
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}>;
+
+export type MainWindowBoundsStore = Readonly<{
+  loadBounds: () => Promise<MainWindowBounds | null>;
+  saveBounds: (bounds: MainWindowBounds) => Promise<void>;
+}>;
+
+const boundsSchema = z.object({
+  top: z.number().int(),
+  left: z.number().int(),
+  width: z.number().int().positive().min(100),
+  height: z.number().int().positive().min(100),
+});
+
+const BOUNDS_STORAGE_KEY = 'mainWindowBounds';
+
+/**
+ * Issue #111: chrome.storage.local 上の `mainWindowBounds` への読み書き adapter。
+ * shape 違反は `null` 扱いで fallback、書き込み失敗は silent ignore (ログのみ)。
+ */
+export const createChromeLocalMainWindowBoundsStore = (
+  logWarn: (message: string) => void = (message) => {
+    console.warn(message);
+  },
+): MainWindowBoundsStore => ({
+  loadBounds: async () => {
+    try {
+      const items: Record<string, unknown> = await chrome.storage.local.get(BOUNDS_STORAGE_KEY);
+      const raw: unknown = items[BOUNDS_STORAGE_KEY];
+      if (raw === undefined || raw === null) return null;
+      const parsed = boundsSchema.safeParse(raw);
+      if (!parsed.success) {
+        logWarn(
+          `[perapera] main-window bounds schema invalid: ${parsed.error.issues
+            .map((issue) => issue.message)
+            .join('; ')}`,
+        );
+        return null;
+      }
+      return parsed.data;
+    } catch (cause) {
+      logWarn(`[perapera] main-window boundsStore load failed: ${toMessage(cause)}`);
+      return null;
+    }
+  },
+  saveBounds: async (bounds) => {
+    try {
+      await chrome.storage.local.set({ [BOUNDS_STORAGE_KEY]: bounds });
+    } catch (cause) {
+      logWarn(`[perapera] main-window boundsStore save failed: ${toMessage(cause)}`);
+    }
+  },
+});
+
 export type MainWindowLifecycle = Readonly<{
-  /** 既存の main window があれば focus、なければ新規に create する */
+  /** 既存の main window があれば focus、なければ新規に create する。create 時
+   * に保存済 bounds があれば top/left/width/height を復元する。 */
   openOrFocus: () => Promise<void>;
+  /** chrome.windows.onBoundsChanged を subscribe して main window の bounds を
+   * 永続化する。background listener 配線から 1 度だけ呼ぶ。*/
+  registerBoundsListener: () => void;
 }>;
 
 export type MainWindowLifecycleDependencies = Readonly<{
@@ -40,6 +133,8 @@ export type MainWindowLifecycleDependencies = Readonly<{
   /** window 高さ (default 720) */
   height?: number;
   logWarn?: (message: string) => void;
+  /** Issue #111: 未指定時は bounds の save/restore を行わない (テスト互換) */
+  boundsStore?: MainWindowBoundsStore;
 }>;
 
 const DEFAULT_WIDTH = 480;
@@ -52,12 +147,28 @@ const defaultLogWarn = (message: string): void => {
 const toMessage = (cause: unknown): string =>
   cause instanceof Error ? cause.message : String(cause);
 
+const hasValidBounds = (
+  window: chrome.windows.Window,
+): window is chrome.windows.Window & {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+} =>
+  typeof window.top === 'number' &&
+  typeof window.left === 'number' &&
+  typeof window.width === 'number' &&
+  typeof window.height === 'number' &&
+  window.width >= 100 &&
+  window.height >= 100;
+
 export const createMainWindowLifecycle = (
   deps: MainWindowLifecycleDependencies,
 ): MainWindowLifecycle => {
   const width = deps.width ?? DEFAULT_WIDTH;
   const height = deps.height ?? DEFAULT_HEIGHT;
   const logWarn = deps.logWarn ?? defaultLogWarn;
+  let trackedWindowId: number | null = null;
 
   const findExisting = async (): Promise<chrome.windows.Window | null> => {
     try {
@@ -81,6 +192,7 @@ export const createMainWindowLifecycle = (
     openOrFocus: async () => {
       const existing = await findExisting();
       if (existing?.id !== undefined) {
+        trackedWindowId = existing.id;
         try {
           await deps.windowsApi.update(existing.id, { focused: true });
           return;
@@ -88,16 +200,47 @@ export const createMainWindowLifecycle = (
           logWarn(`[perapera] main-window-lifecycle update failed: ${toMessage(cause)}`);
         }
       }
+      const saved = deps.boundsStore !== undefined ? await deps.boundsStore.loadBounds() : null;
+      const createOptions: chrome.windows.CreateData =
+        saved !== null
+          ? {
+              url: deps.mainWindowUrl,
+              type: 'popup',
+              top: saved.top,
+              left: saved.left,
+              width: saved.width,
+              height: saved.height,
+            }
+          : {
+              url: deps.mainWindowUrl,
+              type: 'popup',
+              width,
+              height,
+            };
       try {
-        await deps.windowsApi.create({
-          url: deps.mainWindowUrl,
-          type: 'popup',
-          width,
-          height,
-        });
+        const created = await deps.windowsApi.create(createOptions);
+        if (created?.id !== undefined) {
+          trackedWindowId = created.id;
+        }
       } catch (cause) {
         logWarn(`[perapera] main-window-lifecycle create failed: ${toMessage(cause)}`);
       }
+    },
+    registerBoundsListener: () => {
+      if (deps.boundsStore === undefined || deps.windowsApi.onBoundsChanged === undefined) {
+        return;
+      }
+      const boundsStore = deps.boundsStore;
+      deps.windowsApi.onBoundsChanged.addListener((window) => {
+        if (trackedWindowId === null || window.id !== trackedWindowId) return;
+        if (!hasValidBounds(window)) return;
+        void boundsStore.saveBounds({
+          top: window.top,
+          left: window.left,
+          width: window.width,
+          height: window.height,
+        });
+      });
     },
   };
 };

--- a/packages/extension/src/entrypoints/background.ts
+++ b/packages/extension/src/entrypoints/background.ts
@@ -4,7 +4,11 @@ import {
   type ExtensionApp,
   type ExtensionRuntimeConfig,
 } from '../composition/extension-composition';
-import { createMainWindowLifecycle, defaultWindowsApi } from '../composition/main-window-lifecycle';
+import {
+  createChromeLocalMainWindowBoundsStore,
+  createMainWindowLifecycle,
+  defaultWindowsApi,
+} from '../composition/main-window-lifecycle';
 import { createOffscreenLifecycle, defaultOffscreenApi } from '../composition/offscreen-lifecycle';
 import { createRuntimeDispatcher, type RuntimeDispatcher } from '../composition/runtime-dispatcher';
 
@@ -109,10 +113,14 @@ export default defineBackground(() => {
   // 既存 window があれば focus する idempotent 動作。manifest.action.default_popup
   // は未設定 (wxt.config.ts) なので、本 listener が発火する。
   const mainWindowUrl = chrome.runtime.getURL('/main.html');
+  // Issue #111: main window の位置 / サイズを chrome.storage.local に永続化
+  const mainWindowBoundsStore = createChromeLocalMainWindowBoundsStore();
   const mainWindowLifecycle = createMainWindowLifecycle({
     windowsApi: defaultWindowsApi,
     mainWindowUrl,
+    boundsStore: mainWindowBoundsStore,
   });
+  mainWindowLifecycle.registerBoundsListener();
   chrome.action.onClicked.addListener((tab) => {
     // action icon クリックは activeTab permission を「クリック時にアクティブだった
     // tab」に対してのみ grant する。main window は独立 window として開くため、


### PR DESCRIPTION
Closes #111

## Summary

main window を閉じて再度開くたびに Chrome デフォルト位置に戻される問題を解消。`chrome.storage.local.mainWindowBounds` に位置 / サイズを保存し、次回起動時に復元する。

- `WindowsApi` に `onBoundsChanged.addListener` を追加
- 新 port `MainWindowBoundsStore` + `createChromeLocalMainWindowBoundsStore` 実装 (Zod schema 検証)
- `createMainWindowLifecycle.openOrFocus` で保存済 bounds を `chrome.windows.create` に渡す
- `registerBoundsListener()` で自 window の bounds 変化を監視し保存 (他 window や 100 未満サイズは ignore)
- `background.ts` で配線

## 受入基準

- [x] `chrome.windows.onBoundsChanged` で bounds を `chrome.storage.local.mainWindowBounds` に保存
- [x] `createMainWindowLifecycle.openOrFocus` で create 時に復元
- [x] shape 違反 / サイズ異常値は fallback (480×720 / top·left 未指定 = Chrome 既定)
- [ ] `state: 'maximized' / 'minimized' / 'fullscreen'` は option 扱いで今回スコープ外
- [x] unit test: lifecycle + storage round-trip (6 件追加)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 954/954 green
- [x] `pnpm lint` 0 errors (既存 IDB cursor 警告のみ)
- [ ] 手動: dev ビルドで main window を端に移動 → 閉じる → アイコン再クリックで同じ位置に開くことを確認