### PR TITLE
feat(extension): add keyboard shortcuts via chrome.commands (#112)

### DIFF
--- a/packages/extension/src/composition/extension-composition.ts
+++ b/packages/extension/src/composition/extension-composition.ts
@@ -103,6 +103,7 @@ import {
   type WebSocketFactory,
 } from '../infrastructure/relay/websocket-factory';
 import { type SettingsStore } from '../application/ports/settings-store';
+import { type SourceSessionRepository } from '../domain/repositories/source-session-repository';
 import {
   createChromeLocalExtensionProfileRepository,
   createChromeLocalSettingsStore,
@@ -234,6 +235,8 @@ export type ExtensionApp = Readonly<{
   ensureDefaultProfile: EnsureDefaultProfile;
   transcriptAssembler: TranscriptAssembler;
   settingsStore: SettingsStore;
+  /** Issue #112: keyboard shortcut 経由の active session 検索に公開 */
+  sourceSessionRepository: SourceSessionRepository;
   close: () => Promise<void>;
 }>;
 
@@ -450,6 +453,7 @@ export const createExtensionApp = (
     ensureDefaultProfile,
     transcriptAssembler,
     settingsStore,
+    sourceSessionRepository,
     close: async () => {
       relaySessionSubscriber.stopAll();
       audioFramePump.stopAll();

--- a/packages/extension/src/composition/keyboard-command-handler.test.ts
+++ b/packages/extension/src/composition/keyboard-command-handler.test.ts
@@ -1,0 +1,215 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLanguagePair } from '../domain/session/language-pair';
+import { createSourceSession, type SourceSession } from '../domain/session/source-session';
+import { invariantViolationError } from '../domain/shared/errors';
+import {
+  OPEN_MAIN_WINDOW_COMMAND,
+  STOP_ACTIVE_SESSION_COMMAND,
+  registerKeyboardCommandHandler,
+  type ChromeCommandsApi,
+  type KeyboardCommandHandlerDependencies,
+} from './keyboard-command-handler';
+
+const SESSION_ID_A = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SESSION_ID_B = '01HZX8Y1R8M7D3Q2P4T5V6W7A2';
+const SOURCE_ID = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+
+const buildSession = (sessionId: string): SourceSession =>
+  createSourceSession({
+    sessionIdentifier: sessionId,
+    sourceIdentifier: SOURCE_ID,
+    sourceType: 'tab',
+    languagePair: createLanguagePair({ source: 'en-US', target: 'ja-JP' })._unsafeUnwrap(),
+    startedAt: '2026-04-21T00:00:00.000Z',
+  })._unsafeUnwrap();
+
+type ListenerCapture = {
+  listener: (command: string) => void;
+  captured: boolean;
+};
+
+const buildCommandsApi = (capture: ListenerCapture): ChromeCommandsApi => ({
+  onCommand: {
+    addListener: (listener) => {
+      capture.listener = listener;
+      capture.captured = true;
+    },
+  },
+});
+
+const buildDependencies = (
+  overrides: Partial<KeyboardCommandHandlerDependencies> = {},
+): { deps: KeyboardCommandHandlerDependencies; capture: ListenerCapture } => {
+  const capture: ListenerCapture = { listener: () => undefined, captured: false };
+  const deps: KeyboardCommandHandlerDependencies = {
+    commandsApi: buildCommandsApi(capture),
+    mainWindowLifecycle: {
+      openOrFocus: vi.fn(() => Promise.resolve()),
+    },
+    sessionCommandService: {
+      stopSource: vi.fn(() =>
+        okAsync({
+          sessionId: SESSION_ID_A,
+          state: 'stopped',
+          stoppedAt: '2026-04-21T00:10:00.000Z',
+        }),
+      ),
+    },
+    sourceSessionRepository: {
+      findActiveSessions: vi.fn(() => okAsync([])),
+    },
+    logWarn: vi.fn(),
+    logInfo: vi.fn(),
+    ...overrides,
+  };
+  return { deps, capture };
+};
+
+describe('registerKeyboardCommandHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers a listener on chrome.commands.onCommand', () => {
+    const { deps, capture } = buildDependencies();
+    registerKeyboardCommandHandler(deps);
+    expect(capture.captured).toBe(true);
+  });
+
+  it('invokes MainWindowLifecycle.openOrFocus on open-main-window command', () => {
+    const { deps, capture } = buildDependencies();
+    registerKeyboardCommandHandler(deps);
+    capture.listener(OPEN_MAIN_WINDOW_COMMAND);
+    expect(deps.mainWindowLifecycle.openOrFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs warning when openOrFocus rejects', async () => {
+    const logWarn = vi.fn();
+    const { deps, capture } = buildDependencies({
+      mainWindowLifecycle: {
+        openOrFocus: vi.fn(() => Promise.reject(new Error('window boom'))),
+      },
+      logWarn,
+    });
+    registerKeyboardCommandHandler(deps);
+    capture.listener(OPEN_MAIN_WINDOW_COMMAND);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(logWarn).toHaveBeenCalled();
+  });
+
+  it('calls stopSource for each active session on stop-active-session command', async () => {
+    const activeA = buildSession(SESSION_ID_A);
+    const activeB = buildSession(SESSION_ID_B);
+    const stopSource = vi.fn(() =>
+      okAsync({
+        sessionId: SESSION_ID_A,
+        state: 'stopped',
+        stoppedAt: '2026-04-21T00:10:00.000Z',
+      }),
+    );
+    const { deps, capture } = buildDependencies({
+      sourceSessionRepository: {
+        findActiveSessions: vi.fn(() => okAsync([activeA, activeB])),
+      },
+      sessionCommandService: {
+        stopSource,
+      },
+    });
+    registerKeyboardCommandHandler(deps);
+    capture.listener(STOP_ACTIVE_SESSION_COMMAND);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(stopSource).toHaveBeenCalledTimes(2);
+    expect(stopSource).toHaveBeenNthCalledWith(1, { sessionId: SESSION_ID_A });
+    expect(stopSource).toHaveBeenNthCalledWith(2, { sessionId: SESSION_ID_B });
+  });
+
+  it('no-op (no error) when there are no active sessions', async () => {
+    const stopSource = vi.fn(() =>
+      okAsync({
+        sessionId: SESSION_ID_A,
+        state: 'stopped',
+        stoppedAt: '2026-04-21T00:10:00.000Z',
+      }),
+    );
+    const logInfo = vi.fn();
+    const { deps, capture } = buildDependencies({
+      sourceSessionRepository: {
+        findActiveSessions: vi.fn(() => okAsync([])),
+      },
+      sessionCommandService: { stopSource },
+      logInfo,
+    });
+    registerKeyboardCommandHandler(deps);
+    capture.listener(STOP_ACTIVE_SESSION_COMMAND);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(stopSource).not.toHaveBeenCalled();
+    expect(
+      logInfo.mock.calls.some(
+        (call) => typeof call[0] === 'string' && call[0].includes('no active session'),
+      ),
+    ).toBe(true);
+  });
+
+  it('logs warning when findActiveSessions fails', async () => {
+    const logWarn = vi.fn();
+    const { deps, capture } = buildDependencies({
+      sourceSessionRepository: {
+        findActiveSessions: vi.fn(() =>
+          errAsync(
+            invariantViolationError({
+              invariant: 'storage-read-integrity',
+              details: 'boom',
+            }),
+          ),
+        ),
+      },
+      logWarn,
+    });
+    registerKeyboardCommandHandler(deps);
+    capture.listener(STOP_ACTIVE_SESSION_COMMAND);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(logWarn).toHaveBeenCalled();
+  });
+
+  it('logs warning when stopSource returns err for a session', async () => {
+    const logWarn = vi.fn();
+    const active = buildSession(SESSION_ID_A);
+    const { deps, capture } = buildDependencies({
+      sourceSessionRepository: {
+        findActiveSessions: vi.fn(() => okAsync([active])),
+      },
+      sessionCommandService: {
+        stopSource: vi.fn(() =>
+          errAsync({
+            type: 'internal' as const,
+            code: 'INTERNAL_ERROR' as const,
+            message: 'stop failed',
+          }),
+        ),
+      },
+      logWarn,
+    });
+    registerKeyboardCommandHandler(deps);
+    capture.listener(STOP_ACTIVE_SESSION_COMMAND);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(logWarn).toHaveBeenCalled();
+  });
+
+  it('ignores unknown command names without throwing', () => {
+    const { deps, capture } = buildDependencies();
+    registerKeyboardCommandHandler(deps);
+    expect(() => {
+      capture.listener('some-future-unknown-command');
+    }).not.toThrow();
+    expect(deps.mainWindowLifecycle.openOrFocus).not.toHaveBeenCalled();
+    expect(deps.sourceSessionRepository.findActiveSessions).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/src/composition/keyboard-command-handler.ts
+++ b/packages/extension/src/composition/keyboard-command-handler.ts
@@ -1,0 +1,104 @@
+/**
+ * Issue #112: chrome.commands キーボードショートカット配線 helper。
+ *
+ * background service worker から呼ばれ、`chrome.commands.onCommand` listener を
+ * 登録する。2 つの command を扱う:
+ *
+ * - `open-main-window`: MainWindowLifecycle.openOrFocus() を呼ぶ
+ * - `stop-active-session`: 全活性 SourceSession を sessionCommandService 経由で停止
+ *
+ * DI を挟むことで unit test で chrome.commands / 依存 service を mock 可能にする。
+ */
+
+import { type SessionCommandService } from '../application/services/session-command-service';
+import { type SourceSessionRepository } from '../domain/repositories/source-session-repository';
+import { describeDomainError } from '../domain/shared/errors';
+import { type MainWindowLifecycle } from './main-window-lifecycle';
+
+export type ChromeCommandsApi = Readonly<{
+  onCommand: {
+    addListener: (listener: (command: string) => void) => void;
+    removeListener?: (listener: (command: string) => void) => void;
+  };
+}>;
+
+export const defaultChromeCommandsApi: ChromeCommandsApi = {
+  onCommand: {
+    addListener: (listener) => {
+      chrome.commands.onCommand.addListener(listener);
+    },
+    removeListener: (listener) => {
+      chrome.commands.onCommand.removeListener(listener);
+    },
+  },
+};
+
+export const OPEN_MAIN_WINDOW_COMMAND = 'open-main-window';
+export const STOP_ACTIVE_SESSION_COMMAND = 'stop-active-session';
+
+export type KeyboardCommandHandlerDependencies = Readonly<{
+  commandsApi: ChromeCommandsApi;
+  mainWindowLifecycle: Pick<MainWindowLifecycle, 'openOrFocus'>;
+  sessionCommandService: Pick<SessionCommandService, 'stopSource'>;
+  sourceSessionRepository: Pick<SourceSessionRepository, 'findActiveSessions'>;
+  logWarn?: (message: string, cause?: unknown) => void;
+  logInfo?: (message: string) => void;
+}>;
+
+const defaultLogWarn = (message: string, cause?: unknown): void => {
+  if (cause === undefined) console.warn(message);
+  else console.warn(message, cause);
+};
+
+const defaultLogInfo = (message: string): void => {
+  console.log(message);
+};
+
+/**
+ * chrome.commands.onCommand listener を登録する。idempotent ではないため
+ * 1 度だけ呼ぶこと (SW 初期化時)。
+ */
+export const registerKeyboardCommandHandler = (deps: KeyboardCommandHandlerDependencies): void => {
+  const logWarn = deps.logWarn ?? defaultLogWarn;
+  const logInfo = deps.logInfo ?? defaultLogInfo;
+
+  deps.commandsApi.onCommand.addListener((command) => {
+    if (command === OPEN_MAIN_WINDOW_COMMAND) {
+      logInfo('[perapera] keyboard: open-main-window');
+      void deps.mainWindowLifecycle.openOrFocus().catch((cause: unknown) => {
+        logWarn('[perapera] keyboard: open-main-window failed', cause);
+      });
+      return;
+    }
+
+    if (command === STOP_ACTIVE_SESSION_COMMAND) {
+      logInfo('[perapera] keyboard: stop-active-session');
+      void deps.sourceSessionRepository.findActiveSessions().match(
+        (sessions) => {
+          if (sessions.length === 0) {
+            logInfo('[perapera] keyboard: stop-active-session — no active session');
+            return;
+          }
+          for (const session of sessions) {
+            void deps.sessionCommandService
+              .stopSource({ sessionId: session.sessionIdentifier })
+              .match(
+                () => {
+                  logInfo(`[perapera] keyboard: stopped session ${session.sessionIdentifier}`);
+                },
+                (error) => {
+                  logWarn('[perapera] keyboard: stopSource failed', error);
+                },
+              );
+          }
+        },
+        (error) => {
+          logWarn(`[perapera] keyboard: findActiveSessions failed: ${describeDomainError(error)}`);
+        },
+      );
+      return;
+    }
+
+    // 未知の command は silent ignore (Chrome が送る可能性がある内部 command 用)
+  });
+};

--- a/packages/extension/src/entrypoints/background.ts
+++ b/packages/extension/src/entrypoints/background.ts
@@ -5,6 +5,10 @@ import {
   type ExtensionRuntimeConfig,
 } from '../composition/extension-composition';
 import {
+  defaultChromeCommandsApi,
+  registerKeyboardCommandHandler,
+} from '../composition/keyboard-command-handler';
+import {
   createChromeLocalMainWindowBoundsStore,
   createMainWindowLifecycle,
   defaultWindowsApi,
@@ -185,6 +189,15 @@ export default defineBackground(() => {
       console.warn('[perapera] ensureDefaultProfile failed:', error);
     },
   );
+
+  // Issue #112: chrome.commands キーボードショートカット。
+  // `open-main-window` / `stop-active-session` を配線する。
+  registerKeyboardCommandHandler({
+    commandsApi: defaultChromeCommandsApi,
+    mainWindowLifecycle,
+    sessionCommandService: app.sessionCommandService,
+    sourceSessionRepository: app.sourceSessionRepository,
+  });
 
   const dispatch: RuntimeDispatcher = createRuntimeDispatcher({
     sessionCommandService: app.sessionCommandService,

--- a/packages/extension/wxt.config.ts
+++ b/packages/extension/wxt.config.ts
@@ -31,6 +31,25 @@ export default defineConfig({
     action: {
       default_title: 'perapera',
     },
+    // Issue #112: chrome.commands によるキーボードショートカット。
+    // 既定キーはユーザが chrome://extensions/shortcuts から変更可能。
+    // Chrome の仕様上 Alt キーは Mac では Option として機能する。
+    commands: {
+      'open-main-window': {
+        suggested_key: {
+          default: 'Alt+Shift+P',
+          mac: 'Alt+Shift+P',
+        },
+        description: 'perapera の main window を起動 / focus する',
+      },
+      'stop-active-session': {
+        suggested_key: {
+          default: 'Alt+Shift+S',
+          mac: 'Alt+Shift+S',
+        },
+        description: '活性セッションを停止する',
+      },
+    },
     web_accessible_resources: [
       {
         resources: ['main.html'],


### PR DESCRIPTION
## Summary

Closes #112. main window 起動 / active session 停止のキーボードショートカットを `chrome.commands` で追加。action icon が出ない場面 (フルスクリーン等) でも拡張を操作可能にする。

- `wxt.config.ts` manifest.commands:
  - `open-main-window`: Alt+Shift+P (Mac は Option+Shift+P として動作) → `MainWindowLifecycle.openOrFocus()`
  - `stop-active-session`: Alt+Shift+S → 全活性 `SourceSession` を `sessionCommandService.stopSource` で停止
- `background.ts` で `registerKeyboardCommandHandler` 経由で `chrome.commands.onCommand` を配線
- `ExtensionApp` に `sourceSessionRepository` を公開 (active session 検索用)
- 既定キーは `suggested_key` のみ — ユーザは `chrome://extensions/shortcuts` から変更可能

## Test plan

- [x] `pnpm typecheck` (extension workspace)
- [x] `pnpm test --run` — 962 tests passed (8 new keyboard-command-handler tests)
- [x] `pnpm lint` — 0 errors (1 pre-existing warning in open-perapera-db.ts unrelated to this PR)
- [x] `pnpm exec wxt build` — manifest.json に `commands` が正しく出力されることを確認
- [ ] 手動: dev ビルドで chrome://extensions/shortcuts からショートカット表示確認
- [ ] 手動: Alt+Shift+P で main window が起動 / focus される
- [ ] 手動: session 起動後 Alt+Shift+S で stop される

## Files changed

- `packages/extension/wxt.config.ts` — manifest.commands 追加
- `packages/extension/src/composition/extension-composition.ts` — `sourceSessionRepository` を export
- `packages/extension/src/composition/keyboard-command-handler.ts` (新規) — listener 配線 helper
- `packages/extension/src/composition/keyboard-command-handler.test.ts` (新規) — 8 test
- `packages/extension/src/entrypoints/background.ts` — `registerKeyboardCommandHandler` を呼ぶ