### PR TITLE
feat(extension): full-text search for session history (#125)

### DIFF
--- a/docs/in-progress/03-detailed-design/domain.md
+++ b/docs/in-progress/03-detailed-design/domain.md
@@ -213,6 +213,7 @@ classDiagram
 | DD-237 | TranslationContextWindow | ソースセッション集約                        | `maxSegments` / `includeTranslatedText` の一致                      | `maxSegments` は 0〜5（既定 3）、`includeTranslatedText` は boolean（既定 true）                                                             |
 | DD-238 | Glossary                 | ソースセッション集約 / 拡張プロファイル集約 | `entries` の原文・訳文・caseSensitive 完全一致                      | `entries` は最大 200 件、各 entry の `source` / `target` は 1〜64 文字、`source !== target`、`entries` 内の `source` は一意 (case-sensitive) |
 | DD-239 | SessionRetentionPolicy   | 拡張プロファイル集約                        | `days` / `maxCount` の一致                                          | `days` は 1〜365 または null、`maxCount` は 1〜10000 または null、少なくとも一方は非 null (両方 null 不可、既定 30 日 / 100 件)              |
+| DD-261 | TranscriptSearchQuery    | 字幕ストリーム集約 (検索 API 入力)          | `keyword` / `language` / `caseSensitive` の一致                     | `keyword` は 1〜256 文字、`language` は `source` / `target` / `both`、`caseSensitive` は boolean                                             |
 
 ## 7. ドメインサービス
 

--- a/packages/extension/src/application/use-cases/get-session-monitor-state-query.test.ts
+++ b/packages/extension/src/application/use-cases/get-session-monitor-state-query.test.ts
@@ -87,6 +87,7 @@ const buildDependencies = (
     appendPartial: vi.fn(() => okAsync(undefined)),
     appendFinal: vi.fn(() => okAsync(undefined)),
     appendTranslation: vi.fn(() => okAsync(undefined)),
+    search: vi.fn(() => okAsync([])),
   };
   const settingsStore: SettingsStore = {
     getDefaultLanguagePair: vi.fn(() =>
@@ -186,6 +187,7 @@ describe('createGetSessionMonitorStateQuery (IMPL-211, DD-302)', () => {
         appendPartial: vi.fn(() => okAsync(undefined)),
         appendFinal: vi.fn(() => okAsync(undefined)),
         appendTranslation: vi.fn(() => okAsync(undefined)),
+        search: vi.fn(() => okAsync([])),
       },
     });
     const query = createGetSessionMonitorStateQuery(deps);

--- a/packages/extension/src/application/use-cases/handle-transcript-final-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/handle-transcript-final-use-case.test.ts
@@ -67,6 +67,7 @@ const buildDependencies = (
     appendPartial: vi.fn(() => okAsync(undefined)),
     appendFinal: vi.fn(() => okAsync(undefined)),
     appendTranslation: vi.fn(() => okAsync(undefined)),
+    search: vi.fn(() => okAsync([])),
   };
   const overlayPresenter: OverlayPresenter = {
     mount: vi.fn(() => okAsync(undefined)),
@@ -198,6 +199,7 @@ describe('createHandleTranscriptFinalUseCase (IMPL-214, DD-305)', () => {
         appendPartial: vi.fn(() => okAsync<void, DomainError>(undefined)),
         appendFinal: vi.fn(() => okAsync<void, DomainError>(undefined)),
         appendTranslation: vi.fn(() => okAsync<void, DomainError>(undefined)),
+        search: vi.fn(() => okAsync([])),
       },
     });
     const useCase = createHandleTranscriptFinalUseCase(deps);
@@ -263,6 +265,7 @@ describe('createHandleTranscriptFinalUseCase (IMPL-214, DD-305)', () => {
         appendPartial: vi.fn(() => okAsync(undefined)),
         appendFinal: vi.fn(() => okAsync(undefined)),
         appendTranslation: vi.fn(() => okAsync(undefined)),
+        search: vi.fn(() => okAsync([])),
       },
     });
     const useCase = createHandleTranscriptFinalUseCase(deps);

--- a/packages/extension/src/application/use-cases/handle-transcript-partial-use-case.test.ts
+++ b/packages/extension/src/application/use-cases/handle-transcript-partial-use-case.test.ts
@@ -47,6 +47,7 @@ const buildDependencies = (
     appendPartial: vi.fn(() => okAsync(undefined)),
     appendFinal: vi.fn(() => okAsync(undefined)),
     appendTranslation: vi.fn(() => okAsync(undefined)),
+    search: vi.fn(() => okAsync([])),
   };
   const overlayPresenter: OverlayPresenter = {
     mount: vi.fn(() => okAsync(undefined)),
@@ -157,6 +158,7 @@ describe('createHandleTranscriptPartialUseCase (IMPL-213, DD-304)', () => {
         appendPartial: appendPartialMock,
         appendFinal: vi.fn(() => okAsync(undefined)),
         appendTranslation: vi.fn(() => okAsync(undefined)),
+        search: vi.fn(() => okAsync([])),
       },
     });
     const useCase = createHandleTranscriptPartialUseCase(deps);
@@ -206,6 +208,7 @@ describe('createHandleTranscriptPartialUseCase (IMPL-213, DD-304)', () => {
         ),
         appendFinal: vi.fn(() => okAsync(undefined)),
         appendTranslation: vi.fn(() => okAsync(undefined)),
+        search: vi.fn(() => okAsync([])),
       },
     });
     const useCase = createHandleTranscriptPartialUseCase(deps);

--- a/packages/extension/src/application/use-cases/search-session-history-query.test.ts
+++ b/packages/extension/src/application/use-cases/search-session-history-query.test.ts
@@ -1,0 +1,109 @@
+import { okAsync } from 'neverthrow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type TranscriptSearchMatch,
+  type TranscriptStreamRepository,
+} from '../../domain/repositories/transcript-stream-repository';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
+import { type DomainError } from '../../domain/shared/errors';
+import { createSearchSessionHistoryQuery } from './search-session-history-query';
+
+const SESSION_A = '01HZX8Y1R8M7D3Q2P4T5V6W7A1';
+const SESSION_B = '01HZX8Y1R8M7D3Q2P4T5V6W7B1';
+
+const buildRepo = (matches: readonly TranscriptSearchMatch[]): TranscriptStreamRepository => ({
+  findBySessionId: vi.fn(),
+  appendPartial: vi.fn(),
+  appendFinal: vi.fn(),
+  appendTranslation: vi.fn(),
+  search: vi.fn(() => okAsync<readonly TranscriptSearchMatch[], DomainError>(matches)),
+});
+
+const matchFor = (
+  session: SessionIdentifier,
+  segmentId: string,
+  matchedLanguage: 'source' | 'target',
+  startTimeMs: number,
+): TranscriptSearchMatch => ({
+  sessionIdentifier: session,
+  segmentIdentifier: segmentId,
+  snippet: '…hello world…',
+  matchedLanguage,
+  startTimeMs,
+});
+
+describe('createSearchSessionHistoryQuery (IMPL-218, DD-261, Issue #125)', () => {
+  const sessionA: SessionIdentifier = parseSessionIdentifier(SESSION_A)._unsafeUnwrap();
+  const sessionB: SessionIdentifier = parseSessionIdentifier(SESSION_B)._unsafeUnwrap();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns matches grouped by session', async () => {
+    const repo = buildRepo([
+      matchFor(sessionA, 'seg-a1', 'source', 1000),
+      matchFor(sessionA, 'seg-a2', 'source', 2000),
+      matchFor(sessionB, 'seg-b1', 'target', 3000),
+    ]);
+    const query = createSearchSessionHistoryQuery({ transcriptStreamRepository: repo });
+    const result = await query({ keyword: 'hello', language: 'both', caseSensitive: false });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const sessions = result.value.sessions;
+      expect(sessions).toHaveLength(2);
+      const groupA = sessions.find((s) => s.sessionIdentifier === SESSION_A);
+      expect(groupA?.matches).toHaveLength(2);
+      const groupB = sessions.find((s) => s.sessionIdentifier === SESSION_B);
+      expect(groupB?.matches).toHaveLength(1);
+    }
+  });
+
+  it('limits each session to 5 matches maximum', async () => {
+    const matches: TranscriptSearchMatch[] = Array.from({ length: 10 }, (_, i) =>
+      matchFor(sessionA, `seg-${String(i)}`, 'source', 1000 * (i + 1)),
+    );
+    const repo = buildRepo(matches);
+    const query = createSearchSessionHistoryQuery({ transcriptStreamRepository: repo });
+    const result = await query({ keyword: 'x', language: 'source', caseSensitive: false });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const groupA = result.value.sessions[0];
+      expect(groupA?.matches).toHaveLength(5);
+    }
+  });
+
+  it('returns empty sessions when no matches', async () => {
+    const repo = buildRepo([]);
+    const query = createSearchSessionHistoryQuery({ transcriptStreamRepository: repo });
+    const result = await query({ keyword: 'nothing', language: 'both', caseSensitive: false });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value.sessions).toHaveLength(0);
+  });
+
+  it('rejects invalid keyword', async () => {
+    const repo = buildRepo([]);
+    const query = createSearchSessionHistoryQuery({ transcriptStreamRepository: repo });
+    const result = await query({ keyword: '', language: 'both', caseSensitive: false });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.type).toBe('validation');
+  });
+
+  it('sorts session matches by startTimeMs ascending within group', async () => {
+    const repo = buildRepo([
+      matchFor(sessionA, 'seg-late', 'source', 5000),
+      matchFor(sessionA, 'seg-early', 'source', 1000),
+    ]);
+    const query = createSearchSessionHistoryQuery({ transcriptStreamRepository: repo });
+    const result = await query({ keyword: 'x', language: 'source', caseSensitive: false });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const groupA = result.value.sessions[0];
+      expect(groupA?.matches[0]?.startTimeMs).toBe(1000);
+      expect(groupA?.matches[1]?.startTimeMs).toBe(5000);
+    }
+  });
+});

--- a/packages/extension/src/application/use-cases/search-session-history-query.ts
+++ b/packages/extension/src/application/use-cases/search-session-history-query.ts
@@ -1,0 +1,81 @@
+import { type ResultAsync } from 'neverthrow';
+import {
+  type TranscriptSearchMatch,
+  type TranscriptStreamRepository,
+} from '../../domain/repositories/transcript-stream-repository';
+import { createTranscriptSearchQuery } from '../../domain/search';
+import { toApplicationError, type ApplicationError } from '../errors/application-errors';
+
+export type SearchSessionHistoryInput = Readonly<{
+  keyword: string;
+  language: 'source' | 'target' | 'both';
+  caseSensitive: boolean;
+}>;
+
+export type SearchSessionHistorySessionGroup = Readonly<{
+  sessionIdentifier: string;
+  matches: readonly {
+    segmentIdentifier: string;
+    snippet: string;
+    matchedLanguage: 'source' | 'target';
+    startTimeMs: number;
+  }[];
+}>;
+
+export type SearchSessionHistoryOutput = Readonly<{
+  sessions: readonly SearchSessionHistorySessionGroup[];
+}>;
+
+export type SearchSessionHistoryDependencies = Readonly<{
+  transcriptStreamRepository: TranscriptStreamRepository;
+}>;
+
+export type SearchSessionHistoryQuery = (
+  input: SearchSessionHistoryInput,
+) => ResultAsync<SearchSessionHistoryOutput, ApplicationError>;
+
+const MAX_MATCHES_PER_SESSION = 5 as const;
+
+const groupBySession = (
+  matches: readonly TranscriptSearchMatch[],
+): readonly SearchSessionHistorySessionGroup[] => {
+  const buckets = new Map<string, TranscriptSearchMatch[]>();
+  for (const match of matches) {
+    const key = match.sessionIdentifier;
+    const bucket = buckets.get(key);
+    if (bucket === undefined) {
+      buckets.set(key, [match]);
+    } else {
+      bucket.push(match);
+    }
+  }
+  return [...buckets.entries()].map(([sessionIdentifier, items]) => {
+    const sorted = [...items].sort((a, b) => a.startTimeMs - b.startTimeMs);
+    return {
+      sessionIdentifier,
+      matches: sorted.slice(0, MAX_MATCHES_PER_SESSION).map((match) => ({
+        segmentIdentifier: match.segmentIdentifier,
+        snippet: match.snippet,
+        matchedLanguage: match.matchedLanguage,
+        startTimeMs: match.startTimeMs,
+      })),
+    };
+  });
+};
+
+/**
+ * IMPL-218 SearchSessionHistoryQuery (DD-261, Issue #125)。
+ *
+ * セッション履歴画面の全文検索。`TranscriptStreamRepository.search` で
+ * transcript / translation を linear scan し、session 単位にグループ化して
+ * 各 session 最大 5 match に絞る (UI 表示安定性のため)。
+ */
+export const createSearchSessionHistoryQuery = (
+  deps: SearchSessionHistoryDependencies,
+): SearchSessionHistoryQuery => {
+  return (input) =>
+    createTranscriptSearchQuery(input)
+      .asyncAndThen((query) => deps.transcriptStreamRepository.search(query))
+      .map((matches): SearchSessionHistoryOutput => ({ sessions: groupBySession(matches) }))
+      .mapErr(toApplicationError);
+};

--- a/packages/extension/src/composition/extension-composition.ts
+++ b/packages/extension/src/composition/extension-composition.ts
@@ -18,6 +18,10 @@ import {
   createPurgeExpiredSessionsUseCase,
   type PurgeExpiredSessionsUseCase,
 } from '../application/use-cases/purge-expired-sessions-use-case';
+import {
+  createSearchSessionHistoryQuery,
+  type SearchSessionHistoryQuery,
+} from '../application/use-cases/search-session-history-query';
 import { createGetSessionMonitorStateQuery } from '../application/use-cases/get-session-monitor-state-query';
 import { createHandleTranscriptFinalUseCase } from '../application/use-cases/handle-transcript-final-use-case';
 import { createHandleTranscriptPartialUseCase } from '../application/use-cases/handle-transcript-partial-use-case';
@@ -242,6 +246,7 @@ export type ExtensionApp = Readonly<{
   getGlossaryQuery: GetGlossaryQuery;
   updateGlossaryUseCase: UpdateGlossaryUseCase;
   purgeExpiredSessionsUseCase: PurgeExpiredSessionsUseCase;
+  searchSessionHistoryQuery: SearchSessionHistoryQuery;
   sessionRegistry: SessionRegistry;
   captureOrchestrator: CaptureOrchestrator;
   audioFramePump: AudioFramePump;
@@ -448,6 +453,9 @@ export const createExtensionApp = (
     settingsStore,
     clock: ports.clockIso,
   });
+  const searchSessionHistoryQuery = createSearchSessionHistoryQuery({
+    transcriptStreamRepository,
+  });
 
   // --------------- Application services (Phase 3 facades) ---------------
   const sessionCommandService = createSessionCommandService({
@@ -476,6 +484,7 @@ export const createExtensionApp = (
     getGlossaryQuery,
     updateGlossaryUseCase,
     purgeExpiredSessionsUseCase,
+    searchSessionHistoryQuery,
     sessionStore,
     sessionRegistry,
     captureOrchestrator,

--- a/packages/extension/src/composition/runtime-dispatcher.test.ts
+++ b/packages/extension/src/composition/runtime-dispatcher.test.ts
@@ -82,6 +82,7 @@ const buildFakeDeps = () => {
   const purgeExpiredSessionsUseCase = vi.fn(() =>
     okAsync({ purgedSessionIds: [], totalPurged: 0 }),
   );
+  const searchSessionHistoryQuery = vi.fn(() => okAsync({ sessions: [] }));
   const sessionStore: SessionStore = {
     saveSession: vi.fn(() => okAsync(undefined)),
     appendTranscript: vi.fn(() => okAsync(undefined)),
@@ -100,6 +101,7 @@ const buildFakeDeps = () => {
     getGlossaryQuery,
     updateGlossaryUseCase,
     purgeExpiredSessionsUseCase,
+    searchSessionHistoryQuery,
     sessionStore,
     settingsStore,
   };

--- a/packages/extension/src/composition/runtime-dispatcher.ts
+++ b/packages/extension/src/composition/runtime-dispatcher.ts
@@ -12,6 +12,7 @@ import { type GetSessionHistoryDetailQuery } from '../application/use-cases/get-
 import { type GetSessionHistoryQuery } from '../application/use-cases/get-session-history-query';
 import { type GetSessionMonitorStateQuery } from '../application/use-cases/get-session-monitor-state-query';
 import { type PurgeExpiredSessionsUseCase } from '../application/use-cases/purge-expired-sessions-use-case';
+import { type SearchSessionHistoryQuery } from '../application/use-cases/search-session-history-query';
 import { type UpdateGlossaryUseCase } from '../application/use-cases/update-glossary-use-case';
 import { createOverlaySettings, type OverlaySettings } from '../domain/profile/overlay-settings';
 import {
@@ -53,6 +54,7 @@ export type RuntimeDispatcherDependencies = Readonly<{
   getGlossaryQuery: GetGlossaryQuery;
   updateGlossaryUseCase: UpdateGlossaryUseCase;
   purgeExpiredSessionsUseCase: PurgeExpiredSessionsUseCase;
+  searchSessionHistoryQuery: SearchSessionHistoryQuery;
   sessionStore: SessionStore;
   settingsStore: SettingsStore;
 }>;
@@ -312,6 +314,8 @@ export const createRuntimeDispatcher = (deps: RuntimeDispatcherDependencies): Ru
             }))
             .mapErr(toApplicationError),
         );
+      case 'query.search-session-history':
+        return run(deps.searchSessionHistoryQuery(request.input));
       case 'query.get-session-history':
         return run(deps.getSessionHistoryQuery({}));
       case 'query.get-session-history-detail':

--- a/packages/extension/src/composition/runtime-messages.ts
+++ b/packages/extension/src/composition/runtime-messages.ts
@@ -8,6 +8,11 @@ import {
   RETENTION_MAX_COUNT_MAX,
   RETENTION_MAX_COUNT_MIN,
 } from '../domain/retention';
+import {
+  SEARCH_KEYWORD_MAX_LENGTH,
+  SEARCH_KEYWORD_MIN_LENGTH,
+  TRANSCRIPT_SEARCH_LANGUAGES,
+} from '../domain/search';
 import { validationError, type DomainError } from '../domain/shared/errors';
 
 /**
@@ -207,6 +212,15 @@ const purgeAllSessionsRequestSchema = z.object({
   input: z.object({}).optional(),
 });
 
+const searchSessionHistoryRequestSchema = z.object({
+  type: z.literal('query.search-session-history'),
+  input: z.object({
+    keyword: z.string().min(SEARCH_KEYWORD_MIN_LENGTH).max(SEARCH_KEYWORD_MAX_LENGTH),
+    language: z.enum(TRANSCRIPT_SEARCH_LANGUAGES),
+    caseSensitive: z.boolean(),
+  }),
+});
+
 export const backgroundRequestSchema = z.discriminatedUnion('type', [
   startSourceSessionRequestSchema,
   stopSourceSessionRequestSchema,
@@ -226,6 +240,7 @@ export const backgroundRequestSchema = z.discriminatedUnion('type', [
   getSessionRetentionPolicyRequestSchema,
   purgeExpiredSessionsRequestSchema,
   purgeAllSessionsRequestSchema,
+  searchSessionHistoryRequestSchema,
   getSessionHistoryRequestSchema,
   getSessionHistoryDetailRequestSchema,
 ]);

--- a/packages/extension/src/domain/repositories/transcript-stream-repository.test.ts
+++ b/packages/extension/src/domain/repositories/transcript-stream-repository.test.ts
@@ -48,6 +48,7 @@ const okMock: TranscriptStreamRepository = {
   appendPartial: () => okAsync(undefined),
   appendFinal: () => okAsync(undefined),
   appendTranslation: () => okAsync(undefined),
+  search: () => okAsync([]),
 };
 
 describe('TranscriptStreamRepository (DD-261)', () => {

--- a/packages/extension/src/domain/repositories/transcript-stream-repository.ts
+++ b/packages/extension/src/domain/repositories/transcript-stream-repository.ts
@@ -1,9 +1,24 @@
 import { type ResultAsync } from 'neverthrow';
+import { type TranscriptSearchQuery } from '../search';
 import { type SessionIdentifier } from '../session/session-identifier';
 import { type DomainError } from '../shared/errors';
 import { type TranscriptSegment } from '../transcript/transcript-segment';
 import { type TranscriptStream } from '../transcript/transcript-stream';
 import { type TranslationSegment } from '../transcript/translation-segment';
+
+/**
+ * 字幕検索マッチ (DD-261, Issue #125)。
+ *
+ * 1 segment における検索ヒットを表す。`matchedLanguage` で原文 / 訳文を
+ * 区別し、`snippet` は前後 20 文字を含むハイライト表示用の短文。
+ */
+export type TranscriptSearchMatch = Readonly<{
+  sessionIdentifier: SessionIdentifier;
+  segmentIdentifier: string;
+  snippet: string;
+  matchedLanguage: 'source' | 'target';
+  startTimeMs: number;
+}>;
 
 /**
  * 字幕ストリームリポジトリ (DD-261)。
@@ -42,4 +57,12 @@ export type TranscriptStreamRepository = Readonly<{
     sessionIdentifier: SessionIdentifier,
     translation: TranslationSegment,
   ) => ResultAsync<void, DomainError>;
+  /**
+   * 全セッション横断で transcript / translation の部分一致検索を行う (Issue #125)。
+   * MVP は linear scan (`by-sessionId` index 経由で全セッション分を取得 → 部分
+   * 一致判定)。将来的に `tokens` index で O(log n) 化する余地を残す。
+   */
+  search: (
+    query: TranscriptSearchQuery,
+  ) => ResultAsync<readonly TranscriptSearchMatch[], DomainError>;
 }>;

--- a/packages/extension/src/domain/search/index.ts
+++ b/packages/extension/src/domain/search/index.ts
@@ -1,0 +1,8 @@
+export {
+  createTranscriptSearchQuery,
+  SEARCH_KEYWORD_MAX_LENGTH,
+  SEARCH_KEYWORD_MIN_LENGTH,
+  TRANSCRIPT_SEARCH_LANGUAGES,
+  type TranscriptSearchLanguage,
+  type TranscriptSearchQuery,
+} from './transcript-search-query';

--- a/packages/extension/src/domain/search/transcript-search-query.test.ts
+++ b/packages/extension/src/domain/search/transcript-search-query.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createTranscriptSearchQuery,
+  SEARCH_KEYWORD_MAX_LENGTH,
+  SEARCH_KEYWORD_MIN_LENGTH,
+} from './transcript-search-query';
+
+describe('TranscriptSearchQuery (DD-261, Issue #125)', () => {
+  it('accepts a valid query with all fields', () => {
+    const result = createTranscriptSearchQuery({
+      keyword: 'hello',
+      language: 'both',
+      caseSensitive: false,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.keyword).toBe('hello');
+      expect(result.value.language).toBe('both');
+      expect(result.value.caseSensitive).toBe(false);
+    }
+  });
+
+  it('accepts source only and target only', () => {
+    const source = createTranscriptSearchQuery({
+      keyword: 'x',
+      language: 'source',
+      caseSensitive: false,
+    });
+    const target = createTranscriptSearchQuery({
+      keyword: 'x',
+      language: 'target',
+      caseSensitive: true,
+    });
+    expect(source.isOk()).toBe(true);
+    expect(target.isOk()).toBe(true);
+  });
+
+  it('rejects empty keyword', () => {
+    const result = createTranscriptSearchQuery({
+      keyword: '',
+      language: 'both',
+      caseSensitive: false,
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) expect(result.error.kind).toBe('validation');
+  });
+
+  it('rejects keyword longer than 256 chars', () => {
+    const result = createTranscriptSearchQuery({
+      keyword: 'a'.repeat(SEARCH_KEYWORD_MAX_LENGTH + 1),
+      language: 'both',
+      caseSensitive: false,
+    });
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('accepts boundary lengths', () => {
+    expect(
+      createTranscriptSearchQuery({
+        keyword: 'a'.repeat(SEARCH_KEYWORD_MIN_LENGTH),
+        language: 'both',
+        caseSensitive: false,
+      }).isOk(),
+    ).toBe(true);
+    expect(
+      createTranscriptSearchQuery({
+        keyword: 'a'.repeat(SEARCH_KEYWORD_MAX_LENGTH),
+        language: 'both',
+        caseSensitive: false,
+      }).isOk(),
+    ).toBe(true);
+  });
+
+  it('rejects invalid language value', () => {
+    const result = createTranscriptSearchQuery({
+      keyword: 'x',
+      language: 'invalid',
+      caseSensitive: false,
+    });
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/extension/src/domain/search/transcript-search-query.ts
+++ b/packages/extension/src/domain/search/transcript-search-query.ts
@@ -1,0 +1,41 @@
+import { err, ok, type Result } from 'neverthrow';
+import { z } from 'zod';
+import { type DomainError, validationError } from '../shared/errors';
+
+export const SEARCH_KEYWORD_MIN_LENGTH = 1 as const;
+export const SEARCH_KEYWORD_MAX_LENGTH = 256 as const;
+
+export const TRANSCRIPT_SEARCH_LANGUAGES = ['source', 'target', 'both'] as const;
+export type TranscriptSearchLanguage = (typeof TRANSCRIPT_SEARCH_LANGUAGES)[number];
+
+const transcriptSearchQuerySchema = z
+  .object({
+    keyword: z.string().min(SEARCH_KEYWORD_MIN_LENGTH).max(SEARCH_KEYWORD_MAX_LENGTH),
+    language: z.enum(TRANSCRIPT_SEARCH_LANGUAGES),
+    caseSensitive: z.boolean(),
+  })
+  .brand<'TranscriptSearchQuery'>();
+
+/**
+ * 字幕検索クエリ (DD-261, Issue #125)。
+ *
+ * セッション履歴画面の全文検索で使用する。`keyword` は 1〜256 文字。
+ * `language` で原文のみ / 訳文のみ / 両方を切替。`caseSensitive` は正規表現の
+ * 大文字小文字区別。
+ */
+export type TranscriptSearchQuery = z.infer<typeof transcriptSearchQuerySchema>;
+
+export const createTranscriptSearchQuery = (
+  params: unknown,
+): Result<TranscriptSearchQuery, DomainError> => {
+  const result = transcriptSearchQuerySchema.safeParse(params);
+  if (!result.success) {
+    return err(
+      validationError({
+        field: 'TranscriptSearchQuery',
+        message: result.error.issues.map((issue) => issue.message).join('; '),
+      }),
+    );
+  }
+  return ok(result.data);
+};

--- a/packages/extension/src/entrypoints/background.ts
+++ b/packages/extension/src/entrypoints/background.ts
@@ -240,6 +240,7 @@ export default defineBackground(() => {
     getGlossaryQuery: app.getGlossaryQuery,
     updateGlossaryUseCase: app.updateGlossaryUseCase,
     purgeExpiredSessionsUseCase: app.purgeExpiredSessionsUseCase,
+    searchSessionHistoryQuery: app.searchSessionHistoryQuery,
     sessionStore: app.sessionStore,
     settingsStore: app.settingsStore,
   });

--- a/packages/extension/src/infrastructure/storage/indexed-db-transcript-stream-repository.ts
+++ b/packages/extension/src/infrastructure/storage/indexed-db-transcript-stream-repository.ts
@@ -1,6 +1,12 @@
 import { ResultAsync, errAsync } from 'neverthrow';
-import { type TranscriptStreamRepository } from '../../domain/repositories/transcript-stream-repository';
-import { type SessionIdentifier } from '../../domain/session/session-identifier';
+import {
+  type TranscriptSearchMatch,
+  type TranscriptStreamRepository,
+} from '../../domain/repositories/transcript-stream-repository';
+import {
+  parseSessionIdentifier,
+  type SessionIdentifier,
+} from '../../domain/session/session-identifier';
 import {
   invariantViolationError,
   notFoundError,
@@ -163,6 +169,63 @@ export const createIndexedDbTranscriptStreamRepository = (
           })(),
           toPersistenceError('appendTranslation/put'),
         );
+      }),
+
+    search: (query) =>
+      ResultAsync.fromPromise(
+        (async () => {
+          const connection = await handle.get();
+          const transcripts =
+            query.language === 'target' ? [] : await connection.getAll(TRANSCRIPT_STORE);
+          const translations =
+            query.language === 'source' ? [] : await connection.getAll(TRANSLATION_STORE);
+          return { transcripts, translations };
+        })(),
+        toPersistenceError('search'),
+      ).andThen((raw): ResultAsync<readonly TranscriptSearchMatch[], DomainError> => {
+        const keyword = query.caseSensitive ? query.keyword : query.keyword.toLowerCase();
+        const matches: TranscriptSearchMatch[] = [];
+        const snippetAround = (text: string, start: number): string => {
+          const before = Math.max(0, start - 20);
+          const after = Math.min(text.length, start + query.keyword.length + 20);
+          return `${before > 0 ? '…' : ''}${text.slice(before, after)}${
+            after < text.length ? '…' : ''
+          }`;
+        };
+        for (const row of raw.transcripts) {
+          if (!row.isFinal) continue;
+          const haystack = query.caseSensitive ? row.text : row.text.toLowerCase();
+          const index = haystack.indexOf(keyword);
+          if (index === -1) continue;
+          const sessionResult = parseSessionIdentifier(row.sessionId);
+          if (sessionResult.isErr()) continue;
+          matches.push({
+            sessionIdentifier: sessionResult.value,
+            segmentIdentifier: row.segmentId,
+            snippet: snippetAround(row.text, index),
+            matchedLanguage: 'source',
+            startTimeMs: row.startMs,
+          });
+        }
+        for (const row of raw.translations) {
+          if (row.status !== 'completed') continue;
+          const haystack = query.caseSensitive ? row.text : row.text.toLowerCase();
+          const index = haystack.indexOf(keyword);
+          if (index === -1) continue;
+          const sessionResult = parseSessionIdentifier(row.sessionId);
+          if (sessionResult.isErr()) continue;
+          // 対応する transcript segment の startMs を取得する (ない場合は 0)
+          const transcriptRow = raw.transcripts.find((t) => t.segmentId === row.segmentId);
+          matches.push({
+            sessionIdentifier: sessionResult.value,
+            segmentIdentifier: row.segmentId,
+            snippet: snippetAround(row.text, index),
+            matchedLanguage: 'target',
+            startTimeMs: transcriptRow?.startMs ?? 0,
+          });
+        }
+        const readonlyMatches: readonly TranscriptSearchMatch[] = matches;
+        return ResultAsync.fromSafePromise(Promise.resolve(readonlyMatches));
       }),
 
     close: handle.close,

--- a/packages/extension/src/presentation/infrastructure/background-client.ts
+++ b/packages/extension/src/presentation/infrastructure/background-client.ts
@@ -157,6 +157,23 @@ const purgeResultOutputSchema = z.object({
 });
 export type PurgeSessionsResult = z.infer<typeof purgeResultOutputSchema>;
 
+const searchSessionHistoryOutputSchema = z.object({
+  sessions: z.array(
+    z.object({
+      sessionIdentifier: z.string(),
+      matches: z.array(
+        z.object({
+          segmentIdentifier: z.string(),
+          snippet: z.string(),
+          matchedLanguage: z.enum(['source', 'target']),
+          startTimeMs: z.number(),
+        }),
+      ),
+    }),
+  ),
+});
+export type SearchSessionHistoryResult = z.infer<typeof searchSessionHistoryOutputSchema>;
+
 const sessionHistorySummarySchema = z.object({
   sessionId: z.string().min(1),
   displayName: z.string(),
@@ -331,6 +348,11 @@ export type BackgroundClient = Readonly<{
   ) => Promise<BackgroundResponse<SavedAckResult>>;
   purgeExpiredSessions: () => Promise<BackgroundResponse<PurgeSessionsResult>>;
   purgeAllSessions: () => Promise<BackgroundResponse<PurgeSessionsResult>>;
+  searchSessionHistory: (input: {
+    keyword: string;
+    language: 'source' | 'target' | 'both';
+    caseSensitive: boolean;
+  }) => Promise<BackgroundResponse<SearchSessionHistoryResult>>;
   getSessionHistory: () => Promise<BackgroundResponse<SessionHistoryListResult>>;
   getSessionHistoryDetail: (input: {
     sessionId: string;
@@ -409,6 +431,12 @@ export const createBackgroundClient = (
     sendTyped(sender, { type: 'command.purge-expired-sessions' }, purgeResultOutputSchema),
   purgeAllSessions: () =>
     sendTyped(sender, { type: 'command.purge-all-sessions' }, purgeResultOutputSchema),
+  searchSessionHistory: (input) =>
+    sendTyped(
+      sender,
+      { type: 'query.search-session-history', input },
+      searchSessionHistoryOutputSchema,
+    ),
   getSessionHistory: () =>
     sendTyped(sender, { type: 'query.get-session-history' }, sessionHistoryListOutputSchema),
   getSessionHistoryDetail: (input) =>

--- a/packages/extension/src/presentation/molecules/export-controls.test.tsx
+++ b/packages/extension/src/presentation/molecules/export-controls.test.tsx
@@ -41,6 +41,7 @@ const buildClient = (overrides: Partial<BackgroundClient> = {}): BackgroundClien
   saveSessionRetentionPolicy: vi.fn(),
   purgeExpiredSessions: vi.fn(),
   purgeAllSessions: vi.fn(),
+  searchSessionHistory: vi.fn(),
   getSessionHistory: vi.fn(),
   getSessionHistoryDetail: vi.fn(),
   ...overrides,

--- a/packages/extension/src/presentation/organisms/session-history-view.test.tsx
+++ b/packages/extension/src/presentation/organisms/session-history-view.test.tsx
@@ -91,6 +91,7 @@ const buildClient = (overrides: Partial<BackgroundClient> = {}): BackgroundClien
   saveSessionRetentionPolicy: vi.fn(),
   purgeExpiredSessions: vi.fn(),
   purgeAllSessions: vi.fn(),
+  searchSessionHistory: vi.fn(),
   getSessionHistory: vi.fn(() => Promise.resolve(buildList())),
   getSessionHistoryDetail: vi.fn(() => Promise.resolve(buildDetail())),
   ...overrides,

--- a/packages/extension/src/presentation/organisms/session-history-view.tsx
+++ b/packages/extension/src/presentation/organisms/session-history-view.tsx
@@ -1,12 +1,18 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button } from '../atoms/button';
+import { Label } from '../atoms/label';
+import { Select } from '../atoms/select';
+import { TextInput } from '../atoms/text-input';
 import { useBackgroundCommand } from '../hooks/use-background-command';
 import { useBackgroundQuery } from '../hooks/use-background-query';
 import {
   type BackgroundClient,
+  type SearchSessionHistoryResult,
   type SessionHistoryDetailResult,
 } from '../infrastructure/background-client';
 import { TranscriptPairItem } from '../molecules/transcript-pair-item';
+
+const SEARCH_DEBOUNCE_MS = 300 as const;
 
 export type Props = Readonly<{
   client: BackgroundClient;
@@ -38,11 +44,49 @@ export function SessionHistoryView(props: Props) {
     input: undefined,
   });
   const detailCommand = useBackgroundCommand(props.client.getSessionHistoryDetail);
+  const searchCommand = useBackgroundCommand(props.client.searchSessionHistory);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const [detail, setDetail] = useState<SessionHistoryDetailResult | null>(null);
   const [detailError, setDetailError] = useState<string | null>(null);
+  const [searchKeyword, setSearchKeyword] = useState<string>('');
+  const [searchLanguage, setSearchLanguage] = useState<'source' | 'target' | 'both'>('both');
+  const [searchResult, setSearchResult] = useState<SearchSessionHistoryResult | null>(null);
+  const [searchError, setSearchError] = useState<string | null>(null);
 
   const sessions = useMemo(() => listQuery.state.data?.sessions ?? [], [listQuery.state.data]);
+
+  useEffect(() => {
+    if (searchKeyword.trim().length === 0) {
+      setSearchResult(null);
+      setSearchError(null);
+      return;
+    }
+    const timer = setTimeout(() => {
+      void (async () => {
+        const response = await searchCommand.execute({
+          keyword: searchKeyword,
+          language: searchLanguage,
+          caseSensitive: false,
+        });
+        if (response.ok) {
+          setSearchResult(response.value);
+          setSearchError(null);
+        } else {
+          setSearchResult(null);
+          setSearchError(`検索に失敗しました: ${response.error.message}`);
+        }
+      })();
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [searchKeyword, searchLanguage, searchCommand]);
+
+  const filteredSessions = useMemo(() => {
+    if (searchResult === null) return sessions;
+    const matchedIds = new Set(searchResult.sessions.map((s) => s.sessionIdentifier));
+    return sessions.filter((s) => matchedIds.has(s.sessionId));
+  }, [sessions, searchResult]);
 
   const handleSelect = useCallback(
     async (sessionId: string): Promise<void> => {
@@ -69,6 +113,40 @@ export function SessionHistoryView(props: Props) {
       </header>
       <div className="body" data-variant="history">
         <aside className="list" aria-label="履歴一覧">
+          <div className="search" role="search">
+            <Label htmlFor="history-search-input">字幕検索</Label>
+            <TextInput
+              id="history-search-input"
+              value={searchKeyword}
+              onChange={setSearchKeyword}
+              placeholder="原文 / 訳文から検索 (1〜256 文字)"
+              ariaLabel="字幕検索キーワード"
+              maxLength={256}
+            />
+            <Select
+              value={searchLanguage}
+              onChange={(value) => {
+                if (value === 'source' || value === 'target' || value === 'both') {
+                  setSearchLanguage(value);
+                }
+              }}
+              options={[
+                { value: 'both', label: '原文と訳文' },
+                { value: 'source', label: '原文のみ' },
+                { value: 'target', label: '訳文のみ' },
+              ]}
+              ariaLabel="検索対象言語"
+            />
+            {searchCommand.state.status === 'pending' ? <p className="message">検索中…</p> : null}
+            {searchError !== null ? (
+              <p className="message" role="alert">
+                {searchError}
+              </p>
+            ) : null}
+            {searchResult !== null && searchResult.sessions.length === 0 ? (
+              <p className="message">該当する字幕はありません。</p>
+            ) : null}
+          </div>
           {listQuery.state.status === 'pending' || listQuery.state.status === 'idle' ? (
             <p className="message">読み込み中…</p>
           ) : null}
@@ -77,11 +155,15 @@ export function SessionHistoryView(props: Props) {
               一覧の取得に失敗しました: {listQuery.state.error?.message ?? 'unknown error'}
             </p>
           ) : null}
-          {listQuery.state.status === 'success' && sessions.length === 0 ? (
-            <p className="message">過去のセッションはまだありません。</p>
+          {listQuery.state.status === 'success' && filteredSessions.length === 0 ? (
+            <p className="message">
+              {searchResult === null
+                ? '過去のセッションはまだありません。'
+                : '検索条件に一致するセッションはありません。'}
+            </p>
           ) : null}
           <ul className="items" role="list">
-            {sessions.map((summary) => (
+            {filteredSessions.map((summary) => (
               <li
                 key={summary.sessionId}
                 className="item"

--- a/packages/extension/src/presentation/organisms/session-toolbar.test.tsx
+++ b/packages/extension/src/presentation/organisms/session-toolbar.test.tsx
@@ -33,6 +33,7 @@ const buildClient = (overrides: Partial<BackgroundClient> = {}): BackgroundClien
   saveSessionRetentionPolicy: vi.fn(),
   purgeExpiredSessions: vi.fn(),
   purgeAllSessions: vi.fn(),
+  searchSessionHistory: vi.fn(),
   getSessionHistory: vi.fn(),
   getSessionHistoryDetail: vi.fn(),
   ...overrides,

--- a/packages/extension/src/presentation/organisms/settings-view.test.tsx
+++ b/packages/extension/src/presentation/organisms/settings-view.test.tsx
@@ -72,6 +72,7 @@ const buildClient = (overrides: Partial<BackgroundClient> = {}): BackgroundClien
     (): Promise<BackgroundResponse<PurgeSessionsResult>> =>
       Promise.resolve({ ok: true, value: { purgedSessionIds: [], totalPurged: 0 } }),
   ),
+  searchSessionHistory: vi.fn(),
   getSessionHistory: vi.fn(),
   getSessionHistoryDetail: vi.fn(),
   ...overrides,

--- a/packages/extension/src/presentation/organisms/start-session-form.test.tsx
+++ b/packages/extension/src/presentation/organisms/start-session-form.test.tsx
@@ -48,6 +48,7 @@ const buildClient = (start: BackgroundClient['startSourceSession']): BackgroundC
   saveSessionRetentionPolicy: vi.fn(),
   purgeExpiredSessions: vi.fn(),
   purgeAllSessions: vi.fn(),
+  searchSessionHistory: vi.fn(),
   getSessionHistory: vi.fn(),
   getSessionHistoryDetail: vi.fn(),
 });


### PR DESCRIPTION
## Summary

- セッション履歴画面に transcript / translation 全文検索機能を追加
- IndexedDB linear scan (MVP 実装、将来 tokens index で O(log n) 化可能)
- 結果は session 単位グループ化、各 session 最大 5 match、300ms debounce
- 検索時は一覧を filter 表示、非該当セッションは非表示

## 主な変更

- **ドメイン**: `TranscriptSearchQuery` 値オブジェクト (DD-261、keyword 1-256 文字)、`TranscriptSearchMatch` 型
- **リポジトリ**: `TranscriptStreamRepository.search(query)` を追加、既存 adapter に linear scan 実装
- **アプリ層**: `SearchSessionHistoryQuery` UseCase (session グループ化 + 5 match 上限 + startTime 昇順ソート)
- **プレゼン層**: `SessionHistoryView` に検索 input + 言語切替 Select、debounce 実装、filter 表示
- **Dispatcher / background-client**: search メッセージを配線

## Test plan

- [x] \`pnpm typecheck\` — 通過
- [x] \`pnpm lint\` — 既存警告 1 件のみ (本 PR 関連なし)
- [x] \`pnpm test\` — 1053 passed (extension)
- 新規テスト:
  - \`src/domain/search/transcript-search-query.test.ts\` (6 test)
  - \`src/application/use-cases/search-session-history-query.test.ts\` (5 test)

## Related

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)