### PR TITLE
fix(relay-api): add diagnostic logging to Deepgram STT provider

### DIFF
--- a/packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.test.ts
+++ b/packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.test.ts
@@ -57,6 +57,10 @@ const createFakeSocket = (): FakeSocket => {
       case 'error':
         errorListeners.push(e);
         return undefined;
+      case 'open':
+      case 'unexpected-response':
+        // 診断 log 用の listener。本テストでは emit しないため no-op で握りつぶす。
+        return undefined;
     }
   };
   const once: MinimalDeepgramSocket['once'] = (event, listener) => {

--- a/packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.ts
+++ b/packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.ts
@@ -11,14 +11,20 @@ import { invariantViolationError, type DomainError } from '../../domain/shared/e
  * Deepgram adapter が使う最小の WebSocket contract。
  * - `ws` パッケージの `WebSocket` はこの interface を自然に満たす
  * - test では EventEmitter ベースの fake が直接渡せる
+ *
+ * `ws` の `close` event は `(code: number, reason: Buffer)` を渡してくる。
+ * `error` event は `(err: Error)` を渡す。診断ログのため両方の引数を受け取れる
+ * shape にしている (test fake は引数を渡さなくてもよい)。
  */
 export type DeepgramRawData = Buffer | ArrayBuffer | Buffer[];
 
-export type DeepgramSocketEvent = 'message' | 'close' | 'error';
+export type DeepgramSocketEvent = 'message' | 'close' | 'error' | 'open' | 'unexpected-response';
 export type DeepgramSocketListener =
   | ((data: DeepgramRawData) => void)
   | (() => void)
-  | ((err: Error) => void);
+  | ((err: Error) => void)
+  | ((code: number, reason: Buffer) => void)
+  | ((req: unknown, res: unknown) => void);
 
 export type MinimalDeepgramSocket = Readonly<{
   on: (event: DeepgramSocketEvent, listener: DeepgramSocketListener) => unknown;
@@ -43,6 +49,22 @@ export type DeepgramWebSocketFactory = (
   headers: Record<string, string>,
 ) => MinimalDeepgramSocket;
 
+/**
+ * 診断ログハンドラ (DI、test では no-op)。production は pino logger を渡す。
+ * fatal な失敗 (auth fail、format mismatch 等) を WARN/ERROR で記録するため。
+ */
+export type DeepgramLogger = Readonly<{
+  info: (msg: string, fields?: Record<string, unknown>) => void;
+  warn: (msg: string, fields?: Record<string, unknown>) => void;
+  error: (msg: string, fields?: Record<string, unknown>) => void;
+}>;
+
+const NOOP_LOGGER: DeepgramLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
 export type DeepgramSttProviderConfig = Readonly<{
   apiKey: string;
   /** 既定 `wss://api.deepgram.com/v1/listen`。テストで上書き可能 */
@@ -54,6 +76,8 @@ export type DeepgramSttProviderConfig = Readonly<{
   segmentIdFactory?: () => string;
   /** ISO8601 now (test で deterministic に) */
   clock?: () => string;
+  /** 診断ログ (close code / error reason の捕捉)。未指定は no-op (既存テスト互換) */
+  logger?: DeepgramLogger;
 }>;
 
 type DeepgramMessageAlternative = {
@@ -143,6 +167,7 @@ export const createDeepgramSttProvider = (config: DeepgramSttProviderConfig): St
   const model = config.model ?? 'nova-2';
   const segmentIdFactory = config.segmentIdFactory ?? (() => ulid());
   const clock = config.clock ?? (() => new Date().toISOString());
+  const logger = config.logger ?? NOOP_LOGGER;
 
   return {
     openStream: (streamConfig) => {
@@ -169,12 +194,26 @@ export const createDeepgramSttProvider = (config: DeepgramSttProviderConfig): St
       }
       const url = `${baseUrl}?${qs.toString()}`;
 
+      // 診断: URL の query string は秘密ではないが API key は header で送るため
+      // ログには含まれない。auth fail / format mismatch を切り分けるため
+      // 接続パラメータを INFO で残す。
+      logger.info('deepgram open: connecting', {
+        url: baseUrl,
+        model,
+        sourceLanguage: streamConfig.sourceLanguage,
+        autoDetectLanguage: streamConfig.autoDetectLanguage,
+        endpointing: streamConfig.endpointing,
+      });
+
       let socket: MinimalDeepgramSocket;
       try {
         socket = config.webSocketFactory(url, {
           Authorization: `Token ${config.apiKey}`,
         });
       } catch (cause) {
+        logger.error('deepgram open: webSocketFactory threw', {
+          err: cause instanceof Error ? cause.message : String(cause),
+        });
         return errAsync<SttStreamHandle, DomainError>(
           invariantViolationError({
             invariant: 'deepgram-ws-open-failed',
@@ -188,6 +227,7 @@ export const createDeepgramSttProvider = (config: DeepgramSttProviderConfig): St
       const eventQueue: TranscriptEvent[] = [];
       const waiters: ((event: IteratorResult<TranscriptEvent>) => void)[] = [];
       let closed = false;
+      let frameCount = 0;
 
       const pushEvent = (event: TranscriptEvent): void => {
         const waiter = waiters.shift();
@@ -252,8 +292,58 @@ export const createDeepgramSttProvider = (config: DeepgramSttProviderConfig): St
         });
       });
 
-      socket.on('close', endStream);
-      socket.on('error', endStream);
+      // ws ライブラリの open / close / error / unexpected-response を診断ログ
+      // へつなぐ。これがないと Deepgram が「なぜ閉じたか」が永久に不明になる。
+      // 各 listener は DeepgramSocketListener union のいずれかのメンバーに
+      // 一致するため cast 不要で `socket.on` に直接渡せる。
+      const onOpen: () => void = () => {
+        logger.info('deepgram open: WebSocket established', {
+          framesQueued: eventQueue.length,
+        });
+      };
+      const onClose: (code: number, reason: Buffer) => void = (code, reason) => {
+        const reasonStr = Buffer.isBuffer(reason) ? reason.toString('utf8') : '';
+        // 1000 = normal、それ以外は異常終了。Deepgram 固有 code (4000-4999) は
+        // auth/billing/format mismatch などを示すので必ず WARN/ERROR。
+        const fields = {
+          code,
+          reason: reasonStr,
+          framesSent: frameCount,
+          sourceLanguage: streamConfig.sourceLanguage,
+          autoDetectLanguage: streamConfig.autoDetectLanguage,
+        };
+        if (code === 1000) {
+          logger.info('deepgram close: normal closure', fields);
+        } else if (code >= 4000) {
+          logger.error('deepgram close: provider-specific error code', fields);
+        } else {
+          logger.warn('deepgram close: abnormal closure', fields);
+        }
+        endStream();
+      };
+      const onError: (err: Error) => void = (cause) => {
+        logger.error('deepgram error', {
+          err: cause instanceof Error ? cause.message : String(cause),
+          framesSent: frameCount,
+        });
+        endStream();
+      };
+      const onUnexpectedResponse: (req: unknown, res: unknown) => void = (_req, res) => {
+        // ws の unexpected-response: HTTP upgrade が拒否された (status>=400)。
+        // auth fail (401) / quota (403) / bad request (400) などをここで捕捉する。
+        const statusCode =
+          typeof res === 'object' && res !== null && 'statusCode' in res
+            ? Reflect.get(res, 'statusCode')
+            : 'unknown';
+        logger.error('deepgram open: HTTP upgrade rejected', {
+          statusCode,
+        });
+      };
+
+      socket.on('open', onOpen);
+      socket.on('close', onClose);
+      socket.on('error', onError);
+      socket.on('unexpected-response', onUnexpectedResponse);
 
       const handle: SttStreamHandle = {
         sendFrame: (params): Result<void, DomainError> => {
@@ -268,8 +358,19 @@ export const createDeepgramSttProvider = (config: DeepgramSttProviderConfig): St
           try {
             const binary = Buffer.from(params.audioBase64, 'base64');
             socket.send(binary, { binary: true });
+            frameCount += 1;
+            if (frameCount === 1) {
+              logger.info('deepgram sendFrame: first frame', {
+                bytes: binary.length,
+                chunkId: params.chunkId,
+              });
+            }
             return ok(undefined);
           } catch (cause) {
+            logger.warn('deepgram sendFrame: socket.send threw', {
+              err: cause instanceof Error ? cause.message : String(cause),
+              framesSent: frameCount,
+            });
             return err(
               invariantViolationError({
                 invariant: 'deepgram-send-failed',

--- a/packages/relay-api/src/presentation/http/server.ts
+++ b/packages/relay-api/src/presentation/http/server.ts
@@ -1,5 +1,6 @@
 import fastifyWebsocket from '@fastify/websocket';
 import Fastify, { type FastifyInstance } from 'fastify';
+import pino from 'pino';
 import { ulid } from 'ulid';
 import { WebSocket as WsWebSocket } from 'ws';
 import { type AccessTokenVerifier } from '../../application/ports/access-token-verifier';
@@ -14,7 +15,10 @@ import { createJoseJwtSigner } from '../../infrastructure/auth/jose-jwt-signer';
 import { createJoseJwtVerifier } from '../../infrastructure/auth/jose-jwt-verifier';
 import { createStaticAccessTokenVerifier } from '../../infrastructure/auth/static-access-token-verifier';
 import { loggerOptions } from '../../infrastructure/logging/logger';
-import { createDeepgramSttProvider } from '../../infrastructure/providers/deepgram-stt-provider';
+import {
+  createDeepgramSttProvider,
+  type DeepgramLogger,
+} from '../../infrastructure/providers/deepgram-stt-provider';
 import { createDeepLTranslationProvider } from '../../infrastructure/providers/deepl-translation-provider';
 import { registerRelayRoute } from '../ws/relay-route';
 import { registerRequestContextHook } from './request-context-hook';
@@ -160,10 +164,22 @@ const buildProductionDependencies = (): AppDependencies => {
   if (deepgramApiKey === undefined || deepgramApiKey.length === 0) {
     throw new Error('DEEPGRAM_API_KEY env var is required for production STT provider');
   }
+  // Deepgram WebSocket の close code / reason / unexpected-response status を
+  // 捕捉するための診断 logger。Fastify の app.log と同じ pino オプションで
+  // 別 instance を作成し、`module: 'deepgram-stt'` で識別できるようにする。
+  // これがないと deepgram-stream-closed が発生した際に「なぜ閉じたか」が
+  // 永久に不明になる (PR #131 後の継続課題)。
+  const pinoLogger = pino(loggerOptions).child({ module: 'deepgram-stt' });
+  const deepgramLogger: DeepgramLogger = {
+    info: (msg, fields) => pinoLogger.info(fields ?? {}, msg),
+    warn: (msg, fields) => pinoLogger.warn(fields ?? {}, msg),
+    error: (msg, fields) => pinoLogger.error(fields ?? {}, msg),
+  };
   const sttPort = createDeepgramSttProvider({
     apiKey: deepgramApiKey,
     baseUrl: process.env['DEEPGRAM_BASE_URL'] ?? 'wss://api.deepgram.com/v1/listen',
     webSocketFactory: (url, headers) => new WsWebSocket(url, { headers }),
+    logger: deepgramLogger,
   });
 
   const deeplApiKey = process.env['DEEPL_API_KEY'];


### PR DESCRIPTION
## Summary
- Deepgram WebSocket の close code / reason / error / unexpected-response を診断ログに記録
- production 配線で pino instance を作成し `DeepgramLogger` adapter として注入
- close code 別に log level を分岐 (1000=info, ≥4000=error, その他=warn)

## Why
PR #131 (deepgram-stream-closed recovery) では、stream が閉じた際に client へ `STT_STREAM_FAILED` を通知し session を tear-down する経路を作った。しかし「**なぜ Deepgram が閉じたか**」は依然として不明のままで、`socket.on('close', endStream)` と `socket.on('error', endStream)` が close code / reason / error message を **破棄して** いた。

ユーザーから以下のログが繰り返し出続けるとの報告:
\`\`\`
[session-command-service] relay session.error: {"code":"STT_STREAM_FAILED","retryable":true,"fatal":false,...}
\`\`\`

recovery flow は動作しているが、根本原因 (Deepgram 側 close 理由) が分からないと修正できない。本 PR は次回発生時に code・reason・送信 frame 数・upgrade rejection の HTTP status などから原因を特定できるようにする診断 wiring。

## Changes
- \`DeepgramLogger\` interface (info/warn/error fields)、NOOP_LOGGER 既定 (test 互換)
- \`DeepgramSocketEvent\` に \`'open'\` / \`'unexpected-response'\` を追加
- open / close / error / unexpected-response listener を診断ログにつなぐ
- frame send 時に first-frame 通知 + send-throw warn
- \`server.ts\` で pino instance + DeepgramLogger adapter を生成し DI

## Test plan
- [x] \`pnpm --filter @perapera/relay-api typecheck\` 通過
- [x] \`pnpm --filter @perapera/relay-api lint\` 私の変更分エラー 0 (perf/scenarios/*.js は既存の parse error)
- [x] \`pnpm --filter @perapera/relay-api test --run\` 216 / 216 passed
- [ ] CI 全 pass を確認後 merge
- [ ] 実機で再現させて Deepgram の close code / reason を確認 (フォローアップ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)