### PR TITLE
fix(relay-api): wait for Deepgram WebSocket 'open' before resolving openStream

### DIFF
--- a/packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.test.ts
+++ b/packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.test.ts
@@ -12,23 +12,34 @@ import {
  * Deepgram adapter が要求する最小 API を満たす test fake。
  * `MinimalDeepgramSocket` を直接実装し、EventEmitter は使わず Map に直接
  * listener を保持することで型情報を失わず (cast 不要) dispatch する。
+ *
+ * `manualOpen: true` を渡すと 'open' event を自動 emit しない (open 待ち
+ * テスト用)。既定では `socket.on('open', ...)` 登録時に setImmediate で
+ * emit するため、provider の openStream 待機が既存テストでは透過に進む。
  */
 type FakeSocket = MinimalDeepgramSocket & {
   emitMessage: (raw: DeepgramRawData) => void;
-  emitClose: () => void;
+  emitOpen: () => void;
+  emitClose: (code?: number, reason?: Buffer) => void;
+  emitError: (err: Error) => void;
+  emitUnexpectedResponse: (req: unknown, res: unknown) => void;
   sendSpy: ReturnType<typeof vi.fn>;
   closeSpy: ReturnType<typeof vi.fn>;
 };
 
-const createFakeSocket = (): FakeSocket => {
+type FakeSocketOptions = Readonly<{ manualOpen?: boolean }>;
+
+const createFakeSocket = (options: FakeSocketOptions = {}): FakeSocket => {
   const messageListeners: ((data: DeepgramRawData) => void)[] = [];
-  const closeListeners: (() => void)[] = [];
+  const closeListeners: ((code: number, reason: Buffer) => void)[] = [];
   const errorListeners: ((err: Error) => void)[] = [];
+  const openListeners: (() => void)[] = [];
+  const unexpectedResponseListeners: ((req: unknown, res: unknown) => void)[] = [];
 
   const sendSpy = vi.fn<(data: Buffer, options: { binary: boolean }) => void>();
   const closeSpy = vi.fn<(code: number, reason: string) => void>(() => {
     setImmediate(() => {
-      for (const listener of closeListeners) listener();
+      for (const listener of closeListeners) listener(1000, Buffer.from(''));
     });
   });
 
@@ -44,9 +55,13 @@ const createFakeSocket = (): FakeSocket => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const m = listener as (data: DeepgramRawData) => void;
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const c = listener as () => void;
+    const c = listener as (code: number, reason: Buffer) => void;
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const e = listener as (err: Error) => void;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const o = listener as () => void;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const u = listener as (req: unknown, res: unknown) => void;
     switch (event) {
       case 'message':
         messageListeners.push(m);
@@ -58,14 +73,21 @@ const createFakeSocket = (): FakeSocket => {
         errorListeners.push(e);
         return undefined;
       case 'open':
+        openListeners.push(o);
+        if (options.manualOpen !== true) {
+          // production 互換: 'open' event は socket 作成後に非同期で発火する。
+          // 既定で auto-emit して既存テストの openStream 待機を透過に進める。
+          setImmediate(() => o());
+        }
+        return undefined;
       case 'unexpected-response':
-        // 診断 log 用の listener。本テストでは emit しないため no-op で握りつぶす。
+        unexpectedResponseListeners.push(u);
         return undefined;
     }
   };
   const once: MinimalDeepgramSocket['once'] = (event, listener) => {
     if (event === 'close') {
-      const wrapper = () => {
+      const wrapper = (_code: number, _reason: Buffer) => {
         const idx = closeListeners.indexOf(wrapper);
         if (idx >= 0) closeListeners.splice(idx, 1);
         listener();
@@ -83,8 +105,17 @@ const createFakeSocket = (): FakeSocket => {
     emitMessage: (raw) => {
       for (const listener of messageListeners) listener(raw);
     },
-    emitClose: () => {
-      for (const listener of closeListeners) listener();
+    emitOpen: () => {
+      for (const listener of openListeners) listener();
+    },
+    emitClose: (code = 1000, reason = Buffer.from('')) => {
+      for (const listener of closeListeners) listener(code, reason);
+    },
+    emitError: (err: Error) => {
+      for (const listener of errorListeners) listener(err);
+    },
+    emitUnexpectedResponse: (req: unknown, res: unknown) => {
+      for (const listener of unexpectedResponseListeners) listener(req, res);
     },
     sendSpy,
     closeSpy,
@@ -246,5 +277,119 @@ describe('createDeepgramSttProvider (IMPL-444)', () => {
     expect(url).toContain('detect_language=true');
     // `language=` 単体 query (detect_language= ではない) が含まれないこと
     expect(url).not.toMatch(/(?<!detect_)language=/);
+  });
+
+  describe('openStream waits for WebSocket open event', () => {
+    it('does not resolve until "open" event fires (manual emit)', async () => {
+      const fakeSocket = createFakeSocket({ manualOpen: true });
+      const provider = createDeepgramSttProvider({
+        apiKey: 'dg-secret',
+        webSocketFactory: () => fakeSocket,
+      });
+      const opening = provider.openStream({
+        sourceLanguage: 'en-US',
+        autoDetectLanguage: false,
+      });
+      // 'open' を emit するまでは pending — 非同期に決着する race を作って
+      // 「先に Promise.race で sentinel が勝つ」ことで pending 状態を確認する
+      const sentinel = Symbol('still-pending');
+      const racedBefore = await Promise.race([
+        opening.then((r) => r.isOk()),
+        new Promise((resolve) => setImmediate(() => resolve(sentinel))),
+      ]);
+      expect(racedBefore).toBe(sentinel);
+
+      fakeSocket.emitOpen();
+      const result = await opening;
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('rejects with deepgram-open-rejected on unexpected-response (e.g. 401)', async () => {
+      const fakeSocket = createFakeSocket({ manualOpen: true });
+      const provider = createDeepgramSttProvider({
+        apiKey: 'dg-secret',
+        webSocketFactory: () => fakeSocket,
+      });
+      const opening = provider.openStream({
+        sourceLanguage: 'en-US',
+        autoDetectLanguage: false,
+      });
+      // ws の unexpected-response は (req, res) を引数に取る。res に statusCode を含む
+      setImmediate(() => fakeSocket.emitUnexpectedResponse({}, { statusCode: 401 }));
+      const result = await opening;
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe('invariant-violation');
+        if (result.error.kind === 'invariant-violation') {
+          expect(result.error.invariant).toBe('deepgram-open-rejected');
+          expect(result.error.details).toContain('401');
+        }
+      }
+    });
+
+    it('rejects with deepgram-open-failed on error before open', async () => {
+      const fakeSocket = createFakeSocket({ manualOpen: true });
+      const provider = createDeepgramSttProvider({
+        apiKey: 'dg-secret',
+        webSocketFactory: () => fakeSocket,
+      });
+      const opening = provider.openStream({
+        sourceLanguage: 'en-US',
+        autoDetectLanguage: false,
+      });
+      setImmediate(() => fakeSocket.emitError(new Error('ECONNRESET')));
+      const result = await opening;
+      expect(result.isErr()).toBe(true);
+      if (result.isErr() && result.error.kind === 'invariant-violation') {
+        expect(result.error.invariant).toBe('deepgram-open-failed');
+        expect(result.error.details).toContain('ECONNRESET');
+      }
+    });
+
+    it('rejects with deepgram-open-failed when socket closes before open', async () => {
+      const fakeSocket = createFakeSocket({ manualOpen: true });
+      const provider = createDeepgramSttProvider({
+        apiKey: 'dg-secret',
+        webSocketFactory: () => fakeSocket,
+      });
+      const opening = provider.openStream({
+        sourceLanguage: 'en-US',
+        autoDetectLanguage: false,
+      });
+      setImmediate(() => fakeSocket.emitClose(1006, Buffer.from('')));
+      const result = await opening;
+      expect(result.isErr()).toBe(true);
+      if (result.isErr() && result.error.kind === 'invariant-violation') {
+        expect(result.error.invariant).toBe('deepgram-open-failed');
+        expect(result.error.details).toContain('1006');
+      }
+    });
+
+    it('rejects with deepgram-open-timeout when open never fires', async () => {
+      vi.useFakeTimers();
+      try {
+        const fakeSocket = createFakeSocket({ manualOpen: true });
+        const provider = createDeepgramSttProvider({
+          apiKey: 'dg-secret',
+          webSocketFactory: () => fakeSocket,
+          openTimeoutMs: 100,
+        });
+        const opening = provider.openStream({
+          sourceLanguage: 'en-US',
+          autoDetectLanguage: false,
+        });
+        await vi.advanceTimersByTimeAsync(150);
+        const result = await opening;
+        expect(result.isErr()).toBe(true);
+        if (result.isErr() && result.error.kind === 'invariant-violation') {
+          expect(result.error.invariant).toBe('deepgram-open-timeout');
+          expect(result.error.details).toContain('100ms');
+        }
+        // timeout 時に socket.close が呼ばれていることも確認 (resource leak 防止)
+        expect(fakeSocket.closeSpy).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.ts
+++ b/packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.ts
@@ -1,4 +1,4 @@
-import { ResultAsync, err, errAsync, ok, okAsync, type Result } from 'neverthrow';
+import { ResultAsync, err, errAsync, ok, type Result } from 'neverthrow';
 import { ulid } from 'ulid';
 import {
   type SttPort,
@@ -78,6 +78,11 @@ export type DeepgramSttProviderConfig = Readonly<{
   clock?: () => string;
   /** 診断ログ (close code / error reason の捕捉)。未指定は no-op (既存テスト互換) */
   logger?: DeepgramLogger;
+  /**
+   * WebSocket 'open' event 待機タイムアウト (既定 5000ms)。
+   * これを超えると `deepgram-open-timeout` で reject。test では短縮可能。
+   */
+  openTimeoutMs?: number;
 }>;
 
 type DeepgramMessageAlternative = {
@@ -168,6 +173,7 @@ export const createDeepgramSttProvider = (config: DeepgramSttProviderConfig): St
   const segmentIdFactory = config.segmentIdFactory ?? (() => ulid());
   const clock = config.clock ?? (() => new Date().toISOString());
   const logger = config.logger ?? NOOP_LOGGER;
+  const openTimeoutMs = config.openTimeoutMs ?? 5000;
 
   return {
     openStream: (streamConfig) => {
@@ -292,59 +298,6 @@ export const createDeepgramSttProvider = (config: DeepgramSttProviderConfig): St
         });
       });
 
-      // ws ライブラリの open / close / error / unexpected-response を診断ログ
-      // へつなぐ。これがないと Deepgram が「なぜ閉じたか」が永久に不明になる。
-      // 各 listener は DeepgramSocketListener union のいずれかのメンバーに
-      // 一致するため cast 不要で `socket.on` に直接渡せる。
-      const onOpen: () => void = () => {
-        logger.info('deepgram open: WebSocket established', {
-          framesQueued: eventQueue.length,
-        });
-      };
-      const onClose: (code: number, reason: Buffer) => void = (code, reason) => {
-        const reasonStr = Buffer.isBuffer(reason) ? reason.toString('utf8') : '';
-        // 1000 = normal、それ以外は異常終了。Deepgram 固有 code (4000-4999) は
-        // auth/billing/format mismatch などを示すので必ず WARN/ERROR。
-        const fields = {
-          code,
-          reason: reasonStr,
-          framesSent: frameCount,
-          sourceLanguage: streamConfig.sourceLanguage,
-          autoDetectLanguage: streamConfig.autoDetectLanguage,
-        };
-        if (code === 1000) {
-          logger.info('deepgram close: normal closure', fields);
-        } else if (code >= 4000) {
-          logger.error('deepgram close: provider-specific error code', fields);
-        } else {
-          logger.warn('deepgram close: abnormal closure', fields);
-        }
-        endStream();
-      };
-      const onError: (err: Error) => void = (cause) => {
-        logger.error('deepgram error', {
-          err: cause instanceof Error ? cause.message : String(cause),
-          framesSent: frameCount,
-        });
-        endStream();
-      };
-      const onUnexpectedResponse: (req: unknown, res: unknown) => void = (_req, res) => {
-        // ws の unexpected-response: HTTP upgrade が拒否された (status>=400)。
-        // auth fail (401) / quota (403) / bad request (400) などをここで捕捉する。
-        const statusCode =
-          typeof res === 'object' && res !== null && 'statusCode' in res
-            ? Reflect.get(res, 'statusCode')
-            : 'unknown';
-        logger.error('deepgram open: HTTP upgrade rejected', {
-          statusCode,
-        });
-      };
-
-      socket.on('open', onOpen);
-      socket.on('close', onClose);
-      socket.on('error', onError);
-      socket.on('unexpected-response', onUnexpectedResponse);
-
       const handle: SttStreamHandle = {
         sendFrame: (params): Result<void, DomainError> => {
           if (closed) {
@@ -416,7 +369,123 @@ export const createDeepgramSttProvider = (config: DeepgramSttProviderConfig): St
           }),
         },
       };
-      return okAsync<SttStreamHandle, DomainError>(handle);
+
+      // openStream contract: handle が返る時点で socket は send 可能 (readyState=1)
+      // でなければならない。WebSocket の 'open' event を待ってから resolve し、
+      // 'error' / 'unexpected-response' / timeout の場合は err で reject する。
+      // open 後に発火する 'close' / 'error' は endStream() を駆動 (運用中の終了検出)。
+      const openPromise = new Promise<Result<SttStreamHandle, DomainError>>((resolve) => {
+        let openSettled = false;
+        const settleOpen = (result: Result<SttStreamHandle, DomainError>): void => {
+          if (openSettled) return;
+          openSettled = true;
+          clearTimeout(openTimer);
+          resolve(result);
+        };
+        const openTimer = setTimeout(() => {
+          logger.error('deepgram open: timeout', {
+            timeoutMs: openTimeoutMs,
+            sourceLanguage: streamConfig.sourceLanguage,
+            autoDetectLanguage: streamConfig.autoDetectLanguage,
+          });
+          settleOpen(
+            err(
+              invariantViolationError({
+                invariant: 'deepgram-open-timeout',
+                details: `WebSocket open timeout ${String(openTimeoutMs)}ms`,
+              }),
+            ),
+          );
+          // socket がまだ CONNECTING の場合に resource leak を防ぐ
+          try {
+            socket.close(1000, 'open timeout');
+          } catch {
+            /* ignore */
+          }
+        }, openTimeoutMs);
+
+        const onOpen: () => void = () => {
+          logger.info('deepgram open: WebSocket established', {
+            framesQueued: eventQueue.length,
+          });
+          settleOpen(ok(handle));
+        };
+        const onClose: (code: number, reason: Buffer) => void = (code, reason) => {
+          const reasonStr = Buffer.isBuffer(reason) ? reason.toString('utf8') : '';
+          // 1000 = normal、それ以外は異常終了。Deepgram 固有 code (4000-4999) は
+          // auth/billing/format mismatch などを示すので必ず WARN/ERROR。
+          const fields = {
+            code,
+            reason: reasonStr,
+            framesSent: frameCount,
+            sourceLanguage: streamConfig.sourceLanguage,
+            autoDetectLanguage: streamConfig.autoDetectLanguage,
+          };
+          if (code === 1000) {
+            logger.info('deepgram close: normal closure', fields);
+          } else if (code >= 4000) {
+            logger.error('deepgram close: provider-specific error code', fields);
+          } else {
+            logger.warn('deepgram close: abnormal closure', fields);
+          }
+          // open 前に閉じたら open failure として扱う
+          if (!openSettled) {
+            settleOpen(
+              err(
+                invariantViolationError({
+                  invariant: 'deepgram-open-failed',
+                  details: `WebSocket closed before open (code=${String(code)}${reasonStr.length > 0 ? `, reason=${reasonStr}` : ''})`,
+                }),
+              ),
+            );
+          }
+          endStream();
+        };
+        const onError: (err: Error) => void = (cause) => {
+          logger.error('deepgram error', {
+            err: cause instanceof Error ? cause.message : String(cause),
+            framesSent: frameCount,
+          });
+          if (!openSettled) {
+            settleOpen(
+              err(
+                invariantViolationError({
+                  invariant: 'deepgram-open-failed',
+                  details: cause instanceof Error ? cause.message : 'unknown error before open',
+                }),
+              ),
+            );
+            return;
+          }
+          endStream();
+        };
+        const onUnexpectedResponse: (req: unknown, res: unknown) => void = (_req, res) => {
+          // ws の unexpected-response: HTTP upgrade が拒否された (status>=400)。
+          // auth fail (401) / quota (403) / bad request (400) などをここで捕捉する。
+          const statusCode =
+            typeof res === 'object' && res !== null && 'statusCode' in res
+              ? Reflect.get(res, 'statusCode')
+              : 'unknown';
+          logger.error('deepgram open: HTTP upgrade rejected', {
+            statusCode,
+          });
+          settleOpen(
+            err(
+              invariantViolationError({
+                invariant: 'deepgram-open-rejected',
+                details: `HTTP ${typeof statusCode === 'number' ? String(statusCode) : 'unknown'}`,
+              }),
+            ),
+          );
+        };
+
+        socket.on('open', onOpen);
+        socket.on('close', onClose);
+        socket.on('error', onError);
+        socket.on('unexpected-response', onUnexpectedResponse);
+      });
+
+      return new ResultAsync(openPromise);
     },
   };
 };

--- a/packages/relay-api/src/presentation/ws/relay-route.test.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.test.ts
@@ -773,5 +773,114 @@ describe('WebSocket /relay route', () => {
 
       ws.close();
     }, 10000);
+
+    it('emits session.error STT_STREAM_FAILED when sendFrame returns deepgram-send-failed (defense-in-depth)', async () => {
+      // openStream 修正後 (open 待機) で本来は発生しないが、socket が突然
+      // 不安定になった場合の defense-in-depth として、`deepgram-send-failed`
+      // でも同じ recovery 経路に乗ることを検証する。
+      let sendFrameCallCount = 0;
+      const sendFailedSttPort: SttPort = {
+        openStream: () => {
+          const handle: SttStreamHandle = {
+            sendFrame: () => {
+              sendFrameCallCount += 1;
+              return err(
+                invariantViolationError({
+                  invariant: 'deepgram-send-failed',
+                  details: 'WebSocket is not open: readyState 0 (CONNECTING)',
+                }),
+              );
+            },
+            close: () => okAsync<void, DomainError>(undefined),
+            events: {
+              [Symbol.asyncIterator]: () => ({
+                next: (): Promise<IteratorResult<TranscriptEvent>> =>
+                  new Promise<IteratorResult<TranscriptEvent>>(() => {
+                    /* 無限保留 */
+                  }),
+              }),
+            },
+          };
+          return okAsync<SttStreamHandle, DomainError>(handle);
+        },
+      };
+      harness = await startApp(okVerifier, { sttPort: sendFailedSttPort });
+      const ws = connectWithAuth(relayUrl(harness), 'valid.jwt');
+      const queue = createMessageQueue(ws);
+      await awaitOpen(ws);
+      await queue.next(); // session.ready
+
+      ws.send(
+        JSON.stringify({
+          eventType: 'session.start',
+          sessionId: SESSION_ID,
+          sequence: 1,
+          timestamp: new Date().toISOString(),
+          payload: {
+            sourceLanguage: 'en-US',
+            autoDetectLanguage: false,
+            targetLanguage: 'ja-JP',
+            translationEnabled: true,
+          },
+        }),
+      );
+
+      ws.send(
+        JSON.stringify({
+          eventType: 'audio.frame',
+          sessionId: SESSION_ID,
+          sequence: 2,
+          timestamp: new Date().toISOString(),
+          payload: {
+            chunkId: 'chk_1',
+            audioBase64: 'AAAA=',
+            encoding: 'pcm_s16le',
+            sampleRateHz: 16000,
+            channels: 1,
+            frameDurationMs: 100,
+            capturedAt: new Date().toISOString(),
+          },
+        }),
+      );
+
+      const errorEvent = await queue.next(3000);
+      expect(errorEvent).toMatchObject({
+        eventType: 'session.error',
+        payload: {
+          code: 'STT_STREAM_FAILED',
+          retryable: true,
+          fatal: false,
+        },
+      });
+
+      // 二重送信防止: 同じ STT_STREAM_FAILED は 1 回のみ。
+      // 後続の audio.frame は activeStream=null になっているため SESSION_NOT_READY。
+      ws.send(
+        JSON.stringify({
+          eventType: 'audio.frame',
+          sessionId: SESSION_ID,
+          sequence: 3,
+          timestamp: new Date().toISOString(),
+          payload: {
+            chunkId: 'chk_2',
+            audioBase64: 'BBBB=',
+            encoding: 'pcm_s16le',
+            sampleRateHz: 16000,
+            channels: 1,
+            frameDurationMs: 100,
+            capturedAt: new Date().toISOString(),
+          },
+        }),
+      );
+      const secondError = await queue.next(3000);
+      expect(secondError).toMatchObject({
+        eventType: 'session.error',
+        payload: { code: 'SESSION_NOT_READY' },
+      });
+
+      expect(sendFrameCallCount).toBe(1);
+
+      ws.close();
+    }, 10000);
   });
 });

--- a/packages/relay-api/src/presentation/ws/relay-route.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.ts
@@ -693,7 +693,7 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
                   { count: pendingFrames.length, sessionId: context.sessionId },
                   'flushing pending audio.frame buffer after session.start',
                 );
-                let flushHitStreamClosed = false;
+                let flushHitStreamFailure = false;
                 for (const frame of pendingFrames) {
                   const flushResult = handle.sendFrame(frame);
                   if (flushResult.isErr()) {
@@ -701,17 +701,23 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
                       { err: flushResult.error },
                       'stt sendFrame failed during pending flush',
                     );
+                    // `deepgram-stream-closed` (実運用 close) と
+                    // `deepgram-send-failed` (socket throw、e.g. CONNECTING 状態
+                    // で send) の両方を recovery 経路に乗せる。openStream が
+                    // 'open' を待つよう修正されたので後者は本来発生しないが
+                    // defense-in-depth として残す。
                     if (
                       flushResult.error.kind === 'invariant-violation' &&
-                      flushResult.error.invariant === 'deepgram-stream-closed'
+                      (flushResult.error.invariant === 'deepgram-stream-closed' ||
+                        flushResult.error.invariant === 'deepgram-send-failed')
                     ) {
-                      flushHitStreamClosed = true;
+                      flushHitStreamFailure = true;
                     }
                   }
                 }
                 pendingFrames = [];
-                if (flushHitStreamClosed) {
-                  notifyStreamFailure('sendFrame failed during pending flush: STT stream closed');
+                if (flushHitStreamFailure) {
+                  notifyStreamFailure('sendFrame failed during pending flush: STT stream unusable');
                 }
               }
               runTranscriptLoop(stream);
@@ -781,15 +787,18 @@ export const registerRelayRoute = (app: FastifyInstance, deps: RelayRouteDepende
         });
         if (result.isErr()) {
           request.log.warn({ err: result.error }, 'stt sendFrame failed');
-          // Deepgram WebSocket がサーバ都合で閉じた場合 (`deepgram-stream-closed`)
-          // は activeStream を null 化してクライアントへ retryable エラーを一度
-          // だけ通知する。これにより拡張側は session.stop → session.start で
-          // 再接続できる。それ以外の一時的送信失敗 (transient) は WARN のみ。
-          const isStreamClosed =
+          // Deepgram WebSocket がサーバ都合で閉じた (`deepgram-stream-closed`)、
+          // または socket.send が throw した (`deepgram-send-failed`、e.g.
+          // CONNECTING 状態で send) 場合は activeStream を null 化してクライアント
+          // へ retryable エラーを一度だけ通知する。これにより拡張側は
+          // session.stop → session.start で再接続できる。それ以外の transient
+          // 送信失敗は WARN のみ。
+          const isStreamUnusable =
             result.error.kind === 'invariant-violation' &&
-            result.error.invariant === 'deepgram-stream-closed';
-          if (isStreamClosed) {
-            notifyStreamFailure('sendFrame failed: STT stream closed');
+            (result.error.invariant === 'deepgram-stream-closed' ||
+              result.error.invariant === 'deepgram-send-failed');
+          if (isStreamUnusable) {
+            notifyStreamFailure('sendFrame failed: STT stream unusable');
           }
         }
       };


### PR DESCRIPTION
## Summary
- \`openStream()\` を WebSocket の \`'open'\` event 待機に変更 (handle 返却時に socket は readyState=1 OPEN を保証)
- 失敗ケースを invariant で区別: \`deepgram-open-failed\` / \`deepgram-open-rejected\` / \`deepgram-open-timeout\`
- defense-in-depth: \`deepgram-send-failed\` も \`STT_STREAM_FAILED\` recovery 経路に乗せる

## Why (root cause)

PR #131 (deepgram-stream-closed recovery) と PR #132 (診断ログ) を経て、PR #132 の logger でようやく原因が判明:

\`\`\`
WARN: stt sendFrame failed
    err: { invariant: \"deepgram-send-failed\",
           details: \"WebSocket is not open: readyState 0 (CONNECTING)\" }
activeStream: true, sttOpening: false, framesSent: 0
\`\`\`

\`openStream()\` が WebSocket の \`'open'\` event を待たずに即座に \`okAsync(handle)\` を返していた。\`relay-route.ts\` は handle 受信時に \`activeStream = handle\` (\`sttOpening = false\`) → \`pendingFrames\` を flush するが、socket はまだ \`readyState=0 (CONNECTING)\` のため \`socket.send()\` が throw → \`deepgram-send-failed\` を返す。さらに既存 recovery 経路は \`deepgram-stream-closed\` のみを検出していたため silent failure (100ms ごとに WARN を吐き続けるだけ)。

## Changes

### \`packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.ts\`
- \`openStream\` を \`new ResultAsync(Promise<Result<...>>)\` でラップ
- \`'open'\` / \`'error'\` / \`'unexpected-response'\` / \`'close'\` / setTimeout (既定 5000ms) の **最初に発火したもの** で settle
- \`openTimeoutMs?: number\` 設定を追加 (test では短縮可能)
- timeout 時に \`socket.close(1000, 'open timeout')\` で resource leak 防止

### \`packages/relay-api/src/presentation/ws/relay-route.ts\`
- \`handleAudioFrame\` の sendFrame 失敗判定: \`'deepgram-stream-closed' || 'deepgram-send-failed'\` の両方で recovery
- \`pendingFrames\` flush 経路も同様

### Tests (+6 cases, total 222 pass)
- \`openStream waits for WebSocket open event\` describe block:
  - \`does not resolve until 'open' event fires\`
  - \`rejects with deepgram-open-rejected on unexpected-response (401)\`
  - \`rejects with deepgram-open-failed on error before open\`
  - \`rejects with deepgram-open-failed when socket closes before open\`
  - \`rejects with deepgram-open-timeout when open never fires\` (vi.useFakeTimers)
- \`relay-route.test.ts\`: \`STT_STREAM_FAILED\` defense-in-depth test for \`deepgram-send-failed\`
- 既存 fake socket に \`emitOpen\` / \`emitError\` / \`emitUnexpectedResponse\` を追加。\`'open'\` は既定で auto-emit (manualOpen=true で opt-out)

## Test plan
- [x] \`pnpm --filter @perapera/relay-api typecheck\` 通過
- [x] \`pnpm --filter @perapera/relay-api lint\` 私の変更分エラーなし (perf/scenarios/*.js は既存の parse error)
- [x] \`pnpm --filter @perapera/relay-api test --run\` 222 / 222 pass
- [ ] CI 全 pass を確認後 merge
- [ ] 実機で session.start → audio.frame 送信時に \`WebSocket is not open: readyState 0\` ログが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)