### PR TITLE
fix(relay-api): drop utterance_end_ms from Deepgram URL (HTTP 400 root cause)

### DIFF
--- a/packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.test.ts
+++ b/packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.test.ts
@@ -392,4 +392,69 @@ describe('createDeepgramSttProvider (IMPL-444)', () => {
       }
     });
   });
+
+  describe('openStream URL construction (regression: HTTP 400 from invalid Deepgram params)', () => {
+    const captureUrl = async (
+      streamConfig: Parameters<ReturnType<typeof createDeepgramSttProvider>['openStream']>[0],
+    ): Promise<URLSearchParams> => {
+      const factory = vi.fn<DeepgramWebSocketFactory>(() => createFakeSocket());
+      const provider = createDeepgramSttProvider({
+        apiKey: 'dg-secret',
+        webSocketFactory: factory,
+      });
+      await provider.openStream(streamConfig);
+      const url = factory.mock.calls[0]?.[0] ?? '';
+      const queryStart = url.indexOf('?');
+      return new URLSearchParams(queryStart >= 0 ? url.slice(queryStart + 1) : '');
+    };
+
+    it('does NOT include utterance_end_ms (Deepgram requires >=1000ms; we cannot honor SttEndpointingConfig.minUtteranceMs default 500)', async () => {
+      const params = await captureUrl({
+        sourceLanguage: 'en-US',
+        autoDetectLanguage: false,
+        endpointing: {
+          silenceThresholdMs: 600,
+          minUtteranceMs: 500,
+          punctuationAware: true,
+        },
+      });
+      expect(params.has('utterance_end_ms')).toBe(false);
+    });
+
+    it('includes endpointing query param when SttEndpointingConfig provided', async () => {
+      const params = await captureUrl({
+        sourceLanguage: 'en-US',
+        autoDetectLanguage: false,
+        endpointing: {
+          silenceThresholdMs: 600,
+          minUtteranceMs: 500,
+          punctuationAware: true,
+        },
+      });
+      expect(params.get('endpointing')).toBe('600');
+    });
+
+    it('includes punctuate query param when SttEndpointingConfig provided', async () => {
+      const params = await captureUrl({
+        sourceLanguage: 'en-US',
+        autoDetectLanguage: false,
+        endpointing: {
+          silenceThresholdMs: 600,
+          minUtteranceMs: 500,
+          punctuationAware: true,
+        },
+      });
+      expect(params.get('punctuate')).toBe('true');
+    });
+
+    it('omits endpointing/punctuate when SttEndpointingConfig is undefined', async () => {
+      const params = await captureUrl({
+        sourceLanguage: 'en-US',
+        autoDetectLanguage: false,
+      });
+      expect(params.has('endpointing')).toBe(false);
+      expect(params.has('punctuate')).toBe(false);
+      expect(params.has('utterance_end_ms')).toBe(false);
+    });
+  });
 });

--- a/packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.ts
+++ b/packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.ts
@@ -191,11 +191,22 @@ export const createDeepgramSttProvider = (config: DeepgramSttProviderConfig): St
         qs.set('language', streamConfig.sourceLanguage);
       }
       // IMPL-447 (DD-412): endpointing 設定を Deepgram 固有パラメータへマップ。
-      // Deepgram は `endpointing` (ms) と `utterance_end_ms` を受け取る。
-      // `punctuate` は `smart_format=true` と組み合わせて句読点付与を強化する。
+      //
+      // 送信する param:
+      // - `endpointing`: 無音時間 (ms)。発話終端の判定に使う
+      // - `punctuate`: `smart_format=true` と組み合わせて句読点付与を強化
+      //
+      // 送信しない param:
+      // - `utterance_end_ms`: Deepgram の最小値は **1000ms** であり、SttEndpointingConfig
+      //   の `minUtteranceMs` (default 500) を渡すと HTTP 400 で reject される。
+      //   さらに意味的にも mapping が誤り (`minUtteranceMs` は「utterance の最小長」、
+      //   Deepgram の `utterance_end_ms` は「UtteranceEnd event を発火させる無音時間」
+      //   で別概念)。本 adapter は `Results` メッセージの `is_final` / `speech_final`
+      //   のみ consume し UtteranceEnd event は使っていないため、付与しないのが安全。
+      //   将来 UtteranceEnd を活用したくなったら別 config field を追加し >= 1000 に
+      //   clamp して渡すこと。
       if (streamConfig.endpointing !== undefined) {
         qs.set('endpointing', String(streamConfig.endpointing.silenceThresholdMs));
-        qs.set('utterance_end_ms', String(streamConfig.endpointing.minUtteranceMs));
         qs.set('punctuate', streamConfig.endpointing.punctuationAware ? 'true' : 'false');
       }
       const url = `${baseUrl}?${qs.toString()}`;

--- a/packages/relay-api/src/presentation/ws/relay-route.test.ts
+++ b/packages/relay-api/src/presentation/ws/relay-route.test.ts
@@ -1,6 +1,6 @@
 import fastifyWebsocket from '@fastify/websocket';
 import { err, errAsync, ok, ok as okResult, okAsync, ResultAsync, type Result } from 'neverthrow';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import WebSocket from 'ws';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { type AccessTokenVerifier } from '../../application/ports/access-token-verifier';
@@ -13,6 +13,13 @@ import {
 import { type TranslationPort } from '../../application/ports/translation-port';
 import { type IssueStreamTokenUseCase } from '../../application/use-cases/issue-stream-token-use-case';
 import { invariantViolationError, type DomainError } from '../../domain/shared/errors';
+import {
+  createDeepgramSttProvider,
+  type DeepgramSocketEvent,
+  type DeepgramSocketListener,
+  type DeepgramWebSocketFactory,
+  type MinimalDeepgramSocket,
+} from '../../infrastructure/providers/deepgram-stt-provider';
 import { createMockSttProvider } from '../../../tests/support/mock/mock-stt-provider';
 import { createMockTranslationProvider } from '../../../tests/support/mock/mock-translation-provider';
 import { buildApp } from '../http/server';
@@ -879,6 +886,153 @@ describe('WebSocket /relay route', () => {
       });
 
       expect(sendFrameCallCount).toBe(1);
+
+      ws.close();
+    }, 10000);
+  });
+
+  /**
+   * Integration: 本物の `createDeepgramSttProvider` を fake `webSocketFactory`
+   * 経由で配線し、Deepgram への URL 構築 + HTTP error propagation を end-to-end で検証する。
+   *
+   * MockSttProvider では Deepgram URL の構築ミスを捕まえられない (URL を作っていないため)。
+   * 本 describe ブロックの test は HTTP 400 (utterance_end_ms<1000 等の Deepgram 仕様
+   * 違反) regression を CI で防ぐためのもの。
+   */
+  describe('IMPL-444 Deepgram provider integration (HTTP 400 regression)', () => {
+    type IntegFakeSocket = MinimalDeepgramSocket & {
+      emitOpen: () => void;
+      emitUnexpectedResponse: (statusCode: number) => void;
+    };
+
+    const createIntegFakeSocket = (options: { autoOpen?: boolean } = {}): IntegFakeSocket => {
+      const openListeners: (() => void)[] = [];
+      const unexpectedResponseListeners: ((req: unknown, res: unknown) => void)[] = [];
+      const closeListeners: ((code: number, reason: Buffer) => void)[] = [];
+      const on: MinimalDeepgramSocket['on'] = (
+        event: DeepgramSocketEvent,
+        listener: DeepgramSocketListener,
+      ) => {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const o = listener as () => void;
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const u = listener as (req: unknown, res: unknown) => void;
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const c = listener as (code: number, reason: Buffer) => void;
+        switch (event) {
+          case 'open':
+            openListeners.push(o);
+            if (options.autoOpen === true) setImmediate(() => o());
+            return undefined;
+          case 'unexpected-response':
+            unexpectedResponseListeners.push(u);
+            return undefined;
+          case 'close':
+            closeListeners.push(c);
+            return undefined;
+          case 'message':
+          case 'error':
+            return undefined;
+        }
+      };
+      const once: MinimalDeepgramSocket['once'] = () => undefined;
+      return {
+        on,
+        once,
+        send: () => undefined,
+        close: () => undefined,
+        emitOpen: () => {
+          for (const listener of openListeners) listener();
+        },
+        emitUnexpectedResponse: (statusCode) => {
+          for (const listener of unexpectedResponseListeners) listener({}, { statusCode });
+        },
+      };
+    };
+
+    it('does not include utterance_end_ms in Deepgram URL (regression: HTTP 400 from <1000 minimum)', async () => {
+      const factory = vi.fn<DeepgramWebSocketFactory>(() =>
+        createIntegFakeSocket({ autoOpen: true }),
+      );
+      const realDeepgramPort = createDeepgramSttProvider({
+        apiKey: 'dg-test',
+        webSocketFactory: factory,
+      });
+      harness = await startApp(okVerifier, { sttPort: realDeepgramPort });
+      const ws = connectWithAuth(relayUrl(harness), 'valid.jwt');
+      const queue = createMessageQueue(ws);
+      await awaitOpen(ws);
+      await queue.next(); // session.ready
+
+      ws.send(
+        JSON.stringify({
+          eventType: 'session.start',
+          sessionId: SESSION_ID,
+          sequence: 1,
+          timestamp: new Date().toISOString(),
+          payload: {
+            sourceLanguage: 'en-US',
+            autoDetectLanguage: false,
+            targetLanguage: 'ja-JP',
+            translationEnabled: true,
+          },
+        }),
+      );
+
+      // factory が呼ばれて URL を観測できるまで待つ (openStream が走る)
+      await vi.waitFor(() => expect(factory).toHaveBeenCalled(), { timeout: 3000 });
+      const url = factory.mock.calls[0]?.[0] ?? '';
+      const queryStart = url.indexOf('?');
+      const params = new URLSearchParams(queryStart >= 0 ? url.slice(queryStart + 1) : '');
+      expect(params.has('utterance_end_ms')).toBe(false);
+      // endpointing と punctuate は引き続き含まれること
+      expect(params.has('endpointing')).toBe(true);
+      expect(params.has('punctuate')).toBe(true);
+
+      ws.close();
+    }, 10000);
+
+    it('propagates Deepgram HTTP 400 (unexpected-response) as session.error STT_ERROR', async () => {
+      const fakeSocket = createIntegFakeSocket();
+      const factory = vi.fn<DeepgramWebSocketFactory>(() => fakeSocket);
+      const realDeepgramPort = createDeepgramSttProvider({
+        apiKey: 'dg-test',
+        webSocketFactory: factory,
+      });
+      harness = await startApp(okVerifier, { sttPort: realDeepgramPort });
+      const ws = connectWithAuth(relayUrl(harness), 'valid.jwt');
+      const queue = createMessageQueue(ws);
+      await awaitOpen(ws);
+      await queue.next(); // session.ready
+
+      ws.send(
+        JSON.stringify({
+          eventType: 'session.start',
+          sessionId: SESSION_ID,
+          sequence: 1,
+          timestamp: new Date().toISOString(),
+          payload: {
+            sourceLanguage: 'en-US',
+            autoDetectLanguage: false,
+            targetLanguage: 'ja-JP',
+            translationEnabled: true,
+          },
+        }),
+      );
+
+      // factory 呼び出し直後に HTTP 400 を emit (Deepgram が param 不正で reject する状況)
+      await vi.waitFor(() => expect(factory).toHaveBeenCalled(), { timeout: 3000 });
+      fakeSocket.emitUnexpectedResponse(400);
+
+      const errorEvent = await queue.next(3000);
+      expect(errorEvent).toMatchObject({
+        eventType: 'session.error',
+        payload: {
+          code: 'STT_ERROR',
+          retryable: true,
+          fatal: false,
+        },
+      });
 
       ws.close();
     }, 10000);


### PR DESCRIPTION
## Summary
- Deepgram WebSocket URL から \`utterance_end_ms\` query param を削除 (HTTP 400 を解消)
- Unit test +4: URL 構築 regression (utterance_end_ms 不在の保証)
- Integration test +2: relay-route + 本物の Deepgram provider + fake webSocketFactory で URL 観測 + HTTP 400 propagation 検証

## Why (root cause)

PR #133 で追加した \`'open'\` 待機 + \`unexpected-response\` 検出により、ようやく HTTP 400 の発生元を捕捉:

\`\`\`
ERROR: stt openStream failed
    err: { invariant: \"deepgram-open-rejected\", details: \"HTTP 400\" }
\`\`\`

\`deepgram-stt-provider.ts:198\` で送信していた \`utterance_end_ms=<minUtteranceMs>\` が原因:

1. **Deepgram の最小値違反**: \`utterance_end_ms\` は **>= 1000ms** が必須 (公式 docs / [GitHub Discussion #563](https://github.com/orgs/deepgram/discussions/563))。\`SttEndpointingConfig.minUtteranceMs\` の default は **500ms** だったため HTTP 400 で reject されていた。
2. **意味的な mapping ミス**: 我々の \`minUtteranceMs\` は「utterance の最小長」、Deepgram の \`utterance_end_ms\` は「UtteranceEnd event を発火させる無音時間」で **別概念**。
3. **そもそも未使用**: 本 adapter は Deepgram の Results メッセージのうち \`is_final\` / \`speech_final\` のみ consume しており、\`UtteranceEnd\` event は一切使っていないため \`utterance_end_ms\` 自体が不要。

## Changes

### \`packages/relay-api/src/infrastructure/providers/deepgram-stt-provider.ts\`
- URL 構築から \`utterance_end_ms\` の 1 行を削除
- 削除理由を comment に明記 (将来 UtteranceEnd を活用する場合の指針も)

### Unit tests (\`deepgram-stt-provider.test.ts\`, +4)
新規 describe: \`openStream URL construction (regression: HTTP 400 from invalid Deepgram params)\`
- \`does NOT include utterance_end_ms\`
- \`includes endpointing query param when SttEndpointingConfig provided\`
- \`includes punctuate query param when SttEndpointingConfig provided\`
- \`omits endpointing/punctuate when SttEndpointingConfig is undefined\`

### Integration tests (\`relay-route.test.ts\`, +2)
新規 describe: \`IMPL-444 Deepgram provider integration (HTTP 400 regression)\`
- \`does not include utterance_end_ms in Deepgram URL\` — 本物の \`createDeepgramSttProvider\` に fake \`webSocketFactory\` を注入し、\`session.start\` を契機に factory に渡される URL を捕捉して検証
- \`propagates Deepgram HTTP 400 (unexpected-response) as session.error STT_ERROR\` — fake socket が 400 を emit すると STT_ERROR の session.error が client へ届く end-to-end 経路を検証

これで「Deepgram URL の構築ミス」が将来再発した場合 CI で fail するようになる。

## Test plan
- [x] \`pnpm --filter @perapera/relay-api typecheck\` 通過
- [x] \`pnpm --filter @perapera/relay-api lint\` 私の変更分エラーなし (perf/scenarios/*.js は既存の parse error)
- [x] \`pnpm --filter @perapera/relay-api test --run\` 222 → **228** pass
- [ ] CI 全 pass を確認後 merge
- [ ] 実機で \`HTTP 400\` ログが出ないこと、字幕が描画されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)