### PR TITLE
feat(extension): expose ExportControls in SessionHistoryView detail panel

### DIFF
--- a/packages/extension/src/presentation/organisms/session-history-view.test.tsx
+++ b/packages/extension/src/presentation/organisms/session-history-view.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   type BackgroundClient,
   type BackgroundResponse,
+  type ExportSessionResultResult,
   type SessionHistoryDetailResult,
   type SessionHistoryListResult,
 } from '../infrastructure/background-client';
@@ -102,6 +103,13 @@ const buildClient = (overrides: Partial<BackgroundClient> = {}): BackgroundClien
 describe('SessionHistoryView organism (Issue #109)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // jsdom には URL.createObjectURL / revokeObjectURL が無い。
+    // ExportControls の downloadViaAnchor が依存するため stub する。
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:test'),
+      revokeObjectURL: vi.fn(),
+    });
   });
 
   it('renders the list of past sessions', async () => {
@@ -132,6 +140,56 @@ describe('SessionHistoryView organism (Issue #109)', () => {
     });
     expect(screen.getByText('hello world')).toBeInTheDocument();
     expect(screen.getByText('こんにちは')).toBeInTheDocument();
+  });
+
+  it('renders ExportControls in the detail panel after selecting a session', async () => {
+    const client = buildClient();
+    render(<SessionHistoryView client={client} onClose={() => undefined} />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: `セッション ${SESSION_ID} を開く` }),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: `セッション ${SESSION_ID} を開く` }));
+    await waitFor(() => {
+      expect(screen.getByTestId('history-detail')).toBeInTheDocument();
+    });
+    // ExportControls molecule は data-testid="export-controls" を持つ
+    expect(screen.getByTestId('export-controls')).toBeInTheDocument();
+  });
+
+  it('invokes exportSessionResult with the selected sessionId via ExportControls', async () => {
+    const exportResult: BackgroundResponse<ExportSessionResultResult> = {
+      ok: true,
+      value: {
+        exportId: 'exp_history_1',
+        format: 'json',
+        bytes: 42,
+        content: '{"sessionIdentifier":"' + SESSION_ID + '","segments":[]}',
+      },
+    };
+    const client = buildClient({
+      exportSessionResult: vi.fn(() => Promise.resolve(exportResult)),
+    });
+    render(<SessionHistoryView client={client} onClose={() => undefined} />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: `セッション ${SESSION_ID} を開く` }),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: `セッション ${SESSION_ID} を開く` }));
+    await waitFor(() => {
+      expect(screen.getByTestId('export-controls')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'エクスポート' }));
+    await waitFor(() => {
+      expect(client.exportSessionResult).toHaveBeenCalledWith({
+        sessionId: SESSION_ID,
+        format: 'txt',
+        includeOriginal: true,
+        includeTranslation: true,
+      });
+    });
   });
 
   it('shows error message when detail fetch fails', async () => {

--- a/packages/extension/src/presentation/organisms/session-history-view.tsx
+++ b/packages/extension/src/presentation/organisms/session-history-view.tsx
@@ -10,6 +10,7 @@ import {
   type SearchSessionHistoryResult,
   type SessionHistoryDetailResult,
 } from '../infrastructure/background-client';
+import { ExportControls } from '../molecules/export-controls';
 import { TranscriptPairItem } from '../molecules/transcript-pair-item';
 
 const SEARCH_DEBOUNCE_MS = 300 as const;
@@ -226,6 +227,7 @@ export function SessionHistoryView(props: Props) {
                   ))
                 )}
               </div>
+              <ExportControls client={props.client} sessionId={detail.summary.sessionId} />
             </div>
           ) : null}
         </section>


### PR DESCRIPTION
## Summary
- 「過去のセッションを見る」 → セッション選択 → 形式選択 → エクスポート の導線を完成させる
- \`SessionHistoryView\` の detail panel に \`ExportControls\` を組み込む

## Why
PR #135 で TXT / JSON / **CSV** の 3 形式を `ExportSessionResultUseCase` で出力できるようにしたが、UI 導線を確認したところ、`ExportControls` molecule は **`SessionToolbar` 内 (active session 中のみ)** にしか配置されていなかった。

つまり session を停止した後、「過去のセッションを見る」から該当 session を選んでも export ボタンが無く、CSV / JSON / TXT のいずれでも過去セッションをダウンロードできない状態だった。本 PR でこのギャップを埋める。

## Changes
### \`packages/extension/src/presentation/organisms/session-history-view.tsx\`
- \`import { ExportControls } from '../molecules/export-controls';\`
- detail block 内、字幕一覧の直下に \`<ExportControls client={props.client} sessionId={detail.summary.sessionId} />\` を配置

### \`packages/extension/src/presentation/organisms/session-history-view.test.tsx\` (+2 tests)
- \`renders ExportControls in the detail panel after selecting a session\` — ExportControls の \`data-testid=\"export-controls\"\` が detail 内に出現
- \`invokes exportSessionResult with the selected sessionId via ExportControls\` — エクスポートボタン click → \`exportSessionResult\` が選択 sessionId で呼ばれる
- \`beforeEach\` で \`URL.createObjectURL\` / \`URL.revokeObjectURL\` を stub (jsdom が未実装のため、downloadViaAnchor の resource cleanup 経路の依存)

## Test plan
- [x] \`pnpm --filter @perapera/extension typecheck\` 通過
- [x] \`pnpm --filter @perapera/extension test --run\` 1058 → **1060** pass
- [ ] CI 全 pass を確認後 merge
- [ ] 実機: 「過去のセッションを見る」 → 一覧から session を選択 → detail 末尾に Export form が出る → CSV を選択 → \`.csv\` がダウンロードされ Excel で文字化けせず開ける

🤖 Generated with [Claude Code](https://claude.com/claude-code)